### PR TITLE
Support HTTP Basic auth in secrets transform

### DIFF
--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -5,6 +5,7 @@ package secrets
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -168,28 +169,67 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret) []string {
 		for _, name := range sec.matchHeaders {
 			if vals := req.Header.Values(name); len(vals) > 0 {
 				for _, v := range vals {
-					if strings.Contains(v, sec.proxyValue) {
+					if headerContains(name, v, sec.proxyValue) {
 						locations = append(locations, "header:"+name)
 						break
 					}
 				}
 				req.Header.Del(name)
 				for _, v := range vals {
-					req.Header.Add(name, strings.ReplaceAll(v, sec.proxyValue, sec.realValue))
+					req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, sec.realValue))
 				}
 			}
 		}
 	} else {
 		for name, vals := range req.Header {
 			for i, v := range vals {
-				if strings.Contains(v, sec.proxyValue) {
-					req.Header[name][i] = strings.ReplaceAll(v, sec.proxyValue, sec.realValue)
+				if headerContains(name, v, sec.proxyValue) {
+					req.Header[name][i] = replaceInHeader(name, v, sec.proxyValue, sec.realValue)
 					locations = append(locations, "header:"+name)
 				}
 			}
 		}
 	}
 	return locations
+}
+
+// replaceInHeader performs a secret replacement in a header value. For
+// Authorization headers with HTTP Basic auth, the base64 payload is decoded
+// before replacement and re-encoded after.
+func replaceInHeader(headerName, value, proxyValue, realValue string) string {
+	if strings.EqualFold(headerName, "Authorization") {
+		if decoded, ok := decodeBasicAuth(value); ok {
+			replaced := strings.ReplaceAll(decoded, proxyValue, realValue)
+			return "Basic " + base64.StdEncoding.EncodeToString([]byte(replaced))
+		}
+	}
+	return strings.ReplaceAll(value, proxyValue, realValue)
+}
+
+// headerContains checks whether a header value contains the proxy token.
+// For Authorization headers with HTTP Basic auth, the base64 payload is
+// decoded before checking.
+func headerContains(headerName, value, proxyValue string) bool {
+	if strings.EqualFold(headerName, "Authorization") {
+		if decoded, ok := decodeBasicAuth(value); ok {
+			return strings.Contains(decoded, proxyValue)
+		}
+	}
+	return strings.Contains(value, proxyValue)
+}
+
+// decodeBasicAuth extracts and base64-decodes the payload from a "Basic ..."
+// Authorization header value. Returns the decoded string and true on success.
+func decodeBasicAuth(value string) (string, bool) {
+	after, ok := strings.CutPrefix(value, "Basic ")
+	if !ok {
+		return "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(after)
+	if err != nil {
+		return "", false
+	}
+	return string(decoded), true
 }
 
 func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret) []string {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -341,6 +342,90 @@ func TestSecrets_ConcurrentSafety(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestSecrets_BasicAuthSwap(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Basic auth: "user:proxy-openai-abc123" base64-encoded
+	creds := base64.StdEncoding.EncodeToString([]byte("user:proxy-openai-abc123"))
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Basic "+creds)
+
+	doTransform(t, s, req)
+
+	got := req.Header.Get("Authorization")
+	require.True(t, strings.HasPrefix(got, "Basic "))
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+	require.NoError(t, err)
+	require.Equal(t, "user:sk-real-openai-key", string(decoded))
+}
+
+func TestSecrets_BasicAuthNoMatch(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Basic auth with no proxy token inside
+	creds := base64.StdEncoding.EncodeToString([]byte("user:some-other-password"))
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Basic "+creds)
+
+	doTransform(t, s, req)
+
+	// Should be unchanged
+	require.Equal(t, "Basic "+creds, req.Header.Get("Authorization"))
+}
+
+func TestSecrets_BasicAuthAllHeaders(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{}, // all headers
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	creds := base64.StdEncoding.EncodeToString([]byte("proxy-openai-abc123:secret"))
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Basic "+creds)
+
+	doTransform(t, s, req)
+
+	got := req.Header.Get("Authorization")
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+	require.NoError(t, err)
+	require.Equal(t, "sk-real-openai-key:secret", string(decoded))
+}
+
+func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{}, // all headers
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// "Basic <base64>" on a non-Authorization header should not be decoded
+	creds := base64.StdEncoding.EncodeToString([]byte("proxy-openai-abc123:secret"))
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("X-Custom", "Basic "+creds)
+
+	doTransform(t, s, req)
+
+	// The base64 payload doesn't contain the literal proxy token, so no swap
+	require.Equal(t, "Basic "+creds, req.Header.Get("X-Custom"))
 }
 
 func TestSecrets_Name(t *testing.T) {


### PR DESCRIPTION
The secrets transform now base64-decodes Authorization headers with Basic auth before checking for proxy tokens, does the replacement on the decoded value, and re-encodes. Only applies to Authorization headers, other headers with a Basic prefix are left alone.