### PR TITLE
Add Docker pulls badge and installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # iron-proxy
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/ironsh/iron-proxy)](https://hub.docker.com/r/ironsh/iron-proxy)
+
 An egress firewall for untrusted workloads. Default-deny HTTP/HTTPS, secret
 injection, and full audit logging, in a single binary.
 
@@ -442,7 +444,13 @@ curl -H "X-Internal: proxy-internal-tok" https://httpbin.org/headers
 curl "https://httpbin.org/get?token=proxy-openai-abc123&q=hello"
 ```
 
-## Building
+## Installation
+
+Docker images are available on [Docker Hub](https://hub.docker.com/r/ironsh/iron-proxy)
+and pre-built binaries for Linux/macOS (amd64/arm64) are on
+[GitHub Releases](https://github.com/ironsh/iron-proxy/releases).
+
+Or build from source:
 
 ```bash
 go build -o iron-proxy ./cmd/iron-proxy

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ For stronger enforcement, layer nftables rules to block non-proxy egress, or use
 TPROXY for kernel-level interception. See [Routing traffic to the
 proxy](#routing-traffic-to-the-proxy) for details on each approach.
 
+## Installation
+
+Docker images are available on [Docker Hub](https://hub.docker.com/r/ironsh/iron-proxy)
+and pre-built binaries for Linux/macOS (amd64/arm64) are on
+[GitHub Releases](https://github.com/ironsh/iron-proxy/releases).
+
+Or build from source:
+
+```bash
+go build -o iron-proxy ./cmd/iron-proxy
+```
+
 ## Why iron-proxy?
 
 |                          | iron-proxy                     | Squid                       | mitmproxy                 | Envoy                              |
@@ -442,18 +454,6 @@ curl -H "X-Internal: proxy-internal-tok" https://httpbin.org/headers
 
 # 5. Secret swap: proxy token in query parameter
 curl "https://httpbin.org/get?token=proxy-openai-abc123&q=hello"
-```
-
-## Installation
-
-Docker images are available on [Docker Hub](https://hub.docker.com/r/ironsh/iron-proxy)
-and pre-built binaries for Linux/macOS (amd64/arm64) are on
-[GitHub Releases](https://github.com/ironsh/iron-proxy/releases).
-
-Or build from source:
-
-```bash
-go build -o iron-proxy ./cmd/iron-proxy
 ```
 
 ## Audit log format

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ server, giving you:
     </a>
 </div>
 
+## Installation
+
+Docker images are available on [Docker Hub](https://hub.docker.com/r/ironsh/iron-proxy)
+and pre-built binaries for Linux/macOS (amd64/arm64) are on
+[GitHub Releases](https://github.com/ironsh/iron-proxy/releases).
+
+Or build from source:
+
+```bash
+go build -o iron-proxy ./cmd/iron-proxy
+```
+
 ## Quick start
 
 ```bash
@@ -117,18 +129,6 @@ docker run --rm \
 For stronger enforcement, layer nftables rules to block non-proxy egress, or use
 TPROXY for kernel-level interception. See [Routing traffic to the
 proxy](#routing-traffic-to-the-proxy) for details on each approach.
-
-## Installation
-
-Docker images are available on [Docker Hub](https://hub.docker.com/r/ironsh/iron-proxy)
-and pre-built binaries for Linux/macOS (amd64/arm64) are on
-[GitHub Releases](https://github.com/ironsh/iron-proxy/releases).
-
-Or build from source:
-
-```bash
-go build -o iron-proxy ./cmd/iron-proxy
-```
 
 ## Why iron-proxy?
 


### PR DESCRIPTION
Adds a Docker pulls shield linked to Docker Hub and replaces the bare "Building" section with "Installation" that points to Docker Hub, GitHub Releases, and build-from-source.