### PR TITLE
Add method and path matching to allowlist transform

### DIFF
--- a/internal/transform/allowlist/allowlist.go
+++ b/internal/transform/allowlist/allowlist.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -17,15 +19,30 @@ func init() {
 	transform.Register("allowlist", factory)
 }
 
-// Allowlist is a default-deny transform that checks request hosts against
-// domain globs and CIDR ranges.
+// Allowlist is a default-deny transform that checks request hosts, methods,
+// and paths against a set of rules.
 type Allowlist struct {
-	matcher *hostmatch.Matcher
+	rules []rule
 }
 
 type allowlistConfig struct {
-	Domains []string `yaml:"domains"`
-	CIDRs   []string `yaml:"cidrs"`
+	Domains []string     `yaml:"domains"`
+	CIDRs   []string     `yaml:"cidrs"`
+	Rules   []ruleConfig `yaml:"rules"`
+}
+
+type ruleConfig struct {
+	Host    string   `yaml:"host,omitempty"`
+	CIDR    string   `yaml:"cidr,omitempty"`
+	Methods []string `yaml:"methods,omitempty"`
+	Paths   []string `yaml:"paths,omitempty"`
+}
+
+// rule is a compiled allowlist rule ready for matching.
+type rule struct {
+	matcher *hostmatch.Matcher
+	methods map[string]bool // nil = all methods allowed
+	paths   []string        // nil = all paths allowed
 }
 
 func factory(cfg yaml.Node) (transform.Transformer, error) {
@@ -33,16 +50,80 @@ func factory(cfg yaml.Node) (transform.Transformer, error) {
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing allowlist config: %w", err)
 	}
-	return New(c.Domains, c.CIDRs, net.DefaultResolver)
+	return newFromConfig(c, net.DefaultResolver)
+}
+
+func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist, error) {
+	var rules []rule
+
+	// Flat domains → rules with no method/path restrictions.
+	for _, d := range cfg.Domains {
+		m, err := hostmatch.New([]string{d}, nil, resolver)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule{matcher: m})
+	}
+
+	// Flat CIDRs → rules with no method/path restrictions.
+	for _, c := range cfg.CIDRs {
+		m, err := hostmatch.New(nil, []string{c}, resolver)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, rule{matcher: m})
+	}
+
+	// Explicit rules with optional method/path restrictions.
+	for i, rc := range cfg.Rules {
+		if rc.Host != "" && rc.CIDR != "" {
+			return nil, fmt.Errorf("rules[%d]: host and cidr are mutually exclusive", i)
+		}
+		if rc.Host == "" && rc.CIDR == "" {
+			return nil, fmt.Errorf("rules[%d]: one of host or cidr is required", i)
+		}
+
+		var domains []string
+		var cidrs []string
+		if rc.Host != "" {
+			domains = []string{rc.Host}
+		}
+		if rc.CIDR != "" {
+			cidrs = []string{rc.CIDR}
+		}
+
+		m, err := hostmatch.New(domains, cidrs, resolver)
+		if err != nil {
+			return nil, fmt.Errorf("rules[%d]: %w", i, err)
+		}
+
+		for _, p := range rc.Paths {
+			if !strings.HasPrefix(p, "/") {
+				return nil, fmt.Errorf("rules[%d]: path %q must start with /", i, p)
+			}
+		}
+
+		r := rule{matcher: m}
+		if len(rc.Methods) > 0 {
+			r.methods = make(map[string]bool, len(rc.Methods))
+			for _, method := range rc.Methods {
+				r.methods[strings.ToUpper(method)] = true
+			}
+		}
+		if len(rc.Paths) > 0 {
+			r.paths = rc.Paths
+		}
+
+		rules = append(rules, r)
+	}
+
+	return &Allowlist{rules: rules}, nil
 }
 
 // New creates an Allowlist from domain globs and CIDR strings.
+// All methods and paths are allowed. This is the backwards-compatible constructor.
 func New(domains []string, cidrs []string, resolver hostmatch.Resolver) (*Allowlist, error) {
-	m, err := hostmatch.New(domains, cidrs, resolver)
-	if err != nil {
-		return nil, err
-	}
-	return &Allowlist{matcher: m}, nil
+	return newFromConfig(allowlistConfig{Domains: domains, CIDRs: cidrs}, resolver)
 }
 
 func (a *Allowlist) Name() string { return "allowlist" }
@@ -50,7 +131,16 @@ func (a *Allowlist) Name() string { return "allowlist" }
 func (a *Allowlist) TransformRequest(ctx context.Context, _ *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
 	host := hostmatch.StripPort(req.Host)
 
-	if a.matcher.Matches(ctx, host) {
+	for _, r := range a.rules {
+		if !r.matcher.Matches(ctx, host) {
+			continue
+		}
+		if r.methods != nil && !r.methods[req.Method] {
+			continue
+		}
+		if r.paths != nil && !matchAnyPath(r.paths, req.URL.Path) {
+			continue
+		}
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 
@@ -59,4 +149,26 @@ func (a *Allowlist) TransformRequest(ctx context.Context, _ *transform.Transform
 
 func (a *Allowlist) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func matchAnyPath(patterns []string, reqPath string) bool {
+	for _, p := range patterns {
+		if matchPath(p, reqPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPath checks if reqPath matches a path pattern. Patterns ending in /*
+// match any path under that prefix (e.g. /v1/* matches /v1/models and /v1).
+// Other patterns use path.Match glob semantics.
+func matchPath(pattern, reqPath string) bool {
+	if strings.HasSuffix(pattern, "/*") {
+		prefix := pattern[:len(pattern)-1] // "/v1/"
+		base := pattern[:len(pattern)-2]   // "/v1"
+		return strings.HasPrefix(reqPath, prefix) || reqPath == base
+	}
+	matched, _ := path.Match(pattern, reqPath)
+	return matched
 }

--- a/internal/transform/allowlist/allowlist_test.go
+++ b/internal/transform/allowlist/allowlist_test.go
@@ -33,6 +33,17 @@ func result(t *testing.T, a *Allowlist, host string) *transform.TransformResult 
 	return res
 }
 
+func resultWithMethodAndPath(t *testing.T, a *Allowlist, host, method, path string) *transform.TransformResult {
+	t.Helper()
+	req := httptest.NewRequest(method, "http://"+host+path, nil)
+	req.Host = host
+	res, err := a.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	return res
+}
+
+// --- Existing tests (backwards compat via New) ---
+
 func TestAllowlist_ExactDomainMatch(t *testing.T) {
 	a, err := New([]string{"api.openai.com"}, nil, &mockResolver{})
 	require.NoError(t, err)
@@ -144,4 +155,226 @@ func TestAllowlist_Name(t *testing.T) {
 	a, err := New(nil, nil, &mockResolver{})
 	require.NoError(t, err)
 	require.Equal(t, "allowlist", a.Name())
+}
+
+// --- Method matching tests ---
+
+func TestAllowlist_MethodAllowed(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:    "api.openai.com",
+			Methods: []string{"GET", "POST"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "DELETE", "/").Action)
+}
+
+func TestAllowlist_MethodsCaseInsensitive(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:    "api.openai.com",
+			Methods: []string{"post"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/").Action)
+}
+
+func TestAllowlist_NoMethodsAllowsAll(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host: "api.openai.com",
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "DELETE", "/").Action)
+}
+
+// --- Path matching tests ---
+
+func TestAllowlist_PathGlob(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:  "api.openai.com",
+			Paths: []string{"/v1/*"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/models").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/chat/completions").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v2/models").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/").Action)
+}
+
+func TestAllowlist_PathExact(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:  "api.openai.com",
+			Paths: []string{"/health"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/health").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/health/deep").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/other").Action)
+}
+
+func TestAllowlist_NoPathsAllowsAll(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host: "api.openai.com",
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/anything").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/models").Action)
+}
+
+func TestAllowlist_MultiplePaths(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:  "api.openai.com",
+			Paths: []string{"/v1/chat", "/v1/models"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/chat").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/models").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/other").Action)
+}
+
+// --- Combined tests ---
+
+func TestAllowlist_HostMethodPathCombined(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			Host:    "api.openai.com",
+			Methods: []string{"POST"},
+			Paths:   []string{"/v1/*"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	// All three match
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/v1/chat").Action)
+	// Wrong method
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/chat").Action)
+	// Wrong path
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/v2/chat").Action)
+	// Wrong host
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "evil.com", "POST", "/v1/chat").Action)
+}
+
+func TestAllowlist_MultiRuleSecondMatches(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{
+			{Host: "api.openai.com", Methods: []string{"POST"}},
+			{Host: "api.anthropic.com", Methods: []string{"GET"}},
+		},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.anthropic.com", "GET", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "api.anthropic.com", "POST", "/").Action)
+}
+
+func TestAllowlist_FlatDomainsAndRulesMixed(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Domains: []string{"open.com"},
+		Rules: []ruleConfig{{
+			Host:    "restricted.com",
+			Methods: []string{"GET"},
+		}},
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	// Flat domain: all methods allowed
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "open.com", "DELETE", "/anything").Action)
+	// Rule: only GET
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "restricted.com", "GET", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "restricted.com", "POST", "/").Action)
+}
+
+func TestAllowlist_RuleWithCIDR(t *testing.T) {
+	resolver := &mockResolver{
+		hosts: map[string][]string{
+			"internal.service": {"10.0.1.5"},
+		},
+	}
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{
+			CIDR:    "10.0.0.0/8",
+			Methods: []string{"GET"},
+		}},
+	}, resolver)
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "internal.service", "GET", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "internal.service", "POST", "/").Action)
+}
+
+// --- Validation tests ---
+
+func TestAllowlist_RuleBothHostAndCIDR(t *testing.T) {
+	_, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{Host: "a.com", CIDR: "10.0.0.0/8"}},
+	}, &mockResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestAllowlist_RuleNeitherHostNorCIDR(t *testing.T) {
+	_, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{Methods: []string{"GET"}}},
+	}, &mockResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "one of host or cidr is required")
+}
+
+func TestAllowlist_RuleInvalidPath(t *testing.T) {
+	_, err := newFromConfig(allowlistConfig{
+		Rules: []ruleConfig{{Host: "a.com", Paths: []string{"no-leading-slash"}}},
+	}, &mockResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must start with /")
+}
+
+// --- matchPath unit tests ---
+
+func TestMatchPath(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"/v1/*", "/v1/models", true},
+		{"/v1/*", "/v1/chat/completions", true},
+		{"/v1/*", "/v1", true},
+		{"/v1/*", "/v2/models", false},
+		{"/v1/*", "/", false},
+		{"/health", "/health", true},
+		{"/health", "/health/deep", false},
+		{"/health", "/other", false},
+		{"/*", "/anything", true},
+		{"/*", "/", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_%s", tt.pattern, tt.path), func(t *testing.T) {
+			require.Equal(t, tt.want, matchPath(tt.pattern, tt.path))
+		})
+	}
 }

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -46,6 +46,8 @@ transforms:
         - host: "*.anthropic.com"
           methods: ["POST"]
           paths: ["/v1/messages", "/v1/complete"]
+        - cidr: "172.16.0.0/12"
+          methods: ["GET"]
 
 # Logging
 log:

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -32,13 +32,20 @@ tls:
 transforms:
   - name: allowlist
     config:
+      # Simple form: allow all methods and paths to these hosts
       domains:
-        - "api.openai.com"
-        - "*.anthropic.com"
         - "registry.npmjs.org"
       cidrs:
         - "10.0.0.0/8"
         - "172.16.0.0/12"
+      # Rule form: restrict by method and/or path
+      rules:
+        - host: "api.openai.com"
+          methods: ["POST"]
+          paths: ["/v1/*"]
+        - host: "*.anthropic.com"
+          methods: ["POST"]
+          paths: ["/v1/messages", "/v1/complete"]
 
 # Logging
 log:


### PR DESCRIPTION
Adds optional per-rule HTTP method and path restrictions to the allowlist. Existing flat domains/cidrs configs continue to work unchanged. New rules format lets you restrict by method and path glob, e.g. only allow POST to /v1/* on a given host.