### PR TITLE
Add -v to CI tests, stream response body without buffering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: "1.26"
 
       - name: Run tests
-        run: go test -race -count=1 ./...
+        run: go test -v -race -count=1 ./...
 
   vet:
     runs-on: ubuntu-latest

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -332,16 +332,17 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 
+	reader := streamBody(resp.Body)
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		// Fallback to regular copy if flushing isn't supported
-		_, _ = io.Copy(w, resp.Body)
+		_, _ = io.Copy(w, reader)
 		return
 	}
 
 	buf := make([]byte, 32*1024)
 	for {
-		n, err := resp.Body.Read(buf)
+		n, err := reader.Read(buf)
 		if n > 0 {
 			_, _ = w.Write(buf[:n])
 			flusher.Flush()
@@ -359,8 +360,17 @@ func writeResponse(w http.ResponseWriter, resp *http.Response) {
 	w.Header().Del("Content-Length")
 	w.WriteHeader(resp.StatusCode)
 	if resp.Body != nil {
-		_, _ = io.Copy(w, resp.Body)
+		_, _ = io.Copy(w, streamBody(resp.Body))
 	}
+}
+
+// streamBody returns a streaming reader if the body supports it, avoiding
+// unnecessary buffering when writing the final response.
+func streamBody(body io.ReadCloser) io.Reader {
+	if b, ok := body.(transform.Bufferable); ok {
+		return b.StreamingReader()
+	}
+	return body
 }
 
 // upstreamTransport is the transport used for upstream requests.

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -6,10 +6,12 @@ import (
 	"sync"
 )
 
-// Resetter is implemented by body types that support rewinding for replay
-// between pipeline transforms.
-type Resetter interface {
+// Bufferable is implemented by body types that support rewinding for replay
+// between pipeline transforms, and streaming for final output without
+// unnecessary buffering.
+type Bufferable interface {
 	Reset()
+	StreamingReader() io.Reader
 }
 
 // ReplayableBody wraps an io.ReadCloser with incremental buffering and rewind
@@ -88,6 +90,32 @@ func (b *ReplayableBody) Reset() {
 	b.pos = 0
 }
 
+// StreamingReader returns a reader that drains the buffered data from the
+// current position, then streams directly from the underlying reader without
+// appending to the buffer. Use this for final output (e.g. writing the HTTP
+// response) to avoid buffering the entire body into memory.
+func (b *ReplayableBody) StreamingReader() io.Reader {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var readers []io.Reader
+
+	// Any buffered data from the current position.
+	if b.pos < len(b.buf) {
+		readers = append(readers, bytes.NewReader(b.buf[b.pos:]))
+	}
+
+	// Remaining unbuffered data from the original, if not fully consumed.
+	if !b.eof {
+		readers = append(readers, b.original)
+	}
+
+	if len(readers) == 0 {
+		return bytes.NewReader(nil)
+	}
+	return io.MultiReader(readers...)
+}
+
 // Close is a no-op if the original has already been consumed; otherwise
 // closes the underlying reader.
 func (b *ReplayableBody) Close() error {
@@ -126,6 +154,11 @@ func (b *BufferedBody) Read(p []byte) (int, error) {
 // Reset rewinds to the beginning.
 func (b *BufferedBody) Reset() {
 	b.pos = 0
+}
+
+// StreamingReader returns a reader over the remaining data.
+func (b *BufferedBody) StreamingReader() io.Reader {
+	return bytes.NewReader(b.data[b.pos:])
 }
 
 // Close is a no-op.

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -51,7 +51,7 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 		dur := time.Since(start)
 
 		// Reset body for the next transform.
-		if r, ok := req.Body.(Resetter); ok {
+		if r, ok := req.Body.(Bufferable); ok {
 			r.Reset()
 		}
 
@@ -90,10 +90,10 @@ func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, 
 		dur := time.Since(start)
 
 		// Reset bodies for the next transform.
-		if r, ok := req.Body.(Resetter); ok {
+		if r, ok := req.Body.(Bufferable); ok {
 			r.Reset()
 		}
-		if r, ok := resp.Body.(Resetter); ok {
+		if r, ok := resp.Body.(Bufferable); ok {
 			r.Reset()
 		}
 


### PR DESCRIPTION
Adds -v flag to CI test runs for visibility. Renames Resetter to Bufferable and adds StreamingReader() which drains buffered data then streams the rest without further buffering. writeResponse and streamSSE use this so the full response body is never double-buffered into memory on final write.