### PR TITLE
Add configurable upstream DNS resolver

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -78,15 +78,32 @@ func main() {
 	}, logger)
 	pipeline.SetAuditFunc(transform.NewAuditLogger(logger))
 
+	// Build upstream resolver
+	var resolver *net.Resolver
+	if cfg.DNS.UpstreamResolver != "" {
+		resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{Timeout: 5 * time.Second}
+				return d.DialContext(ctx, "udp", cfg.DNS.UpstreamResolver)
+			},
+		}
+		logger.Info("using upstream resolver", slog.String("addr", cfg.DNS.UpstreamResolver))
+	}
+
 	// Initialize DNS server
-	dnsServer, err := idns.New(cfg.DNS, net.DefaultResolver, logger)
+	dnsResolver := net.DefaultResolver
+	if resolver != nil {
+		dnsResolver = resolver
+	}
+	dnsServer, err := idns.New(cfg.DNS, dnsResolver, logger)
 	if err != nil {
 		logger.Error("initializing DNS server", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 
 	// Initialize proxy
-	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, certCache, pipeline, logger)
+	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, certCache, pipeline, resolver, logger)
 
 	// Start services
 	errc := make(chan error, 2)

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -79,7 +79,7 @@ func main() {
 	pipeline.SetAuditFunc(transform.NewAuditLogger(logger))
 
 	// Build upstream resolver
-	var resolver *net.Resolver
+	resolver := net.DefaultResolver
 	if cfg.DNS.UpstreamResolver != "" {
 		resolver = &net.Resolver{
 			PreferGo: true,
@@ -92,11 +92,7 @@ func main() {
 	}
 
 	// Initialize DNS server
-	dnsResolver := net.DefaultResolver
-	if resolver != nil {
-		dnsResolver = resolver
-	}
-	dnsServer, err := idns.New(cfg.DNS, dnsResolver, logger)
+	dnsServer, err := idns.New(cfg.DNS, resolver, logger)
 	if err != nil {
 		logger.Error("initializing DNS server", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,10 +21,11 @@ type Config struct {
 
 // DNS configures the built-in DNS server.
 type DNS struct {
-	Listen      string      `yaml:"listen"`
-	ProxyIP     string      `yaml:"proxy_ip"`
-	Passthrough []string    `yaml:"passthrough"`
-	Records     []DNSRecord `yaml:"records"`
+	Listen           string      `yaml:"listen"`
+	ProxyIP          string      `yaml:"proxy_ip"`
+	UpstreamResolver string      `yaml:"upstream_resolver"`
+	Passthrough      []string    `yaml:"passthrough"`
+	Records          []DNSRecord `yaml:"records"`
 }
 
 // DNSRecord is a static DNS record entry.

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -80,7 +80,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 
 	// 4. Start proxy with HTTPS
-	p := New("127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, logger)
+	p := New("127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
 
 	// Start HTTP listener
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -101,8 +101,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	})
 
 	// 6. Override upstream transport to route fakeHost to the real upstream
-	origTransport := upstreamTransport
-	upstreamTransport = &http.Transport{
+	p.transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
@@ -111,7 +110,6 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
 		},
 	}
-	defer func() { upstreamTransport = origTransport }()
 
 	// 7. Test: allowed request through HTTPS proxy
 	caPool := x509.NewCertPool()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -24,14 +24,17 @@ type Proxy struct {
 	tlsListener net.Listener
 	certCache   *certcache.Cache
 	pipeline    *transform.Pipeline
+	transport   *http.Transport
 	logger      *slog.Logger
 }
 
-// New creates a new Proxy.
-func New(httpAddr, httpsAddr string, certCache *certcache.Cache, pipeline *transform.Pipeline, logger *slog.Logger) *Proxy {
+// New creates a new Proxy. If resolver is non-nil, it is used to resolve
+// upstream hostnames instead of the OS default resolver.
+func New(httpAddr, httpsAddr string, certCache *certcache.Cache, pipeline *transform.Pipeline, resolver *net.Resolver, logger *slog.Logger) *Proxy {
 	p := &Proxy{
 		certCache: certCache,
 		pipeline:  pipeline,
+		transport: buildTransport(resolver),
 		logger:    logger,
 	}
 
@@ -373,24 +376,29 @@ func streamBody(body io.ReadCloser) io.Reader {
 	return body
 }
 
-// upstreamTransport is the transport used for upstream requests.
-// Separate from http.DefaultTransport so proxy settings don't loop.
-var upstreamTransport = &http.Transport{
-	TLSClientConfig: &tls.Config{
-		MinVersion: tls.VersionTLS12,
-	},
-	DialContext: (&net.Dialer{
+// buildTransport creates the HTTP transport used for upstream requests.
+// If resolver is non-nil, the transport's dialer uses it instead of the OS
+// default — this prevents resolution loops when iron-proxy owns the system DNS.
+func buildTransport(resolver *net.Resolver) *http.Transport {
+	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	MaxIdleConns:          100,
-	IdleConnTimeout:       90 * time.Second,
-	TLSHandshakeTimeout:  10 * time.Second,
-	ResponseHeaderTimeout: 30 * time.Second,
+		Resolver:  resolver,
+	}
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:  10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
 }
 
 func (p *Proxy) doUpstream(req *http.Request) (*http.Response, error) {
-	return upstreamTransport.RoundTrip(req)
+	return p.transport.RoundTrip(req)
 }
 
 func copyHeaders(dst, src http.Header) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -63,7 +63,7 @@ func startProxy(t *testing.T) (*Proxy, string, string, *x509.CertPool) {
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
-	p := New("127.0.0.1:0", "127.0.0.1:0", cache, pipeline, testLogger())
+	p := New("127.0.0.1:0", "127.0.0.1:0", cache, pipeline, nil, testLogger())
 
 	// Start HTTP listener manually to get random port
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -152,7 +152,7 @@ func TestHTTPSProxy(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	_, _, httpsAddr, caPool := startProxy(t)
+	p, _, httpsAddr, caPool := startProxy(t)
 
 	// We need to route the request to the proxy but with the upstream's Host.
 	// The proxy will make a TLS connection to the upstream.
@@ -162,8 +162,7 @@ func TestHTTPSProxy(t *testing.T) {
 	const fakeHost = "test.example.com"
 	upstreamAddr := upstream.Listener.Addr().String()
 
-	origTransport := upstreamTransport
-	upstreamTransport = &http.Transport{
+	p.transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
@@ -172,7 +171,6 @@ func TestHTTPSProxy(t *testing.T) {
 			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
 		},
 	}
-	defer func() { upstreamTransport = origTransport }()
 
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -6,6 +6,10 @@ dns:
   # The IP address returned for intercepted DNS queries.
   # Should be the IP where iron-proxy is running.
   proxy_ip: "10.16.0.1"
+  # Optional upstream DNS resolver for the proxy's own lookups. If set, both
+  # passthrough DNS queries and upstream HTTP connections resolve via this server
+  # instead of the OS default. Useful when iron-proxy owns the system DNS.
+  # upstream_resolver: "8.8.8.8:53"
   # Domains to pass through to the OS resolver (everything else resolves to proxy_ip)
   passthrough:
     - "*.internal.corp"


### PR DESCRIPTION
When iron-proxy owns the system DNS (e.g. running in a GitHub Action where all OS DNS is redirected to itself), upstream connections would loop back through the proxy's own resolver. The new `dns.upstream_resolver` setting (e.g. `8.8.8.8:53`) gives the proxy a dedicated resolver for both passthrough DNS queries and upstream HTTP dials, breaking the loop.