### PR TITLE
Support PKCS1 and PKCS8 private keys in CA parsing

### DIFF
--- a/internal/certcache/cache.go
+++ b/internal/certcache/cache.go
@@ -152,10 +152,14 @@ func loadCA(certPath, keyPath string) (*x509.Certificate, crypto.Signer, error) 
 
 	parsed, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
 	if err != nil {
-		// Try EC private key format as fallback
-		parsed, err = x509.ParseECPrivateKey(keyBlock.Bytes)
+		// Try PKCS1 (RSA) format as fallback
+		parsed, err = x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 		if err != nil {
-			return nil, nil, fmt.Errorf("parsing CA key: %w", err)
+			// Try EC private key format as final fallback
+			parsed, err = x509.ParseECPrivateKey(keyBlock.Bytes)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parsing CA key (tried PKCS8, PKCS1, and EC formats): %w", err)
+			}
 		}
 	}
 

--- a/internal/certcache/cache_test.go
+++ b/internal/certcache/cache_test.go
@@ -5,9 +5,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"math/big"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -92,6 +96,145 @@ func TestNewFromCA_RejectsMissingCertSign(t *testing.T) {
 	_, err = NewFromCA(cert, key, 10, 72*time.Hour)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "KeyUsageCertSign")
+}
+
+func writeTestCA(t *testing.T, dir string, cert *x509.Certificate, certDER []byte, keyPEM []byte) (string, string) {
+	t.Helper()
+
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+
+	certPEMBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	require.NoError(t, os.WriteFile(certPath, certPEMBytes, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	return certPath, keyPath
+}
+
+func TestLoadCA_PKCS8ECKey(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	certPath, keyPath := writeTestCA(t, t.TempDir(), cert, certDER, keyPEM)
+
+	caCert, signer, err := loadCA(certPath, keyPath)
+	require.NoError(t, err)
+	require.Equal(t, "Test CA", caCert.Subject.CommonName)
+	require.NotNil(t, signer)
+}
+
+func TestLoadCA_PKCS8RSAKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test RSA CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	certPath, keyPath := writeTestCA(t, t.TempDir(), cert, certDER, keyPEM)
+
+	caCert, signer, err := loadCA(certPath, keyPath)
+	require.NoError(t, err)
+	require.Equal(t, "Test RSA CA", caCert.Subject.CommonName)
+	require.NotNil(t, signer)
+}
+
+func TestLoadCA_PKCS1RSAKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test PKCS1 CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	certPath, keyPath := writeTestCA(t, t.TempDir(), cert, certDER, keyPEM)
+
+	caCert, signer, err := loadCA(certPath, keyPath)
+	require.NoError(t, err)
+	require.Equal(t, "Test PKCS1 CA", caCert.Subject.CommonName)
+	require.NotNil(t, signer)
+}
+
+func TestLoadCA_ECKey(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test EC CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	certPath, keyPath := writeTestCA(t, t.TempDir(), cert, certDER, keyPEM)
+
+	caCert, signer, err := loadCA(certPath, keyPath)
+	require.NoError(t, err)
+	require.Equal(t, "Test EC CA", caCert.Subject.CommonName)
+	require.NotNil(t, signer)
 }
 
 func TestGetOrCreate_GeneratesCert(t *testing.T) {


### PR DESCRIPTION
Adds PKCS1 (RSA) as a fallback format when parsing the CA private key. The parsing chain now tries PKCS8, then PKCS1, then EC. Also adds tests covering all supported key formats.