### PR TITLE
feat: add warn mode to allowlist transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Unmatched requests get a `403 Forbidden`.
 Domain patterns use glob matching: `*.example.com` matches any subdomain and
 `example.com` itself.
 
+**Warn mode:** Set `warn: true` to observe what the allowlist would block without
+actually enforcing it. Requests that would be rejected are allowed through but
+annotated with `"action": "warn"` in the transform trace. This is useful for
+rolling out new allowlist rules or auditing existing traffic before switching
+to enforcement.
+
 ### Secrets
 
 The sandbox never holds real credentials. Instead:

--- a/internal/transform/allowlist/allowlist.go
+++ b/internal/transform/allowlist/allowlist.go
@@ -20,12 +20,14 @@ func init() {
 // and paths against a set of rules.
 type Allowlist struct {
 	rules []hostmatch.Rule
+	warn  bool
 }
 
 type allowlistConfig struct {
 	Domains []string              `yaml:"domains"`
 	CIDRs   []string              `yaml:"cidrs"`
 	Rules   []hostmatch.RuleConfig `yaml:"rules"`
+	Warn    bool                   `yaml:"warn"`
 }
 
 func factory(cfg yaml.Node) (transform.Transformer, error) {
@@ -64,7 +66,7 @@ func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist
 	}
 	rules = append(rules, compiled...)
 
-	return &Allowlist{rules: rules}, nil
+	return &Allowlist{rules: rules, warn: cfg.Warn}, nil
 }
 
 // New creates an Allowlist from domain globs and CIDR strings.
@@ -75,8 +77,12 @@ func New(domains []string, cidrs []string, resolver hostmatch.Resolver) (*Allowl
 
 func (a *Allowlist) Name() string { return "allowlist" }
 
-func (a *Allowlist) TransformRequest(ctx context.Context, _ *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+func (a *Allowlist) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
 	if hostmatch.MatchAnyRule(ctx, a.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+	if a.warn {
+		tctx.Annotate("action", "warn")
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 	return &transform.TransformResult{Action: transform.ActionReject}, nil

--- a/internal/transform/allowlist/allowlist_test.go
+++ b/internal/transform/allowlist/allowlist_test.go
@@ -327,6 +327,76 @@ func TestAllowlist_RuleWithCIDR(t *testing.T) {
 	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "internal.service", "POST", "/").Action)
 }
 
+// --- Warn mode tests ---
+
+func TestAllowlist_WarnModeAllowsBlockedRequests(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Domains: []string{"api.openai.com"},
+		Warn:    true,
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	// Allowed request: no annotation
+	tctx := &transform.TransformContext{}
+	req := httptest.NewRequest("GET", "http://api.openai.com/", nil)
+	req.Host = "api.openai.com"
+	res, err := a.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Nil(t, tctx.DrainAnnotations())
+
+	// Blocked request in warn mode: continues with annotation
+	tctx2 := &transform.TransformContext{}
+	req2 := httptest.NewRequest("GET", "http://evil.com/", nil)
+	req2.Host = "evil.com"
+	res2, err := a.TransformRequest(context.Background(), tctx2, req2)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res2.Action)
+	annotations := tctx2.DrainAnnotations()
+	require.Equal(t, "warn", annotations["action"])
+}
+
+func TestAllowlist_WarnFalseStillRejects(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Domains: []string{"api.openai.com"},
+		Warn:    false,
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionReject, result(t, a, "evil.com").Action)
+}
+
+func TestAllowlist_WarnModeWithRules(t *testing.T) {
+	a, err := newFromConfig(allowlistConfig{
+		Rules: []hostmatch.RuleConfig{{
+			Host:    "api.openai.com",
+			Methods: []string{"GET"},
+		}},
+		Warn: true,
+	}, &mockResolver{})
+	require.NoError(t, err)
+
+	// Wrong method in warn mode: continues with annotation
+	tctx := &transform.TransformContext{}
+	req := httptest.NewRequest("POST", "http://api.openai.com/", nil)
+	req.Host = "api.openai.com"
+	res, err := a.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	annotations := tctx.DrainAnnotations()
+	require.Equal(t, "warn", annotations["action"])
+
+	// Wrong host in warn mode: continues with annotation
+	tctx2 := &transform.TransformContext{}
+	req2 := httptest.NewRequest("GET", "http://evil.com/", nil)
+	req2.Host = "evil.com"
+	res2, err := a.TransformRequest(context.Background(), tctx2, req2)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res2.Action)
+	annotations2 := tctx2.DrainAnnotations()
+	require.Equal(t, "warn", annotations2["action"])
+}
+
 // --- Validation tests ---
 
 func TestAllowlist_RuleBothHostAndCIDR(t *testing.T) {

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -39,6 +39,9 @@ tls:
 transforms:
   - name: allowlist
     config:
+      # When true, log requests that would be blocked but allow them through.
+      # Useful for rolling out allowlist rules without breaking existing traffic.
+      # warn: true
       # Simple form: allow all methods and paths to these hosts
       domains:
         - "registry.npmjs.org"


### PR DESCRIPTION
Adds a `warn` config flag to the allowlist transform. When enabled, requests that would normally be blocked are instead allowed through with an `action: warn` annotation in the transform trace. This lets operators observe what the allowlist would block without actually enforcing it.