### PR TITLE
feat: add iron-proxy-action to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -35,7 +34,6 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -55,7 +53,6 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -77,7 +74,6 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          warn: 'true'
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -34,6 +35,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          warn: 'true'
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -53,6 +55,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          warn: 'true'
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -74,6 +77,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          warn: 'true'
 
       - uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: ironsh/iron-proxy-action@v1
+        with:
+          egress-rules: egress-rules.yaml
+
       - uses: actions/setup-go@v6.4.0
         with:
           go-version: "1.26"
@@ -19,10 +23,17 @@ jobs:
       - name: Run tests
         run: go test -v -race -count=1 ./...
 
+      - uses: ironsh/iron-proxy-action/summary@v1
+        if: always()
+
   vet:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: ironsh/iron-proxy-action@v1
+        with:
+          egress-rules: egress-rules.yaml
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -31,10 +42,17 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - uses: ironsh/iron-proxy-action/summary@v1
+        if: always()
+
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: ironsh/iron-proxy-action@v1
+        with:
+          egress-rules: egress-rules.yaml
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -45,10 +63,17 @@ jobs:
           version: latest
           install-mode: binary
 
+      - uses: ironsh/iron-proxy-action/summary@v1
+        if: always()
+
   tidy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - uses: ironsh/iron-proxy-action@v1
+        with:
+          egress-rules: egress-rules.yaml
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -58,3 +83,6 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
+
+      - uses: ironsh/iron-proxy-action/summary@v1
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ironsh/iron-proxy-action@v1
+      - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
 
@@ -23,7 +23,7 @@ jobs:
       - name: Run tests
         run: go test -v -race -count=1 ./...
 
-      - uses: ironsh/iron-proxy-action/summary@v1
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
         if: always()
 
   vet:
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ironsh/iron-proxy-action@v1
+      - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
 
@@ -42,7 +42,7 @@ jobs:
       - name: go vet
         run: go vet ./...
 
-      - uses: ironsh/iron-proxy-action/summary@v1
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
         if: always()
 
   lint:
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ironsh/iron-proxy-action@v1
+      - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
 
@@ -63,7 +63,7 @@ jobs:
           version: latest
           install-mode: binary
 
-      - uses: ironsh/iron-proxy-action/summary@v1
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
         if: always()
 
   tidy:
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: ironsh/iron-proxy-action@v1
+      - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
 
@@ -84,5 +84,5 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-      - uses: ironsh/iron-proxy-action/summary@v1
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: 'true'
+          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: 'true'
+          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -55,7 +55,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: 'true'
+          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:
@@ -77,7 +77,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: 'true'
+          warn: true
 
       - uses: actions/setup-go@v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ironsh/iron-proxy-action@v1
+      - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
           disable-docker: 'false'
@@ -51,5 +51,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ironsh/iron-proxy-action/summary@v1
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
-          warn: 'true'
-          disable-docker: 'false'
+          warn: true
+          disable-docker: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          warn: 'true'
           disable-docker: 'false'
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ironsh/iron-proxy-action@v1
+        with:
+          egress-rules: egress-rules.yaml
+          disable-docker: 'false'
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
@@ -45,3 +50,6 @@ jobs:
             --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ironsh/iron-proxy-action/summary@v1
+        if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ironsh/iron-proxy-action@v0.1.0
-        with:
-          egress-rules: egress-rules.yaml
-          warn: true
-          disable-docker: false
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+- uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
@@ -51,6 +45,3 @@ jobs:
             --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ironsh/iron-proxy-action/summary@v0.1.0
-        if: always()

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -1,0 +1,30 @@
+domains:
+  # Go module proxy and checksum database
+  - "proxy.golang.org"
+  - "sum.golang.org"
+  - "storage.googleapis.com"
+
+  # GitHub (for actions, releases, and module downloads)
+  - "github.com"
+  - "*.github.com"
+  - "*.githubusercontent.com"
+
+  # golangci-lint
+  - "*.golangci.com"
+
+  # Go toolchain
+  - "go.dev"
+  - "*.go.dev"
+  - "golang.org"
+  - "*.golang.org"
+
+  # Google (for gRPC/protobuf modules)
+  - "google.golang.org"
+
+  # Docker Hub (for release builds)
+  - "*.docker.io"
+  - "*.docker.com"
+
+  # GoReleaser
+  - "goreleaser.com"
+  - "*.goreleaser.com"

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -11,6 +11,8 @@ domains:
 
   # golangci-lint
   - "*.golangci.com"
+  - "golangci-lint.run"
+  - "*.golangci-lint.run"
 
   # Go toolchain
   - "go.dev"


### PR DESCRIPTION
Adds `ironsh/iron-proxy-action@v1` to all CI and release workflow jobs to enforce default-deny egress policies. Creates an `egress-rules.yaml` allowlist covering Go module proxy, GitHub, Docker Hub, golangci-lint, and GoReleaser domains. The release workflow sets `disable-docker: false` since it needs Docker for multi-arch builds. Each job includes the `summary` step so egress traffic is visible in the Actions UI.