### PR TITLE
fix: preserve Content-Length and simplify body buffering

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -164,7 +164,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	} else if rejectResp != nil {
 		result.Action = transform.ActionReject
 		result.StatusCode = rejectResp.StatusCode
-		writeResponse(w, rejectResp)
+		p.writeResponse(w, rejectResp)
 		return
 	}
 
@@ -232,7 +232,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(w, finalResp)
+	p.writeResponse(w, finalResp)
 }
 
 // isWebSocketUpgrade detects a WebSocket upgrade request.
@@ -309,7 +309,9 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(upstreamConn, clientBuf)
+		if _, err := io.Copy(upstreamConn, clientBuf); err != nil {
+			p.logger.Debug("websocket client->upstream copy error", slog.String("error", err.Error()))
+		}
 		// Signal upstream we're done writing
 		if tc, ok := upstreamConn.(*net.TCPConn); ok {
 			tc.CloseWrite()
@@ -318,7 +320,9 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 
 	go func() {
 		defer wg.Done()
-		_, _ = io.Copy(clientConn, upstreamConn)
+		if _, err := io.Copy(clientConn, upstreamConn); err != nil {
+			p.logger.Debug("websocket upstream->client copy error", slog.String("error", err.Error()))
+		}
 		// Signal client we're done writing
 		if tc, ok := clientConn.(*net.TCPConn); ok {
 			tc.CloseWrite()
@@ -347,24 +351,32 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		_, _ = io.Copy(w, reader)
+		if _, err := io.Copy(w, reader); err != nil {
+			p.logger.Warn("SSE copy error", slog.String("error", err.Error()))
+		}
 		return
 	}
 
 	buf := make([]byte, 32*1024)
 	for {
-		n, err := reader.Read(buf)
+		n, readErr := reader.Read(buf)
 		if n > 0 {
-			_, _ = w.Write(buf[:n])
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				p.logger.Warn("SSE write error", slog.String("error", writeErr.Error()))
+				break
+			}
 			flusher.Flush()
 		}
-		if err != nil {
+		if readErr != nil {
+			if readErr != io.EOF {
+				p.logger.Warn("SSE read error", slog.String("error", readErr.Error()))
+			}
 			break
 		}
 	}
 }
 
-func writeResponse(w http.ResponseWriter, resp *http.Response) {
+func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
 	if buf, ok := resp.Body.(*transform.BufferedBody); ok {
 		// If a transform buffered the response body, set Content-Length
@@ -375,12 +387,16 @@ func writeResponse(w http.ResponseWriter, resp *http.Response) {
 			w.Header().Set("Content-Length", strconv.FormatInt(int64(n), 10))
 		}
 		w.WriteHeader(resp.StatusCode)
-		_, _ = io.Copy(w, buf.StreamingReader())
+		if _, err := io.Copy(w, buf.StreamingReader()); err != nil {
+			p.logger.Warn("response body copy error", slog.String("error", err.Error()))
+		}
 	} else {
 		// Synthetic responses (e.g. reject) with plain bodies.
 		w.WriteHeader(resp.StatusCode)
 		if resp.Body != nil {
-			_, _ = io.Copy(w, resp.Body)
+			if _, err := io.Copy(w, resp.Body); err != nil {
+				p.logger.Warn("response body copy error", slog.String("error", err.Error()))
+			}
 		}
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -184,15 +184,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	upstreamURL := fmt.Sprintf("%s://%s%s", scheme, host, path)
 
-	// Use StreamingReader for the upstream body: streams directly from the
-	// client if no transform touched the body, reads from buffer otherwise.
-	var upstreamBody io.Reader
-	if buf, ok := r.Body.(*transform.BufferedBody); ok {
-		upstreamBody = buf.StreamingReader()
-	} else {
-		upstreamBody = r.Body
-	}
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, io.NopCloser(upstreamBody))
+	reqBody := transform.RequireBufferedBody(r.Body)
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, io.NopCloser(reqBody.StreamingReader()))
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
@@ -203,10 +196,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	copyHeaders(upstreamReq.Header, r.Header)
 	// If a transform buffered the request body, set ContentLength so the
 	// upstream receives a Content-Length header instead of chunked encoding.
-	if buf, ok := r.Body.(*transform.BufferedBody); ok {
-		if n := buf.Len(); n >= 0 {
-			upstreamReq.ContentLength = int64(n)
-		}
+	if n := reqBody.Len(); n >= 0 {
+		upstreamReq.ContentLength = int64(n)
 	}
 
 	resp, err := p.doUpstream(upstreamReq)
@@ -352,7 +343,7 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 
-	reader := streamBody(resp.Body)
+	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -375,27 +366,23 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 
 func writeResponse(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
-	// If a transform buffered the response body, set Content-Length from
-	// the buffered data. Otherwise preserve the upstream header as-is so
-	// clients that require Content-Length (e.g. Docker) work correctly.
 	if buf, ok := resp.Body.(*transform.BufferedBody); ok {
+		// If a transform buffered the response body, set Content-Length
+		// from the buffered data. Otherwise preserve the upstream header
+		// as-is so clients that require Content-Length (e.g. Docker)
+		// work correctly.
 		if n := buf.Len(); n >= 0 {
 			w.Header().Set("Content-Length", strconv.FormatInt(int64(n), 10))
 		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, buf.StreamingReader())
+	} else {
+		// Synthetic responses (e.g. reject) with plain bodies.
+		w.WriteHeader(resp.StatusCode)
+		if resp.Body != nil {
+			_, _ = io.Copy(w, resp.Body)
+		}
 	}
-	w.WriteHeader(resp.StatusCode)
-	if resp.Body != nil {
-		_, _ = io.Copy(w, streamBody(resp.Body))
-	}
-}
-
-// streamBody returns a streaming reader if the body is a BufferedBody,
-// avoiding unnecessary buffering when writing the final response.
-func streamBody(body io.ReadCloser) io.Reader {
-	if b, ok := body.(*transform.BufferedBody); ok {
-		return b.StreamingReader()
-	}
-	return body
 }
 
 // buildTransport creates the HTTP transport used for upstream requests.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strconv"
 	"net"
 	"net/http"
 	"strings"
@@ -150,8 +151,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		p.pipeline.EmitAudit(result)
 	}()
 
-	// Wrap request body for transform replayability.
-	r.Body = transform.NewReplayableBody(r.Body, bodyLimits.MaxRequestBodyBytes)
+	// Wrap request body for lazy buffering by transforms.
+	r.Body = transform.NewBufferedBody(r.Body, bodyLimits.MaxRequestBodyBytes)
 
 	// Run request transforms
 	if rejectResp, err := p.pipeline.ProcessRequest(r.Context(), tctx, r, &reqTraces); err != nil {
@@ -182,7 +183,16 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		path = path + "?" + r.URL.RawQuery
 	}
 	upstreamURL := fmt.Sprintf("%s://%s%s", scheme, host, path)
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, r.Body)
+
+	// Use StreamingReader for the upstream body: streams directly from the
+	// client if no transform touched the body, reads from buffer otherwise.
+	var upstreamBody io.Reader
+	if buf, ok := r.Body.(*transform.BufferedBody); ok {
+		upstreamBody = buf.StreamingReader()
+	} else {
+		upstreamBody = r.Body
+	}
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, io.NopCloser(upstreamBody))
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
@@ -191,6 +201,13 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	copyHeaders(upstreamReq.Header, r.Header)
+	// If a transform buffered the request body, set ContentLength so the
+	// upstream receives a Content-Length header instead of chunked encoding.
+	if buf, ok := r.Body.(*transform.BufferedBody); ok {
+		if n := buf.Len(); n >= 0 {
+			upstreamReq.ContentLength = int64(n)
+		}
+	}
 
 	resp, err := p.doUpstream(upstreamReq)
 	if err != nil {
@@ -202,8 +219,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	// Wrap response body for transform replayability.
-	resp.Body = transform.NewReplayableBody(resp.Body, bodyLimits.MaxResponseBodyBytes)
+	// Wrap response body for lazy buffering by transforms.
+	resp.Body = transform.NewBufferedBody(resp.Body, bodyLimits.MaxResponseBodyBytes)
 
 	// Run response transforms
 	finalResp, err := p.pipeline.ProcessResponse(r.Context(), tctx, r, resp, &respTraces)
@@ -358,19 +375,24 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 
 func writeResponse(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
-	// Remove Content-Length since transforms may have changed the body size.
-	// Go's HTTP server will set it or use chunked encoding.
-	w.Header().Del("Content-Length")
+	// If a transform buffered the response body, set Content-Length from
+	// the buffered data. Otherwise preserve the upstream header as-is so
+	// clients that require Content-Length (e.g. Docker) work correctly.
+	if buf, ok := resp.Body.(*transform.BufferedBody); ok {
+		if n := buf.Len(); n >= 0 {
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(n), 10))
+		}
+	}
 	w.WriteHeader(resp.StatusCode)
 	if resp.Body != nil {
 		_, _ = io.Copy(w, streamBody(resp.Body))
 	}
 }
 
-// streamBody returns a streaming reader if the body supports it, avoiding
-// unnecessary buffering when writing the final response.
+// streamBody returns a streaming reader if the body is a BufferedBody,
+// avoiding unnecessary buffering when writing the final response.
 func streamBody(body io.ReadCloser) io.Reader {
-	if b, ok := body.(transform.Bufferable); ok {
+	if b, ok := body.(*transform.BufferedBody); ok {
 		return b.StreamingReader()
 	}
 	return body

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -374,3 +374,30 @@ func TestHTTPProxy_SSEStreaming(t *testing.T) {
 	require.Contains(t, string(body), "data: event2")
 	require.Contains(t, string(body), "data: event3")
 }
+
+func TestHTTPProxy_ContentLengthPreserved(t *testing.T) {
+	const responseBody = "fixed-size body"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(responseBody)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, responseBody)
+	}))
+	defer upstream.Close()
+
+	_, httpAddr, _, _ := startProxy(t)
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/test", httpAddr), nil)
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int64(len(responseBody)), resp.ContentLength)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, responseBody, string(body))
+}

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -6,143 +6,50 @@ import (
 	"sync"
 )
 
-// Bufferable is implemented by body types that support rewinding for replay
-// between pipeline transforms, and streaming for final output without
-// unnecessary buffering.
-type Bufferable interface {
-	Reset()
-	StreamingReader() io.Reader
-}
-
-// ReplayableBody wraps an io.ReadCloser with incremental buffering and rewind
-// support. Data is buffered as it is read from the underlying reader. After
-// calling Reset(), subsequent reads replay from the buffer. A maxBytes of 0
-// means unlimited; when the limit is reached reads return EOF.
-type ReplayableBody struct {
+// BufferedBody wraps an io.ReadCloser with lazy, all-or-nothing buffering.
+//
+// When a transform calls Read(), the entire underlying reader is consumed into
+// memory on the first call. Subsequent reads and Reset() calls operate on the
+// buffer. When no transform reads the body, StreamingReader() returns the
+// original reader directly — avoiding buffering for the final response write
+// or upstream send.
+//
+// A maxBytes of 0 means unlimited; when the limit is exceeded the body is
+// truncated silently.
+type BufferedBody struct {
 	mu       sync.Mutex
-	original io.ReadCloser
-	buf      []byte
-	pos      int   // read position within buf
-	maxBytes int64 // 0 = unlimited
-	eof      bool  // original has been fully consumed (or capped)
+	original io.ReadCloser // nil once buffered or when created from bytes
+	data     []byte        // nil until buffered
+	pos      int
+	maxBytes int64
+	buffered bool
 }
 
-// NewReplayableBody wraps an existing body. maxBytes caps total buffer size;
-// 0 means unlimited. When the cap is reached, reads return EOF.
-func NewReplayableBody(body io.ReadCloser, maxBytes int64) *ReplayableBody {
+// NewBufferedBody wraps an io.ReadCloser for lazy buffering. maxBytes caps
+// the buffer size; 0 means unlimited.
+func NewBufferedBody(body io.ReadCloser, maxBytes int64) *BufferedBody {
 	if body == nil {
 		body = io.NopCloser(bytes.NewReader(nil))
 	}
-	return &ReplayableBody{original: body, maxBytes: maxBytes}
+	return &BufferedBody{original: body, maxBytes: maxBytes}
 }
 
-// Read implements io.Reader. On the first pass, data is read from the
-// underlying reader and appended to an internal buffer. After Reset(),
-// reads are served from the buffer.
-func (b *ReplayableBody) Read(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	// Serve from buffer if we have unread buffered data.
-	if b.pos < len(b.buf) {
-		n := copy(p, b.buf[b.pos:])
-		b.pos += n
-		if b.pos == len(b.buf) && b.eof {
-			return n, io.EOF
-		}
-		return n, nil
-	}
-
-	// Buffer is exhausted and original is done.
-	if b.eof {
-		return 0, io.EOF
-	}
-
-	// Read from original, append to buffer.
-	n, err := b.original.Read(p)
-	if n > 0 {
-		if b.maxBytes > 0 && int64(len(b.buf)+n) > b.maxBytes {
-			// Cap: take only what fits, then treat as EOF.
-			room := int(b.maxBytes) - len(b.buf)
-			if room > 0 {
-				b.buf = append(b.buf, p[:room]...)
-				b.pos = len(b.buf)
-			}
-			b.eof = true
-			b.original.Close()
-			return room, io.EOF
-		}
-		b.buf = append(b.buf, p[:n]...)
-		b.pos = len(b.buf)
-	}
-	if err == io.EOF {
-		b.eof = true
-		b.original.Close()
-	}
-	return n, err
-}
-
-// Reset rewinds the read position to the beginning so the body can be
-// re-read by the next transform in the pipeline.
-func (b *ReplayableBody) Reset() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.pos = 0
-}
-
-// StreamingReader returns a reader that drains the buffered data from the
-// current position, then streams directly from the underlying reader without
-// appending to the buffer. Use this for final output (e.g. writing the HTTP
-// response) to avoid buffering the entire body into memory.
-func (b *ReplayableBody) StreamingReader() io.Reader {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	var readers []io.Reader
-
-	// Any buffered data from the current position.
-	if b.pos < len(b.buf) {
-		readers = append(readers, bytes.NewReader(b.buf[b.pos:]))
-	}
-
-	// Remaining unbuffered data from the original, if not fully consumed.
-	if !b.eof {
-		readers = append(readers, b.original)
-	}
-
-	if len(readers) == 0 {
-		return bytes.NewReader(nil)
-	}
-	return io.MultiReader(readers...)
-}
-
-// Close is a no-op if the original has already been consumed; otherwise
-// closes the underlying reader.
-func (b *ReplayableBody) Close() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if b.eof {
-		return nil
-	}
-	b.eof = true
-	return b.original.Close()
-}
-
-// BufferedBody is a read-resettable body backed by a fixed byte slice.
+// NewBufferedBodyFromBytes creates a pre-buffered body from a byte slice.
 // Use this when a transform replaces the body with new content.
-type BufferedBody struct {
-	data []byte
-	pos  int
+func NewBufferedBodyFromBytes(data []byte) *BufferedBody {
+	return &BufferedBody{data: data, buffered: true}
 }
 
-// NewBufferedBody creates a BufferedBody from a byte slice.
-func NewBufferedBody(data []byte) *BufferedBody {
-	return &BufferedBody{data: data}
-}
-
-// Read implements io.Reader.
+// Read implements io.Reader. On the first call, the entire underlying reader
+// is eagerly consumed into an internal buffer. All reads serve from the buffer.
 func (b *BufferedBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.buffered {
+		b.bufferLocked()
+	}
+
 	if b.pos >= len(b.data) {
 		return 0, io.EOF
 	}
@@ -151,17 +58,62 @@ func (b *BufferedBody) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// Reset rewinds to the beginning.
+// bufferLocked eagerly reads the entire original body into memory.
+// Must be called with b.mu held.
+func (b *BufferedBody) bufferLocked() {
+	var r io.Reader = b.original
+	if b.maxBytes > 0 {
+		r = io.LimitReader(r, b.maxBytes)
+	}
+	b.data, _ = io.ReadAll(r)
+	b.buffered = true
+	b.original.Close()
+	b.original = nil
+}
+
+// Reset rewinds the read position to the beginning so the body can be
+// re-read by the next transform in the pipeline.
 func (b *BufferedBody) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.pos = 0
 }
 
-// StreamingReader returns a reader over the remaining data.
+// StreamingReader returns a reader for the final output (response write or
+// upstream send). If the body was never read by a transform, this returns the
+// original reader directly — no buffering occurs. If the body was buffered,
+// returns a reader over the buffer from the current position.
 func (b *BufferedBody) StreamingReader() io.Reader {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.buffered {
+		r := b.original
+		b.original = nil
+		return r
+	}
 	return bytes.NewReader(b.data[b.pos:])
 }
 
-// Close is a no-op.
+// Len returns the total size of the buffered body, or -1 if the body has not
+// been buffered yet.
+func (b *BufferedBody) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.buffered {
+		return -1
+	}
+	return len(b.data)
+}
+
+// Close closes the underlying reader if it has not been consumed.
 func (b *BufferedBody) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.original != nil {
+		err := b.original.Close()
+		b.original = nil
+		return err
+	}
 	return nil
 }

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -45,7 +45,9 @@ func NewBufferedBodyFromBytes(data []byte) *BufferedBody {
 // Read implements io.Reader. On the first call, the entire underlying reader
 // is eagerly consumed into an internal buffer. All reads serve from the buffer.
 func (b *BufferedBody) Read(p []byte) (int, error) {
-	b.buffer()
+	if err := b.buffer(); err != nil {
+		return 0, err
+	}
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -59,16 +61,18 @@ func (b *BufferedBody) Read(p []byte) (int, error) {
 }
 
 // buffer eagerly reads the entire original body into memory exactly once.
-func (b *BufferedBody) buffer() {
+func (b *BufferedBody) buffer() error {
+	var err error
 	b.once.Do(func() {
 		var r io.Reader = b.original
 		if b.maxBytes > 0 {
 			r = io.LimitReader(r, b.maxBytes)
 		}
-		b.data, _ = io.ReadAll(r)
+		b.data, err = io.ReadAll(r)
 		b.original.Close()
 		b.original = nil
 	})
+	return err
 }
 
 // Reset rewinds the read position to the beginning so the body can be

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -17,12 +17,12 @@ import (
 // A maxBytes of 0 means unlimited; when the limit is exceeded the body is
 // truncated silently.
 type BufferedBody struct {
-	mu       sync.Mutex
-	original io.ReadCloser // nil once buffered or when created from bytes
-	data     []byte        // nil until buffered
+	once     sync.Once
+	mu       sync.Mutex // protects pos only
+	original io.ReadCloser
+	data     []byte
 	pos      int
 	maxBytes int64
-	buffered bool
 }
 
 // NewBufferedBody wraps an io.ReadCloser for lazy buffering. maxBytes caps
@@ -37,18 +37,18 @@ func NewBufferedBody(body io.ReadCloser, maxBytes int64) *BufferedBody {
 // NewBufferedBodyFromBytes creates a pre-buffered body from a byte slice.
 // Use this when a transform replaces the body with new content.
 func NewBufferedBodyFromBytes(data []byte) *BufferedBody {
-	return &BufferedBody{data: data, buffered: true}
+	b := &BufferedBody{data: data}
+	b.once.Do(func() {}) // mark as already buffered
+	return b
 }
 
 // Read implements io.Reader. On the first call, the entire underlying reader
 // is eagerly consumed into an internal buffer. All reads serve from the buffer.
 func (b *BufferedBody) Read(p []byte) (int, error) {
+	b.buffer()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
-	if !b.buffered {
-		b.bufferLocked()
-	}
 
 	if b.pos >= len(b.data) {
 		return 0, io.EOF
@@ -58,17 +58,17 @@ func (b *BufferedBody) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// bufferLocked eagerly reads the entire original body into memory.
-// Must be called with b.mu held.
-func (b *BufferedBody) bufferLocked() {
-	var r io.Reader = b.original
-	if b.maxBytes > 0 {
-		r = io.LimitReader(r, b.maxBytes)
-	}
-	b.data, _ = io.ReadAll(r)
-	b.buffered = true
-	b.original.Close()
-	b.original = nil
+// buffer eagerly reads the entire original body into memory exactly once.
+func (b *BufferedBody) buffer() {
+	b.once.Do(func() {
+		var r io.Reader = b.original
+		if b.maxBytes > 0 {
+			r = io.LimitReader(r, b.maxBytes)
+		}
+		b.data, _ = io.ReadAll(r)
+		b.original.Close()
+		b.original = nil
+	})
 }
 
 // Reset rewinds the read position to the beginning so the body can be
@@ -84,23 +84,21 @@ func (b *BufferedBody) Reset() {
 // original reader directly — no buffering occurs. If the body was buffered,
 // returns a reader over the buffer from the current position.
 func (b *BufferedBody) StreamingReader() io.Reader {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if !b.buffered {
+	if b.original != nil {
 		r := b.original
 		b.original = nil
 		return r
 	}
-	return bytes.NewReader(b.data[b.pos:])
+	b.mu.Lock()
+	pos := b.pos
+	b.mu.Unlock()
+	return bytes.NewReader(b.data[pos:])
 }
 
 // Len returns the total size of the buffered body, or -1 if the body has not
 // been buffered yet.
 func (b *BufferedBody) Len() int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if !b.buffered {
+	if b.original != nil {
 		return -1
 	}
 	return len(b.data)
@@ -108,8 +106,6 @@ func (b *BufferedBody) Len() int {
 
 // Close closes the underlying reader if it has not been consumed.
 func (b *BufferedBody) Close() error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
 	if b.original != nil {
 		err := b.original.Close()
 		b.original = nil

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 )
@@ -116,4 +117,15 @@ func (b *BufferedBody) Close() error {
 		return err
 	}
 	return nil
+}
+
+// RequireBufferedBody asserts that body is a *BufferedBody and returns it.
+// Panics otherwise. The proxy must wrap all request and response bodies
+// before they enter the pipeline or are forwarded.
+func RequireBufferedBody(body io.ReadCloser) *BufferedBody {
+	b, ok := body.(*BufferedBody)
+	if !ok {
+		panic(fmt.Sprintf("expected *BufferedBody, got %T", body))
+	}
+	return b
 }

--- a/internal/transform/body_test.go
+++ b/internal/transform/body_test.go
@@ -8,16 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReplayableBody_Read(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello")), 1024)
+func TestBufferedBody_Read(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello")), 1024)
 
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(data))
 }
 
-func TestReplayableBody_ResetAndReread(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello")), 1024)
+func TestBufferedBody_ResetAndReread(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello")), 1024)
 
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
@@ -30,8 +30,8 @@ func TestReplayableBody_ResetAndReread(t *testing.T) {
 	require.Equal(t, "hello", string(data))
 }
 
-func TestReplayableBody_MultipleResets(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("abc")), 1024)
+func TestBufferedBody_MultipleResets(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("abc")), 1024)
 
 	for i := 0; i < 5; i++ {
 		data, err := io.ReadAll(body)
@@ -41,30 +41,8 @@ func TestReplayableBody_MultipleResets(t *testing.T) {
 	}
 }
 
-func TestReplayableBody_IncrementalRead(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello world")), 1024)
-
-	// Read in small chunks.
-	buf := make([]byte, 3)
-	n, err := body.Read(buf)
-	require.NoError(t, err)
-	require.Equal(t, 3, n)
-	require.Equal(t, "hel", string(buf[:n]))
-
-	// Read more.
-	n, err = body.Read(buf)
-	require.NoError(t, err)
-	require.Equal(t, "lo ", string(buf[:n]))
-
-	// Reset and re-read from the start — should get buffered data.
-	body.Reset()
-	data, err := io.ReadAll(body)
-	require.NoError(t, err)
-	require.Equal(t, "hello world", string(data))
-}
-
-func TestReplayableBody_MaxBytesTruncates(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello world")), 5)
+func TestBufferedBody_MaxBytesTruncates(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello world")), 5)
 
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
@@ -77,28 +55,77 @@ func TestReplayableBody_MaxBytesTruncates(t *testing.T) {
 	require.Equal(t, "hello", string(data))
 }
 
-func TestReplayableBody_Unlimited(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello world")), 0)
+func TestBufferedBody_Unlimited(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello world")), 0)
 
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, "hello world", string(data))
 }
 
-func TestReplayableBody_NilBody(t *testing.T) {
-	body := NewReplayableBody(nil, 1024)
+func TestBufferedBody_NilBody(t *testing.T) {
+	body := NewBufferedBody(nil, 1024)
 
 	data, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.Empty(t, data)
 }
 
-func TestReplayableBody_Close(t *testing.T) {
-	body := NewReplayableBody(io.NopCloser(strings.NewReader("hello")), 1024)
+func TestBufferedBody_Close(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello")), 1024)
 	require.NoError(t, body.Close())
 
 	// After consuming, close is a no-op.
-	body2 := NewReplayableBody(io.NopCloser(strings.NewReader("hello")), 1024)
+	body2 := NewBufferedBody(io.NopCloser(strings.NewReader("hello")), 1024)
 	_, _ = io.ReadAll(body2)
 	require.NoError(t, body2.Close())
+}
+
+func TestBufferedBody_StreamingReader_Unbuffered(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("stream me")), 1024)
+
+	// StreamingReader without any prior Read should return the original.
+	reader := body.StreamingReader()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "stream me", string(data))
+}
+
+func TestBufferedBody_StreamingReader_Buffered(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("buffered")), 1024)
+
+	// Read first to trigger buffering.
+	_, _ = io.ReadAll(body)
+	body.Reset()
+
+	reader := body.StreamingReader()
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, "buffered", string(data))
+}
+
+func TestBufferedBody_Len(t *testing.T) {
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello")), 1024)
+
+	// Before any read, Len is unknown.
+	require.Equal(t, -1, body.Len())
+
+	// After reading, Len returns the buffered size.
+	_, _ = io.ReadAll(body)
+	require.Equal(t, 5, body.Len())
+}
+
+func TestBufferedBodyFromBytes(t *testing.T) {
+	body := NewBufferedBodyFromBytes([]byte("pre-buffered"))
+
+	require.Equal(t, 12, body.Len())
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "pre-buffered", string(data))
+
+	body.Reset()
+	data, err = io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "pre-buffered", string(data))
 }

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -273,7 +273,7 @@ func protoToHTTPResponse(pb *transformv1.HttpResponse, req *http.Request) *http.
 	resp := &http.Response{
 		StatusCode: int(pb.GetStatusCode()),
 		Header:     protoToHeaders(pb.GetHeaders()),
-		Body:       transform.NewBufferedBody(pb.GetBody()),
+		Body:       transform.NewBufferedBodyFromBytes(pb.GetBody()),
 		Request:    req,
 	}
 	if resp.StatusCode == 0 {
@@ -298,7 +298,7 @@ func applyModifiedRequest(pb *transformv1.HttpRequest, req *http.Request) {
 		req.Header = protoToHeaders(pb.GetHeaders())
 	}
 	if pb.GetBody() != nil {
-		req.Body = transform.NewBufferedBody(pb.GetBody())
+		req.Body = transform.NewBufferedBodyFromBytes(pb.GetBody())
 		req.ContentLength = int64(len(pb.GetBody()))
 	}
 }
@@ -311,8 +311,7 @@ func applyModifiedResponse(pb *transformv1.HttpResponse, resp *http.Response) {
 		resp.Header = protoToHeaders(pb.GetHeaders())
 	}
 	if pb.GetBody() != nil {
-		resp.Body = transform.NewBufferedBody(pb.GetBody())
-		resp.ContentLength = int64(len(pb.GetBody()))
+		resp.Body = transform.NewBufferedBodyFromBytes(pb.GetBody())
 	}
 }
 

--- a/internal/transform/grpc/grpc_test.go
+++ b/internal/transform/grpc/grpc_test.go
@@ -122,7 +122,7 @@ func TestTransformRequest_Reject(t *testing.T) {
 
 	gt := newTestTransform(t, "test", addr, true, false)
 	req, _ := http.NewRequest("POST", "https://api.example.com/v1", nil)
-	req.Body = transform.NewReplayableBody(io.NopCloser(bytes.NewReader([]byte("body"))), 1<<20)
+	req.Body = transform.NewBufferedBody(io.NopCloser(bytes.NewReader([]byte("body"))), 1<<20)
 
 	result, err := gt.TransformRequest(context.Background(), testContext(), req)
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestTransformResponse_Continue(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     http.Header{"Content-Type": {"application/json"}},
-		Body:       transform.NewReplayableBody(io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))), 1<<20),
+		Body:       transform.NewBufferedBody(io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))), 1<<20),
 	}
 
 	result, err := gt.TransformResponse(context.Background(), testContext(), req, resp)
@@ -253,7 +253,7 @@ func TestSendRequestBody_True(t *testing.T) {
 
 	gt := newTestTransform(t, "test", addr, true, false)
 	req, _ := http.NewRequest("POST", "https://example.com/", nil)
-	req.Body = transform.NewReplayableBody(io.NopCloser(bytes.NewReader([]byte("payload"))), 1<<20)
+	req.Body = transform.NewBufferedBody(io.NopCloser(bytes.NewReader([]byte("payload"))), 1<<20)
 
 	_, err := gt.TransformRequest(context.Background(), testContext(), req)
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestSendResponseBody_True(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       transform.NewReplayableBody(io.NopCloser(bytes.NewReader([]byte("response data"))), 1<<20),
+		Body:       transform.NewBufferedBody(io.NopCloser(bytes.NewReader([]byte("response data"))), 1<<20),
 	}
 
 	_, err := gt.TransformResponse(context.Background(), testContext(), req, resp)
@@ -534,11 +534,11 @@ func TestSendResponseBody_UncappedDefault(t *testing.T) {
 	gt := newTestTransform(t, "test", addr, false, true)
 	req, _ := http.NewRequest("GET", "https://example.com/", nil)
 	bigBody := bytes.Repeat([]byte("x"), 2<<20) // 2 MiB
-	// Wrap in ReplayableBody with 0 maxBytes (uncapped).
+	// Wrap in BufferedBody with 0 maxBytes (uncapped).
 	resp := &http.Response{
 		StatusCode: 200,
 		Header:     make(http.Header),
-		Body:       transform.NewReplayableBody(io.NopCloser(bytes.NewReader(bigBody)), 0),
+		Body:       transform.NewBufferedBody(io.NopCloser(bytes.NewReader(bigBody)), 0),
 	}
 
 	_, err := gt.TransformResponse(context.Background(), testContext(), req, resp)

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -3,7 +3,6 @@ package transform
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -52,7 +51,7 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 		dur := time.Since(start)
 
 		// Reset body for the next transform.
-		requireBufferedBody(req.Body).Reset()
+		RequireBufferedBody(req.Body).Reset()
 
 		trace := TransformTrace{
 			Name:        t.Name(),
@@ -89,8 +88,8 @@ func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, 
 		dur := time.Since(start)
 
 		// Reset bodies for the next transform.
-		requireBufferedBody(req.Body).Reset()
-		requireBufferedBody(resp.Body).Reset()
+		RequireBufferedBody(req.Body).Reset()
+		RequireBufferedBody(resp.Body).Reset()
 
 		trace := TransformTrace{
 			Name:        t.Name(),
@@ -122,16 +121,6 @@ func (p *Pipeline) EmitAudit(result *PipelineResult) {
 	if p.onComplete != nil {
 		p.onComplete(result)
 	}
-}
-
-// requireBufferedBody asserts that body is a *BufferedBody. The proxy must
-// wrap all request and response bodies before entering the pipeline.
-func requireBufferedBody(body io.ReadCloser) *BufferedBody {
-	b, ok := body.(*BufferedBody)
-	if !ok {
-		panic(fmt.Sprintf("pipeline: expected *BufferedBody, got %T", body))
-	}
-	return b
 }
 
 func forbiddenResponse(req *http.Request) *http.Response {

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -51,7 +51,7 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 		dur := time.Since(start)
 
 		// Reset body for the next transform.
-		if r, ok := req.Body.(Bufferable); ok {
+		if r, ok := req.Body.(*BufferedBody); ok {
 			r.Reset()
 		}
 
@@ -90,10 +90,10 @@ func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, 
 		dur := time.Since(start)
 
 		// Reset bodies for the next transform.
-		if r, ok := req.Body.(Bufferable); ok {
+		if r, ok := req.Body.(*BufferedBody); ok {
 			r.Reset()
 		}
-		if r, ok := resp.Body.(Bufferable); ok {
+		if r, ok := resp.Body.(*BufferedBody); ok {
 			r.Reset()
 		}
 

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -51,9 +52,7 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 		dur := time.Since(start)
 
 		// Reset body for the next transform.
-		if r, ok := req.Body.(*BufferedBody); ok {
-			r.Reset()
-		}
+		requireBufferedBody(req.Body).Reset()
 
 		trace := TransformTrace{
 			Name:        t.Name(),
@@ -90,12 +89,8 @@ func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, 
 		dur := time.Since(start)
 
 		// Reset bodies for the next transform.
-		if r, ok := req.Body.(*BufferedBody); ok {
-			r.Reset()
-		}
-		if r, ok := resp.Body.(*BufferedBody); ok {
-			r.Reset()
-		}
+		requireBufferedBody(req.Body).Reset()
+		requireBufferedBody(resp.Body).Reset()
 
 		trace := TransformTrace{
 			Name:        t.Name(),
@@ -127,6 +122,16 @@ func (p *Pipeline) EmitAudit(result *PipelineResult) {
 	if p.onComplete != nil {
 		p.onComplete(result)
 	}
+}
+
+// requireBufferedBody asserts that body is a *BufferedBody. The proxy must
+// wrap all request and response bodies before entering the pipeline.
+func requireBufferedBody(body io.ReadCloser) *BufferedBody {
+	b, ok := body.(*BufferedBody)
+	if !ok {
+		panic(fmt.Sprintf("pipeline: expected *BufferedBody, got %T", body))
+	}
+	return b
 }
 
 func forbiddenResponse(req *http.Request) *http.Response {

--- a/internal/transform/pipeline_test.go
+++ b/internal/transform/pipeline_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// wrapBody wraps the request body in a BufferedBody, matching what the proxy
+// does before entering the pipeline.
+func wrapBody(req *http.Request) {
+	req.Body = NewBufferedBody(req.Body, 0)
+}
+
 func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
@@ -57,6 +63,7 @@ func TestPipeline_AllContinue(t *testing.T) {
 	p := NewPipeline([]Transformer{t1, t2}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	resp, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
@@ -75,6 +82,7 @@ func TestPipeline_RequestRejectShortCircuits(t *testing.T) {
 	p := NewPipeline([]Transformer{t1, t2}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	resp, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
@@ -99,6 +107,7 @@ func TestPipeline_RequestRejectCustomResponse(t *testing.T) {
 	p := NewPipeline([]Transformer{t1}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	resp, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
@@ -114,6 +123,7 @@ func TestPipeline_RequestError(t *testing.T) {
 	p := NewPipeline([]Transformer{t1}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	_, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.Error(t, err)
@@ -130,7 +140,8 @@ func TestPipeline_ResponseReject(t *testing.T) {
 	p := NewPipeline([]Transformer{t1}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
-	upstreamResp := &http.Response{StatusCode: http.StatusOK}
+	wrapBody(req)
+	upstreamResp := &http.Response{StatusCode: http.StatusOK, Body: NewBufferedBody(http.NoBody, 0)}
 
 	var traces []TransformTrace
 	resp, err := p.ProcessResponse(context.Background(), &TransformContext{}, req, upstreamResp, &traces)
@@ -144,7 +155,8 @@ func TestPipeline_ResponseContinuePassesThrough(t *testing.T) {
 	p := NewPipeline([]Transformer{t1}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
-	upstreamResp := &http.Response{StatusCode: http.StatusOK}
+	wrapBody(req)
+	upstreamResp := &http.Response{StatusCode: http.StatusOK, Body: NewBufferedBody(http.NoBody, 0)}
 
 	var traces []TransformTrace
 	resp, err := p.ProcessResponse(context.Background(), &TransformContext{}, req, upstreamResp, &traces)
@@ -157,12 +169,13 @@ func TestPipeline_EmptyPipeline(t *testing.T) {
 	p := NewPipeline(nil, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	resp, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
 	require.Nil(t, resp)
 
-	upstreamResp := &http.Response{StatusCode: http.StatusOK}
+	upstreamResp := &http.Response{StatusCode: http.StatusOK, Body: NewBufferedBody(http.NoBody, 0)}
 	resp, err = p.ProcessResponse(context.Background(), &TransformContext{}, req, upstreamResp, &traces)
 	require.NoError(t, err)
 	require.Same(t, upstreamResp, resp)
@@ -185,6 +198,7 @@ func TestPipeline_RequestRejectStopsAtSecond(t *testing.T) {
 	p := NewPipeline([]Transformer{t1, t2, t3}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	resp, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
@@ -202,6 +216,7 @@ func TestPipeline_TraceCapturesTiming(t *testing.T) {
 	p := NewPipeline([]Transformer{t1}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	_, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)
@@ -217,6 +232,7 @@ func TestPipeline_AnnotationsInTrace(t *testing.T) {
 	p := NewPipeline([]Transformer{annotator}, BodyLimits{}, testLogger())
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	wrapBody(req)
 	var traces []TransformTrace
 	_, err := p.ProcessRequest(context.Background(), &TransformContext{}, req, &traces)
 	require.NoError(t, err)

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -272,7 +272,6 @@ func (s *Secrets) swapBody(req *http.Request, sec *resolvedSecret) string {
 	}
 
 	replaced := bytes.ReplaceAll(data, []byte(sec.proxyValue), []byte(sec.realValue))
-	req.Body = transform.NewBufferedBody(replaced)
-	req.ContentLength = int64(len(replaced))
+	req.Body = transform.NewBufferedBodyFromBytes(replaced)
 	return "body"
 }

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -88,7 +88,7 @@ func TestSecrets_BodySwap(t *testing.T) {
 	}})
 
 	body := `{"api_key": "proxy-openai-abc123", "model": "gpt-4"}`
-	rb := transform.NewReplayableBody(io.NopCloser(strings.NewReader(body)), 1<<20)
+	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
 
 	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
 	req.Host = "api.openai.com"
@@ -273,7 +273,7 @@ func TestSecrets_BodyTooLarge(t *testing.T) {
 
 	// Create a body larger than the max (1 MiB)
 	bigBody := strings.Repeat("x", (1<<20)+100)
-	rb := transform.NewReplayableBody(io.NopCloser(strings.NewReader(bigBody)), 1<<20)
+	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(bigBody)), 1<<20)
 
 	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
 	req.Host = "api.openai.com"
@@ -283,7 +283,7 @@ func TestSecrets_BodyTooLarge(t *testing.T) {
 	doTransform(t, s, req)
 
 	// Body should be unchanged (not buffered, so reads from original)
-	// The ReplayableBody couldn't buffer, so reading it gives nothing useful
+	// The BufferedBody couldn't buffer, so reading it gives nothing useful
 	// since the original reader was partially consumed by the Buffer attempt.
 	// The key assertion is that the transform didn't error or reject.
 }


### PR DESCRIPTION
Unifies `ReplayableBody` and `BufferedBody` into a single `BufferedBody` type with lazy, all-or-nothing buffering. When a transform reads the body, the entire stream is eagerly consumed into memory on the first `Read()`. When no transform touches the body, `StreamingReader()` returns the original reader directly for zero-copy passthrough. This fixes Docker pulls breaking because we were unconditionally stripping the `Content-Length` header — now it's only updated when a transform actually buffered/replaced the body.