### PR TITLE
ci: add egress control to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: ironsh/iron-proxy-action@v0.1.0
         with:
           egress-rules: egress-rules.yaml
+          disable-docker: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ironsh/iron-proxy-action@v0.1.0
+        with:
+          egress-rules: egress-rules.yaml
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
@@ -45,3 +49,6 @@ jobs:
             --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ironsh/iron-proxy-action/summary@v0.1.0
+        if: always()


### PR DESCRIPTION
Adds iron-proxy-action egress control to the release workflow, matching the setup already in CI. The Content-Length fix in #15 should resolve the issues that previously prevented this from working.