### PR TITLE
feat: add generate-ca subcommand

### DIFF
--- a/cmd/iron-proxy/generate_ca.go
+++ b/cmd/iron-proxy/generate_ca.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ironsh/iron-proxy/internal/cagen"
+)
+
+func runGenerateCA(args []string) {
+	fs := flag.NewFlagSet("generate-ca", flag.ExitOnError)
+	outdir := fs.String("outdir", ".", "directory to write ca.crt and ca.key")
+	name := fs.String("name", "iron-proxy CA", "common name of the CA")
+	expiryHours := fs.Int("expiry-hours", 8760, "number of hours the CA is valid for")
+	algStr := fs.String("alg", "rsa4096", "key algorithm: rsa4096 or ed25519")
+	fs.Parse(args)
+
+	alg, err := cagen.ParseAlgorithm(*algStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	result, err := cagen.Generate(cagen.Options{
+		Name:        *name,
+		ExpiryHours: *expiryHours,
+		Algorithm:   alg,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	certPath, keyPath, err := cagen.WriteFiles(*outdir, result)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s\n", certPath)
+	fmt.Printf("wrote %s\n", keyPath)
+}

--- a/cmd/iron-proxy/generate_ca.go
+++ b/cmd/iron-proxy/generate_ca.go
@@ -14,7 +14,10 @@ func runGenerateCA(args []string) {
 	name := fs.String("name", "iron-proxy CA", "common name of the CA")
 	expiryHours := fs.Int("expiry-hours", 8760, "number of hours the CA is valid for")
 	algStr := fs.String("alg", "rsa4096", "key algorithm: rsa4096 or ed25519")
-	fs.Parse(args)
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
 
 	alg, err := cagen.ParseAlgorithm(*algStr)
 	if err != nil {

--- a/cmd/iron-proxy/generate_ca_test.go
+++ b/cmd/iron-proxy/generate_ca_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGenerateCA(t *testing.T) {
+	dir := t.TempDir()
+	runGenerateCA([]string{"-outdir", dir, "-alg", "ed25519", "-name", "Test CA", "-expiry-hours", "24"})
+
+	_, err := os.Stat(filepath.Join(dir, "ca.crt"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dir, "ca.key"))
+	require.NoError(t, err)
+}

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -25,6 +25,14 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "generate-ca":
+			runGenerateCA(os.Args[2:])
+			return
+		}
+	}
+
 	configPath := flag.String("config", "", "path to iron-proxy YAML config file")
 	flag.Parse()
 

--- a/internal/cagen/cagen.go
+++ b/internal/cagen/cagen.go
@@ -1,0 +1,137 @@
+// Package cagen generates ephemeral CA certificates and private keys.
+package cagen
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Algorithm is the key algorithm to use for the CA.
+type Algorithm string
+
+const (
+	RSA4096 Algorithm = "rsa4096"
+	Ed25519 Algorithm = "ed25519"
+)
+
+// ParseAlgorithm parses a string into an Algorithm.
+func ParseAlgorithm(s string) (Algorithm, error) {
+	switch Algorithm(s) {
+	case RSA4096:
+		return RSA4096, nil
+	case Ed25519:
+		return Ed25519, nil
+	default:
+		return "", fmt.Errorf("unsupported algorithm %q (use rsa4096 or ed25519)", s)
+	}
+}
+
+// Options configures CA generation.
+type Options struct {
+	Name        string
+	ExpiryHours int
+	Algorithm   Algorithm
+}
+
+// Result holds the generated CA certificate and key in PEM form.
+type Result struct {
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// Generate creates a new CA certificate and private key.
+func Generate(opts Options) (*Result, error) {
+	signer, err := generateKey(opts.Algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("generating key: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("generating serial: %w", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: opts.Name},
+		NotBefore:             now.Add(-1 * time.Minute),
+		NotAfter:              now.Add(time.Duration(opts.ExpiryHours) * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, signer.Public(), signer)
+	if err != nil {
+		return nil, fmt.Errorf("creating certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(signer)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling private key: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	return &Result{CertPEM: certPEM, KeyPEM: keyPEM}, nil
+}
+
+// WriteFiles writes the CA certificate and key to outdir/ca.crt and
+// outdir/ca.key. It creates outdir if needed and refuses to overwrite
+// existing files.
+func WriteFiles(outdir string, result *Result) (certPath, keyPath string, err error) {
+	if err := os.MkdirAll(outdir, 0o755); err != nil {
+		return "", "", fmt.Errorf("creating output directory: %w", err)
+	}
+
+	certPath = filepath.Join(outdir, "ca.crt")
+	if err := writeExclusive(certPath, result.CertPEM, 0o644); err != nil {
+		return "", "", err
+	}
+
+	keyPath = filepath.Join(outdir, "ca.key")
+	if err := writeExclusive(keyPath, result.KeyPEM, 0o600); err != nil {
+		return "", "", err
+	}
+
+	return certPath, keyPath, nil
+}
+
+func generateKey(alg Algorithm) (crypto.Signer, error) {
+	switch alg {
+	case RSA4096:
+		return rsa.GenerateKey(rand.Reader, 4096)
+	case Ed25519:
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		return priv, err
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q", alg)
+	}
+}
+
+func writeExclusive(path string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", path, err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cagen/cagen_test.go
+++ b/internal/cagen/cagen_test.go
@@ -1,0 +1,134 @@
+package cagen
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_RSA(t *testing.T) {
+	result, err := Generate(Options{
+		Name:        "Test CA",
+		ExpiryHours: 24,
+		Algorithm:   RSA4096,
+	})
+	require.NoError(t, err)
+
+	cert := parseCert(t, result.CertPEM)
+	assert.True(t, cert.IsCA)
+	assert.Equal(t, "Test CA", cert.Subject.CommonName)
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageCertSign)
+	assert.NotZero(t, cert.KeyUsage&x509.KeyUsageCRLSign)
+	assert.Equal(t, x509.RSA, cert.PublicKeyAlgorithm)
+	assert.WithinDuration(t, time.Now().Add(24*time.Hour), cert.NotAfter, 2*time.Minute)
+
+	assertValidKey(t, result.KeyPEM)
+}
+
+func TestGenerate_Ed25519(t *testing.T) {
+	result, err := Generate(Options{
+		Name:        "iron-proxy CA",
+		ExpiryHours: 8760,
+		Algorithm:   Ed25519,
+	})
+	require.NoError(t, err)
+
+	cert := parseCert(t, result.CertPEM)
+	assert.True(t, cert.IsCA)
+	assert.Equal(t, "iron-proxy CA", cert.Subject.CommonName)
+	assert.Equal(t, x509.Ed25519, cert.PublicKeyAlgorithm)
+
+	assertValidKey(t, result.KeyPEM)
+}
+
+func TestParseAlgorithm(t *testing.T) {
+	alg, err := ParseAlgorithm("rsa4096")
+	require.NoError(t, err)
+	assert.Equal(t, RSA4096, alg)
+
+	alg, err = ParseAlgorithm("ed25519")
+	require.NoError(t, err)
+	assert.Equal(t, Ed25519, alg)
+
+	_, err = ParseAlgorithm("invalid")
+	assert.Error(t, err)
+}
+
+func TestWriteFiles(t *testing.T) {
+	result, err := Generate(Options{
+		Name:        "Test CA",
+		ExpiryHours: 1,
+		Algorithm:   Ed25519,
+	})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath, keyPath, err := WriteFiles(dir, result)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "ca.crt"), certPath)
+	assert.Equal(t, filepath.Join(dir, "ca.key"), keyPath)
+
+	certData, err := os.ReadFile(certPath)
+	require.NoError(t, err)
+	assert.Equal(t, result.CertPEM, certData)
+
+	keyData, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, result.KeyPEM, keyData)
+
+	info, err := os.Stat(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteFiles_RefusesOverwrite(t *testing.T) {
+	result, err := Generate(Options{
+		Name:        "Test CA",
+		ExpiryHours: 1,
+		Algorithm:   Ed25519,
+	})
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.crt"), []byte("existing"), 0o644))
+
+	_, _, err = WriteFiles(dir, result)
+	assert.Error(t, err)
+}
+
+func TestWriteFiles_CreatesOutdir(t *testing.T) {
+	result, err := Generate(Options{
+		Name:        "Test CA",
+		ExpiryHours: 1,
+		Algorithm:   Ed25519,
+	})
+	require.NoError(t, err)
+
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	_, _, err = WriteFiles(dir, result)
+	require.NoError(t, err)
+}
+
+func parseCert(t *testing.T, data []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}
+
+func assertValidKey(t *testing.T, data []byte) {
+	t.Helper()
+	block, _ := pem.Decode(data)
+	require.NotNil(t, block)
+	assert.Equal(t, "PRIVATE KEY", block.Type)
+	_, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds a `generate-ca` subcommand that creates an ephemeral CA certificate and private key for use with the proxy. The generation logic lives in `internal/cagen` for testability, and the CLI layer is a thin wrapper that parses flags and writes to disk. Supports RSA 4096 and Ed25519, configurable expiry and CA name. Uses `O_EXCL` to prevent silently overwriting existing CA files.