### PR TITLE
ci: temporarily disable egress control in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ironsh/iron-proxy-action@v0.1.0
-        with:
-          egress-rules: egress-rules.yaml
-          disable-docker: false
+      # TODO(mslipper): re-enable egress control after debugging
+      # - uses: ironsh/iron-proxy-action@v0.1.0
+      #   with:
+      #     egress-rules: egress-rules.yaml
+      #     disable-docker: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -51,5 +52,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.0
-        if: always()
+      # - uses: ironsh/iron-proxy-action/summary@v0.1.0
+      #   if: always()


### PR DESCRIPTION
Disables the iron-proxy-action egress control and summary steps in the release workflow while debugging an issue. Will re-enable once the issue is resolved.