### PR TITLE
fix: use dynamic port for metrics in gRPC integration test

### DIFF
--- a/internal/proxy/integration_grpc_test.go
+++ b/internal/proxy/integration_grpc_test.go
@@ -119,6 +119,9 @@ transforms:
       send_request_body: true
       send_response_body: true
 
+metrics:
+  listen: "127.0.0.1:0"
+
 log:
   level: error
 `, caCertPath, caKeyPath, grpcAddr1, grpcAddr2)


### PR DESCRIPTION
The /healthz feature (a1dcfe2) added a metrics server defaulting to `:9090`. The gRPC integration test starts the full application but never set a metrics listen address, so parallel test runs collide on that port. This sets it to `127.0.0.1:0` for dynamic allocation, matching how the DNS listener is already configured in the same test.