### PR TITLE
feat: add annotate transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,33 @@ annotated with `"action": "warn"` in the transform trace. This is useful for
 rolling out new allowlist rules or auditing existing traffic before switching
 to enforcement.
 
+### Annotate
+
+Captures HTTP request headers into audit log annotations based on
+host/method/path rules. This is useful for enriching audit logs with
+request-specific context like request IDs or API keys without modifying the
+proxy core.
+
+Each annotation group specifies rules to match and headers to capture. When a
+request matches any rule in a group, the specified header values are written as
+`header:<Name>` entries in the transform trace annotations. Requests that don't
+match are passed through unchanged. This transform never rejects requests.
+
+```yaml
+transforms:
+  - name: annotate
+    config:
+      annotations:
+        - rules:
+            - host: "api.openai.com"
+              methods: ["POST"]
+              paths: ["/v1/*"]
+          headers: ["x-request-id", "authorization"]
+        - rules:
+            - host: "*.anthropic.com"
+          headers: ["x-api-key"]
+```
+
 ### Secrets
 
 The sandbox never holds real credentials. Instead:

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -22,6 +22,7 @@ import (
 
 	// Register built-in transforms.
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
+	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )

--- a/internal/transform/annotate/annotate.go
+++ b/internal/transform/annotate/annotate.go
@@ -1,0 +1,96 @@
+// Package annotate implements a transform that captures HTTP request headers
+// into audit log annotations based on configurable host/method/path rules.
+package annotate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func init() {
+	transform.Register("annotate", factory)
+}
+
+type annotateConfig struct {
+	Annotations []annotationGroup `yaml:"annotations"`
+}
+
+type annotationGroup struct {
+	Rules   []hostmatch.RuleConfig `yaml:"rules"`
+	Headers []string               `yaml:"headers"`
+}
+
+type compiledGroup struct {
+	rules   []hostmatch.Rule
+	headers []string // canonical form
+}
+
+// Annotate captures request header values into audit annotations when
+// requests match configured rules.
+type Annotate struct {
+	groups []compiledGroup
+}
+
+func factory(cfg yaml.Node) (transform.Transformer, error) {
+	var c annotateConfig
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing annotate config: %w", err)
+	}
+	return newFromConfig(c, hostmatch.NullResolver{})
+}
+
+func newFromConfig(cfg annotateConfig, resolver hostmatch.Resolver) (*Annotate, error) {
+	if len(cfg.Annotations) == 0 {
+		return nil, fmt.Errorf("annotate: at least one annotation group is required")
+	}
+
+	groups := make([]compiledGroup, 0, len(cfg.Annotations))
+	for i, ag := range cfg.Annotations {
+		if len(ag.Rules) == 0 {
+			return nil, fmt.Errorf("annotate: annotations[%d]: at least one rule is required", i)
+		}
+		if len(ag.Headers) == 0 {
+			return nil, fmt.Errorf("annotate: annotations[%d]: at least one header is required", i)
+		}
+
+		compiled, err := hostmatch.CompileRules(ag.Rules, resolver, fmt.Sprintf("annotate annotations[%d]", i))
+		if err != nil {
+			return nil, err
+		}
+
+		headers := make([]string, len(ag.Headers))
+		for j, h := range ag.Headers {
+			headers[j] = http.CanonicalHeaderKey(h)
+		}
+
+		groups = append(groups, compiledGroup{rules: compiled, headers: headers})
+	}
+
+	return &Annotate{groups: groups}, nil
+}
+
+func (a *Annotate) Name() string { return "annotate" }
+
+func (a *Annotate) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	for _, g := range a.groups {
+		if !hostmatch.MatchAnyRule(ctx, g.rules, req) {
+			continue
+		}
+		for _, h := range g.headers {
+			if v := req.Header.Get(h); v != "" {
+				tctx.Annotate("header:"+h, v)
+			}
+		}
+	}
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (a *Annotate) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}

--- a/internal/transform/annotate/annotate_test.go
+++ b/internal/transform/annotate/annotate_test.go
@@ -1,0 +1,249 @@
+package annotate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func makeAnnotate(t *testing.T, groups []annotationGroup) *Annotate {
+	t.Helper()
+	a, err := newFromConfig(annotateConfig{Annotations: groups}, hostmatch.NullResolver{})
+	require.NoError(t, err)
+	return a
+}
+
+func annotate(t *testing.T, a *Annotate, method, host, path string, headers map[string]string) (map[string]any, *transform.TransformResult) {
+	t.Helper()
+	req := httptest.NewRequest(method, "http://"+host+path, nil)
+	req.Host = host
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	tctx := &transform.TransformContext{}
+	res, err := a.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	return tctx.DrainAnnotations(), res
+}
+
+func TestAnnotate_MatchingRuleCapturesHeaders(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, res := annotate(t, a, "GET", "api.openai.com", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
+}
+
+func TestAnnotate_NoMatchNoAnnotation(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "evil.com", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Nil(t, ann)
+}
+
+func TestAnnotate_MissingHeaderSkipped(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id", "x-missing"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "api.openai.com", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
+	require.Nil(t, ann["header:X-Missing"])
+}
+
+func TestAnnotate_MultipleGroups(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{
+		{
+			Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+			Headers: []string{"x-openai-id"},
+		},
+		{
+			Rules:   []hostmatch.RuleConfig{{Host: "api.anthropic.com"}},
+			Headers: []string{"x-anthropic-id"},
+		},
+	})
+
+	ann, _ := annotate(t, a, "GET", "api.anthropic.com", "/", map[string]string{
+		"X-Openai-Id":    "oai-123",
+		"X-Anthropic-Id": "ant-456",
+	})
+	require.Nil(t, ann["header:X-Openai-Id"])
+	require.Equal(t, "ant-456", ann["header:X-Anthropic-Id"])
+}
+
+func TestAnnotate_HeaderNormalization(t *testing.T) {
+	// Config uses lowercase, lookup should still work via CanonicalHeaderKey.
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "example.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "example.com", "/", map[string]string{
+		"X-Request-Id": "req-abc",
+	})
+	require.Equal(t, "req-abc", ann["header:X-Request-Id"])
+}
+
+func TestAnnotate_WildcardHost(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "*.anthropic.com"}},
+		Headers: []string{"x-api-key"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "api.anthropic.com", "/", map[string]string{
+		"X-Api-Key": "key-123",
+	})
+	require.Equal(t, "key-123", ann["header:X-Api-Key"])
+
+	ann2, _ := annotate(t, a, "GET", "other.com", "/", map[string]string{
+		"X-Api-Key": "key-123",
+	})
+	require.Nil(t, ann2)
+}
+
+func TestAnnotate_MethodFiltering(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com", Methods: []string{"POST"}}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, _ := annotate(t, a, "POST", "api.openai.com", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
+
+	ann2, _ := annotate(t, a, "GET", "api.openai.com", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Nil(t, ann2)
+}
+
+func TestAnnotate_PathFiltering(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com", Paths: []string{"/v1/*"}}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "api.openai.com", "/v1/chat", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
+
+	ann2, _ := annotate(t, a, "GET", "api.openai.com", "/v2/chat", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Nil(t, ann2)
+}
+
+func TestAnnotate_AlwaysContinues(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	// Matching request
+	_, res := annotate(t, a, "GET", "api.openai.com", "/", nil)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	// Non-matching request
+	_, res2 := annotate(t, a, "GET", "evil.com", "/", nil)
+	require.Equal(t, transform.ActionContinue, res2.Action)
+}
+
+func TestAnnotate_ResponseIsNoop(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	resp := &http.Response{StatusCode: http.StatusOK}
+	res, err := a.TransformResponse(context.Background(), &transform.TransformContext{}, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+}
+
+func TestAnnotate_Name(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "example.com"}},
+		Headers: []string{"x-foo"},
+	}})
+	require.Equal(t, "annotate", a.Name())
+}
+
+func TestAnnotate_HostWithPort(t *testing.T) {
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Headers: []string{"x-request-id"},
+	}})
+
+	ann, _ := annotate(t, a, "GET", "api.openai.com:443", "/", map[string]string{
+		"X-Request-Id": "req-123",
+	})
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
+}
+
+func TestAnnotate_MultipleHeaderValues(t *testing.T) {
+	// Header.Get returns the first value for multi-valued headers.
+	a := makeAnnotate(t, []annotationGroup{{
+		Rules:   []hostmatch.RuleConfig{{Host: "example.com"}},
+		Headers: []string{"x-multi"},
+	}})
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Host = "example.com"
+	req.Header.Add("X-Multi", "first")
+	req.Header.Add("X-Multi", "second")
+	tctx := &transform.TransformContext{}
+	_, err := a.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	ann := tctx.DrainAnnotations()
+	require.Equal(t, "first", ann["header:X-Multi"])
+}
+
+// --- Validation tests ---
+
+func TestAnnotate_EmptyAnnotationsValidation(t *testing.T) {
+	_, err := newFromConfig(annotateConfig{}, hostmatch.NullResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one annotation group is required")
+}
+
+func TestAnnotate_EmptyRulesValidation(t *testing.T) {
+	_, err := newFromConfig(annotateConfig{
+		Annotations: []annotationGroup{{
+			Headers: []string{"x-foo"},
+		}},
+	}, hostmatch.NullResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one rule is required")
+}
+
+func TestAnnotate_EmptyHeadersValidation(t *testing.T) {
+	_, err := newFromConfig(annotateConfig{
+		Annotations: []annotationGroup{{
+			Rules: []hostmatch.RuleConfig{{Host: "example.com"}},
+		}},
+	}, hostmatch.NullResolver{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one header is required")
+}


### PR DESCRIPTION
Adds a new `annotate` transformer that captures HTTP request header values into audit log annotations based on configurable host/method/path rules. Each annotation group specifies rules to match and headers to capture, with values written as `header:<Name>` annotations.