### PR TITLE
Remove API key references from annotate docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,13 +276,16 @@ to enforcement.
 
 Captures HTTP request headers into audit log annotations based on
 host/method/path rules. This is useful for enriching audit logs with
-request-specific context like request IDs or API keys without modifying the
-proxy core.
+request-specific context like request IDs without modifying the proxy core.
 
 Each annotation group specifies rules to match and headers to capture. When a
 request matches any rule in a group, the specified header values are written as
 `header:<Name>` entries in the transform trace annotations. Requests that don't
 match are passed through unchanged. This transform never rejects requests.
+
+> **Warning:** Header values are emitted in plain text in the audit log. Only
+> log headers that are safe to expose, such as request IDs or headers containing
+> proxy secret tokens. Do not log headers that contain raw secrets.
 
 ```yaml
 transforms:
@@ -293,10 +296,10 @@ transforms:
             - host: "api.openai.com"
               methods: ["POST"]
               paths: ["/v1/*"]
-          headers: ["x-request-id", "authorization"]
+          headers: ["x-request-id"]
         - rules:
             - host: "*.anthropic.com"
-          headers: ["x-api-key"]
+          headers: ["x-request-id"]
 ```
 
 ### Secrets

--- a/internal/transform/annotate/annotate_test.go
+++ b/internal/transform/annotate/annotate_test.go
@@ -106,16 +106,16 @@ func TestAnnotate_HeaderNormalization(t *testing.T) {
 func TestAnnotate_WildcardHost(t *testing.T) {
 	a := makeAnnotate(t, []annotationGroup{{
 		Rules:   []hostmatch.RuleConfig{{Host: "*.anthropic.com"}},
-		Headers: []string{"x-api-key"},
+		Headers: []string{"x-request-id"},
 	}})
 
 	ann, _ := annotate(t, a, "GET", "api.anthropic.com", "/", map[string]string{
-		"X-Api-Key": "key-123",
+		"X-Request-Id": "req-123",
 	})
-	require.Equal(t, "key-123", ann["header:X-Api-Key"])
+	require.Equal(t, "req-123", ann["header:X-Request-Id"])
 
 	ann2, _ := annotate(t, a, "GET", "other.com", "/", map[string]string{
-		"X-Api-Key": "key-123",
+		"X-Request-Id": "req-123",
 	})
 	require.Nil(t, ann2)
 }


### PR DESCRIPTION
Replaces `x-api-key` and `authorization` header examples with `x-request-id` in the annotate transform tests and README. Adds a warning that header values are emitted in plain text, so users should only log safe headers or those containing proxy secret tokens.