### PR TITLE
feat: add `require` flag to secrets transform to reject unswapped requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ transforms:
           proxy_value: "proxy-token-123" # Token the sandbox sends
           match_headers: ["Authorization"]
           match_body: false
+          require: true # Reject requests without the proxy token
           hosts:
             - name: "api.openai.com"
 
@@ -315,6 +316,9 @@ values before forwarding upstream. You control where it looks:
 
 - **`match_headers`:** list of header names to scan. Empty list = all headers.
 - **`match_body`:** scan the request body (buffered up to `max_request_body_bytes`).
+- **`require`:** when `true`, requests to a matching host that do **not** contain
+  the proxy token are rejected with 403. This prevents a compromised workload
+  from bypassing the secret-swap mechanism with alternative credentials. Default: `false`.
 - **`hosts`:** restrict swapping to specific domains or CIDRs.
 
 Query parameters are always scanned.

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -34,6 +34,7 @@ type secretEntry struct {
 	ProxyValue   string      `yaml:"proxy_value"`
 	MatchHeaders []string    `yaml:"match_headers"`
 	MatchBody    bool        `yaml:"match_body"`
+	Require      bool        `yaml:"require"`
 	Hosts        []hostMatch `yaml:"hosts"`
 }
 
@@ -49,6 +50,7 @@ type resolvedSecret struct {
 	realValue    string
 	matchHeaders []string // empty = all headers
 	matchBody    bool
+	require      bool
 	matcher      *hostmatch.Matcher
 }
 
@@ -112,6 +114,7 @@ func newFromConfig(cfg secretsConfig, getenv func(string) string) (*Secrets, err
 			realValue:    realValue,
 			matchHeaders: entry.MatchHeaders,
 			matchBody:    entry.MatchBody,
+			require:      entry.Require,
 			matcher:      matcher,
 		})
 	}
@@ -147,6 +150,9 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 		if len(locations) > 0 {
 			swapped = append(swapped, swapRecord{Secret: sec.name, Locations: locations})
+		} else if sec.require {
+			tctx.Annotate("rejected", sec.name)
+			return &transform.TransformResult{Action: transform.ActionReject}, nil
 		}
 	}
 

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -428,6 +428,119 @@ func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
 	require.Equal(t, "Basic "+creds, req.Header.Get("X-Custom"))
 }
 
+func TestSecrets_RequireRejectsWithoutProxyToken(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Require:      true,
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Request to matching host but with a different credential — should be rejected.
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer sk-some-other-key")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestSecrets_RequireContinuesWithProxyToken(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Require:      true,
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_RequireDefaultFalseAllowsThrough(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		// Require defaults to false
+		Hosts: []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Request without proxy token — should still pass (require is false).
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer sk-some-other-key")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-some-other-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_RequireNonMatchingHostAllowsThrough(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Require:      true,
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Request to a different host — host doesn't match, so require doesn't apply.
+	req := httptest.NewRequest("GET", "http://other.com/v1/chat", nil)
+	req.Host = "other.com"
+	req.Header.Set("Authorization", "Bearer sk-some-other-key")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-some-other-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:          "OPENAI_API_KEY",
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Require:      true,
+		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	// Request to matching host with no Authorization header at all.
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestSecrets_RequireWithBodySwap(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Var:        "OPENAI_API_KEY",
+		ProxyValue: "proxy-openai-abc123",
+		MatchBody:  true,
+		Require:    true,
+		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+	}})
+
+	body := `{"api_key": "proxy-openai-abc123"}`
+	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
+
+	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Body = rb
+
+	doTransform(t, s, req)
+
+	result, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(result), "sk-real-openai-key")
+}
+
 func TestSecrets_Name(t *testing.T) {
 	s := makeSecrets(t, nil)
 	require.Equal(t, "secrets", s.Name())

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -59,6 +59,21 @@ transforms:
         - cidr: "172.16.0.0/12"
           methods: ["GET"]
 
+  - name: secrets
+    config:
+      source: env
+      secrets:
+        - var: OPENAI_API_KEY
+          proxy_value: "proxy-token-123"
+          match_headers: ["Authorization"]
+          match_body: false
+          # When true, requests to a matching host that do not contain the proxy
+          # token are rejected (403). Prevents workloads from bypassing the
+          # secret-swap mechanism with alternative credentials.
+          require: true
+          hosts:
+            - name: "api.openai.com"
+
   # gRPC transforms: each entry delegates to one external TransformService server.
   # Use multiple entries for multiple servers; they run in pipeline order.
   - name: grpc


### PR DESCRIPTION
## Why

Great idea, thanks for releasing.

One potential attack vector is a hostname + a missed secret-swap.

For example, the agent in the sandbox could be fed a real, working credential instead of using the proxy value. This could permit exfiltration if the host is allow listed.

Hoping this PR fits the intended semantics and behavior of your project.

## What

When `require: true` is set on a secret entry and a request matches the configured host but the proxy token is not found in any scanned location (headers, query, body), the transform returns ActionReject (403) instead of ActionContinue. This prevents sandboxed workloads from bypassing the secret-swap mechanism with alternative credentials.

Default is false, preserving existing behavior.