### PR TITLE
feat: add CONNECT/SOCKS5 tunnel listener

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	// Initialize proxy
-	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, certCache, pipeline, resolver, logger)
+	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, cfg.Proxy.TunnelListen, certCache, pipeline, resolver, logger)
 
 	// Initialize metrics server
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)
@@ -139,12 +139,16 @@ func main() {
 	go func() { errc <- fmt.Errorf("proxy: %w", p.ListenAndServe()) }()
 	go func() { errc <- fmt.Errorf("metrics: %w", metricsServer.ListenAndServe()) }()
 
-	logger.Info("iron-proxy starting",
+	startAttrs := []any{
 		slog.String("dns_listen", cfg.DNS.Listen),
 		slog.String("http_listen", cfg.Proxy.HTTPListen),
 		slog.String("https_listen", cfg.Proxy.HTTPSListen),
 		slog.String("metrics_listen", cfg.Metrics.Listen),
-	)
+	}
+	if cfg.Proxy.TunnelListen != "" {
+		startAttrs = append(startAttrs, slog.String("tunnel_listen", cfg.Proxy.TunnelListen))
+	}
+	logger.Info("iron-proxy starting", startAttrs...)
 	if !pipeline.Empty() {
 		logger.Info("transform pipeline", slog.String("transforms", pipeline.Names()))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type DNSRecord struct {
 type Proxy struct {
 	HTTPListen           string `yaml:"http_listen"`
 	HTTPSListen          string `yaml:"https_listen"`
+	TunnelListen         string `yaml:"tunnel_listen"`
 	MaxRequestBodyBytes  int64  `yaml:"max_request_body_bytes"`
 	MaxResponseBodyBytes int64  `yaml:"max_response_body_bytes"`
 }

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -80,7 +81,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 
 	// 4. Start proxy with HTTPS
-	p := New("127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "", certCache, pipeline, nil, logger)
 
 	// Start HTTP listener
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -149,6 +150,399 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	defer resp2.Body.Close()
 
 	require.Equal(t, http.StatusForbidden, resp2.StatusCode)
+}
+
+// TestIntegration_CONNECT exercises the full CONNECT tunnel flow:
+// client CONNECT -> tunnel handshake -> TLS MITM -> allowlist -> upstream -> response.
+func TestIntegration_CONNECT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// 1. Start upstream HTTPS server
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream", "true")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "connect integration response")
+	}))
+	defer upstream.Close()
+	upstreamAddr := upstream.Listener.Addr().String()
+
+	const allowedHost = "allowed.example.com"
+	const deniedHost = "denied.example.com"
+
+	// 2. Generate CA
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "CONNECT Integration Test CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+
+	certCache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+
+	// 3. Build allowlist pipeline
+	al, err := allowlist.New([]string{allowedHost}, nil, &staticResolver{})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	// 4. Start proxy with tunnel listener
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
+
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	// Override transport to route all dials to the real upstream
+	p.transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
+		},
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	// 5. Test: allowed CONNECT -> TLS MITM -> success
+	t.Run("allowed", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		// Send CONNECT
+		fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", allowedHost, allowedHost)
+
+		br := bufio.NewReader(conn)
+		resp, err := http.ReadResponse(br, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// TLS handshake over the tunnel
+		tlsConn := tls.Client(conn, &tls.Config{
+			RootCAs:    caPool,
+			ServerName: allowedHost,
+		})
+		defer tlsConn.Close()
+		require.NoError(t, tlsConn.Handshake())
+
+		// HTTP request over the TLS tunnel
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/test", allowedHost), nil)
+		require.NoError(t, err)
+		require.NoError(t, req.Write(tlsConn))
+
+		resp2, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+		require.NoError(t, err)
+		defer resp2.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp2.StatusCode)
+		require.Equal(t, "true", resp2.Header.Get("X-Upstream"))
+		body, err := io.ReadAll(resp2.Body)
+		require.NoError(t, err)
+		require.Equal(t, "connect integration response", string(body))
+	})
+
+	// 6. Test: denied CONNECT -> 403
+	t.Run("denied", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", deniedHost, deniedHost)
+
+		br := bufio.NewReader(conn)
+		resp, err := http.ReadResponse(br, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	// 7. Test: allowed CONNECT -> plain HTTP (non-TLS)
+	t.Run("allowed_plain_http", func(t *testing.T) {
+		// Start a plain HTTP upstream
+		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "plain http response")
+		}))
+		defer plainUpstream.Close()
+		plainAddr := plainUpstream.Listener.Addr().String()
+
+		// Override transport for this sub-test to route to the plain upstream
+		origTransport := p.transport
+		p.transport = &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, plainAddr)
+			},
+		}
+		defer func() { p.transport = origTransport }()
+
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		fmt.Fprintf(conn, "CONNECT %s:80 HTTP/1.1\r\nHost: %s:80\r\n\r\n", allowedHost, allowedHost)
+
+		br := bufio.NewReader(conn)
+		resp, err := http.ReadResponse(br, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Send plain HTTP through the tunnel
+		fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+
+		resp2, err := http.ReadResponse(br, nil)
+		require.NoError(t, err)
+		defer resp2.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp2.StatusCode)
+		body, err := io.ReadAll(resp2.Body)
+		require.NoError(t, err)
+		require.Equal(t, "plain http response", string(body))
+	})
+}
+
+// TestIntegration_SOCKS5 exercises the full SOCKS5 tunnel flow:
+// client SOCKS5 -> tunnel handshake -> TLS MITM -> allowlist -> upstream -> response.
+func TestIntegration_SOCKS5(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// 1. Start upstream HTTPS server
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream", "true")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "socks5 integration response")
+	}))
+	defer upstream.Close()
+	upstreamAddr := upstream.Listener.Addr().String()
+
+	const allowedHost = "allowed.example.com"
+	const deniedHost = "denied.example.com"
+
+	// 2. Generate CA
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		Subject:               pkix.Name{CommonName: "SOCKS5 Integration Test CA"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+
+	certCache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+
+	// 3. Build allowlist pipeline
+	al, err := allowlist.New([]string{allowedHost}, nil, &staticResolver{})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	// 4. Start proxy with tunnel listener
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
+
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	// Override transport to route all dials to the real upstream
+	p.transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
+		},
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	// Helper: perform SOCKS5 handshake with domain-name address type
+	socks5Connect := func(t *testing.T, conn net.Conn, host string, port uint16) {
+		t.Helper()
+
+		// Auth: offer no-auth
+		_, err := conn.Write([]byte{0x05, 0x01, 0x00})
+		require.NoError(t, err)
+
+		authResp := make([]byte, 2)
+		_, err = io.ReadFull(conn, authResp)
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x05, 0x00}, authResp)
+
+		// Connect request with domain name
+		req := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+		req = append(req, []byte(host)...)
+		portBuf := make([]byte, 2)
+		portBuf[0] = byte(port >> 8)
+		portBuf[1] = byte(port)
+		req = append(req, portBuf...)
+		_, err = conn.Write(req)
+		require.NoError(t, err)
+	}
+
+	readSocks5Reply := func(t *testing.T, conn net.Conn) byte {
+		t.Helper()
+		reply := make([]byte, 10) // IPv4 reply is always 10 bytes
+		_, err := io.ReadFull(conn, reply)
+		require.NoError(t, err)
+		require.Equal(t, byte(0x05), reply[0])
+		return reply[1] // status
+	}
+
+	// 5. Test: allowed SOCKS5 -> TLS MITM -> success
+	t.Run("allowed_tls", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		socks5Connect(t, conn, allowedHost, 443)
+		status := readSocks5Reply(t, conn)
+		require.Equal(t, byte(0x00), status, "expected SOCKS5 success")
+
+		// TLS handshake
+		tlsConn := tls.Client(conn, &tls.Config{
+			RootCAs:    caPool,
+			ServerName: allowedHost,
+		})
+		defer tlsConn.Close()
+		require.NoError(t, tlsConn.Handshake())
+
+		// HTTP request
+		req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/test", allowedHost), nil)
+		require.NoError(t, err)
+		require.NoError(t, req.Write(tlsConn))
+
+		resp, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "true", resp.Header.Get("X-Upstream"))
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "socks5 integration response", string(body))
+	})
+
+	// 6. Test: denied SOCKS5 -> connection not allowed
+	t.Run("denied", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		socks5Connect(t, conn, deniedHost, 443)
+		status := readSocks5Reply(t, conn)
+		require.Equal(t, byte(0x02), status, "expected SOCKS5 connection not allowed")
+	})
+
+	// 7. Test: allowed SOCKS5 -> plain HTTP
+	t.Run("allowed_plain_http", func(t *testing.T) {
+		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "socks5 plain http")
+		}))
+		defer plainUpstream.Close()
+		plainAddr := plainUpstream.Listener.Addr().String()
+
+		origTransport := p.transport
+		p.transport = &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, plainAddr)
+			},
+		}
+		defer func() { p.transport = origTransport }()
+
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		socks5Connect(t, conn, allowedHost, 80)
+		status := readSocks5Reply(t, conn)
+		require.Equal(t, byte(0x00), status, "expected SOCKS5 success")
+
+		// Send plain HTTP
+		fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, "socks5 plain http", string(body))
+	})
+
+	// 8. Test: non-HTTP/TLS protocol -> proxy closes the connection
+	t.Run("unsupported_protocol", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		socks5Connect(t, conn, allowedHost, 22)
+		status := readSocks5Reply(t, conn)
+		require.Equal(t, byte(0x00), status, "SOCKS5 handshake should succeed")
+
+		// Send something that is neither TLS (0x16) nor an HTTP method (A-Z).
+		// SSH banner starts with "SSH-", but let's send raw binary to be explicit.
+		_, err = conn.Write([]byte{0x00, 0x01, 0x02, 0x03})
+		require.NoError(t, err)
+
+		// The proxy should close the connection without forwarding anything.
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 1)
+		_, err = conn.Read(buf)
+		require.ErrorIs(t, err, io.EOF, "expected proxy to close the connection")
+	})
 }
 
 // staticResolver is a test resolver that returns preconfigured addresses.

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -165,7 +165,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Upstream", "true")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "connect integration response")
+		_, _ = fmt.Fprint(w, "connect integration response")
 	}))
 	defer upstream.Close()
 	upstreamAddr := upstream.Listener.Addr().String()
@@ -238,7 +238,8 @@ func TestIntegration_CONNECT(t *testing.T) {
 		defer conn.Close()
 
 		// Send CONNECT
-		fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", allowedHost, allowedHost)
+		_, err = fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", allowedHost, allowedHost)
+		require.NoError(t, err)
 
 		br := bufio.NewReader(conn)
 		resp, err := http.ReadResponse(br, nil)
@@ -250,7 +251,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 			RootCAs:    caPool,
 			ServerName: allowedHost,
 		})
-		defer tlsConn.Close()
+		defer func() { _ = tlsConn.Close() }()
 		require.NoError(t, tlsConn.Handshake())
 
 		// HTTP request over the TLS tunnel
@@ -275,7 +276,8 @@ func TestIntegration_CONNECT(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", deniedHost, deniedHost)
+		_, err = fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", deniedHost, deniedHost)
+		require.NoError(t, err)
 
 		br := bufio.NewReader(conn)
 		resp, err := http.ReadResponse(br, nil)
@@ -288,7 +290,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 		// Start a plain HTTP upstream
 		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "plain http response")
+			_, _ = fmt.Fprint(w, "plain http response")
 		}))
 		defer plainUpstream.Close()
 		plainAddr := plainUpstream.Listener.Addr().String()
@@ -306,7 +308,8 @@ func TestIntegration_CONNECT(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
-		fmt.Fprintf(conn, "CONNECT %s:80 HTTP/1.1\r\nHost: %s:80\r\n\r\n", allowedHost, allowedHost)
+		_, err = fmt.Fprintf(conn, "CONNECT %s:80 HTTP/1.1\r\nHost: %s:80\r\n\r\n", allowedHost, allowedHost)
+		require.NoError(t, err)
 
 		br := bufio.NewReader(conn)
 		resp, err := http.ReadResponse(br, nil)
@@ -314,7 +317,8 @@ func TestIntegration_CONNECT(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		// Send plain HTTP through the tunnel
-		fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+		_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+		require.NoError(t, err)
 
 		resp2, err := http.ReadResponse(br, nil)
 		require.NoError(t, err)
@@ -340,7 +344,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Upstream", "true")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "socks5 integration response")
+		_, _ = fmt.Fprint(w, "socks5 integration response")
 	}))
 	defer upstream.Close()
 	upstreamAddr := upstream.Listener.Addr().String()
@@ -454,7 +458,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 			RootCAs:    caPool,
 			ServerName: allowedHost,
 		})
-		defer tlsConn.Close()
+		defer func() { _ = tlsConn.Close() }()
 		require.NoError(t, tlsConn.Handshake())
 
 		// HTTP request
@@ -488,7 +492,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 	t.Run("allowed_plain_http", func(t *testing.T) {
 		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "socks5 plain http")
+			_, _ = fmt.Fprint(w, "socks5 plain http")
 		}))
 		defer plainUpstream.Close()
 		plainAddr := plainUpstream.Listener.Addr().String()
@@ -510,7 +514,8 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		require.Equal(t, byte(0x00), status, "expected SOCKS5 success")
 
 		// Send plain HTTP
-		fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+		_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", allowedHost)
+		require.NoError(t, err)
 
 		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
 		require.NoError(t, err)
@@ -538,7 +543,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		require.NoError(t, err)
 
 		// The proxy should close the connection without forwarding anything.
-		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
 		buf := make([]byte, 1)
 		_, err = conn.Read(buf)
 		require.ErrorIs(t, err, io.EOF, "expected proxy to close the connection")

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -3,16 +3,11 @@ package proxy
 import (
 	"bufio"
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"fmt"
 	"io"
 	"log/slog"
-	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +21,61 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
+
+// integrationCA bundles the test CA certificate, cert cache, and trust pool.
+type integrationCA struct {
+	certCache *certcache.Cache
+	caPool    *x509.CertPool
+}
+
+// newIntegrationCA generates a test CA and returns the cert cache and CA pool.
+func newIntegrationCA(t *testing.T) integrationCA {
+	t.Helper()
+
+	caCert, caKey := generateTestCA(t)
+	cache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	return integrationCA{certCache: cache, caPool: pool}
+}
+
+// startTunnelIntegrationProxy creates a proxy with an allowlist and tunnel
+// listener, returning the proxy, tunnel address, and CA pool.
+func startTunnelIntegrationProxy(t *testing.T, allowedHosts []string, logger *slog.Logger) (*Proxy, string, *x509.CertPool) {
+	t.Helper()
+
+	ca := newIntegrationCA(t)
+
+	al, err := allowlist.New(allowedHosts, nil, &staticResolver{})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", ca.certCache, pipeline, nil, logger)
+
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	return p, tunnelAddr, ca.caPool
+}
 
 // TestIntegration_DNSToProxyToUpstream is an end-to-end test that exercises:
 // DNS interception -> TLS MITM -> allowlist transform -> upstream -> response.
@@ -50,25 +100,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	const fakeHost = "test-upstream.example.com"
 
 	// 2. Generate CA and cert cache
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "Integration Test CA"},
-		NotBefore:             time.Now().Add(-1 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caCertDER)
-	require.NoError(t, err)
-
-	certCache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
-	require.NoError(t, err)
+	ca := newIntegrationCA(t)
 
 	// 3. Build transform pipeline with allowlist
 	al, err := allowlist.New(
@@ -81,7 +113,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 
 	// 4. Start proxy with HTTPS
-	p := New("127.0.0.1:0", "127.0.0.1:0", "", certCache, pipeline, nil, logger)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "", ca.certCache, pipeline, nil, logger)
 
 	// Start HTTP listener
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -113,13 +145,10 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	}
 
 	// 7. Test: allowed request through HTTPS proxy
-	caPool := x509.NewCertPool()
-	caPool.AddCert(caCert)
-
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:    caPool,
+				RootCAs:    ca.caPool,
 				ServerName: fakeHost,
 			},
 		},
@@ -173,52 +202,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 	const allowedHost = "allowed.example.com"
 	const deniedHost = "denied.example.com"
 
-	// 2. Generate CA
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(2),
-		Subject:               pkix.Name{CommonName: "CONNECT Integration Test CA"},
-		NotBefore:             time.Now().Add(-1 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caCertDER)
-	require.NoError(t, err)
-
-	certCache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
-	require.NoError(t, err)
-
-	// 3. Build allowlist pipeline
-	al, err := allowlist.New([]string{allowedHost}, nil, &staticResolver{})
-	require.NoError(t, err)
-	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
-
-	// 4. Start proxy with tunnel listener
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
-
-	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	tunnelAddr := tunnelLn.Addr().String()
-	p.tunnelListener = tunnelLn
-
-	go func() {
-		for {
-			conn, err := tunnelLn.Accept()
-			if err != nil {
-				return
-			}
-			go p.handleTunnel(conn)
-		}
-	}()
-	t.Cleanup(func() {
-		tunnelLn.Close()
-		close(p.tunnelDone)
-	})
+	p, tunnelAddr, caPool := startTunnelIntegrationProxy(t, []string{allowedHost}, logger)
 
 	// Override transport to route all dials to the real upstream
 	p.transport = &http.Transport{
@@ -228,10 +212,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 		},
 	}
 
-	caPool := x509.NewCertPool()
-	caPool.AddCert(caCert)
-
-	// 5. Test: allowed CONNECT -> TLS MITM -> success
+	// 2. Test: allowed CONNECT -> TLS MITM -> success
 	t.Run("allowed", func(t *testing.T) {
 		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
 		require.NoError(t, err)
@@ -270,7 +251,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 		require.Equal(t, "connect integration response", string(body))
 	})
 
-	// 6. Test: denied CONNECT -> 403
+	// 3. Test: denied CONNECT -> 403
 	t.Run("denied", func(t *testing.T) {
 		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
 		require.NoError(t, err)
@@ -285,7 +266,7 @@ func TestIntegration_CONNECT(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 
-	// 7. Test: allowed CONNECT -> plain HTTP (non-TLS)
+	// 4. Test: allowed CONNECT -> plain HTTP (non-TLS)
 	t.Run("allowed_plain_http", func(t *testing.T) {
 		// Start a plain HTTP upstream
 		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -352,52 +333,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 	const allowedHost = "allowed.example.com"
 	const deniedHost = "denied.example.com"
 
-	// 2. Generate CA
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(3),
-		Subject:               pkix.Name{CommonName: "SOCKS5 Integration Test CA"},
-		NotBefore:             time.Now().Add(-1 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caCertDER)
-	require.NoError(t, err)
-
-	certCache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
-	require.NoError(t, err)
-
-	// 3. Build allowlist pipeline
-	al, err := allowlist.New([]string{allowedHost}, nil, &staticResolver{})
-	require.NoError(t, err)
-	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
-
-	// 4. Start proxy with tunnel listener
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", certCache, pipeline, nil, logger)
-
-	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	tunnelAddr := tunnelLn.Addr().String()
-	p.tunnelListener = tunnelLn
-
-	go func() {
-		for {
-			conn, err := tunnelLn.Accept()
-			if err != nil {
-				return
-			}
-			go p.handleTunnel(conn)
-		}
-	}()
-	t.Cleanup(func() {
-		tunnelLn.Close()
-		close(p.tunnelDone)
-	})
+	p, tunnelAddr, caPool := startTunnelIntegrationProxy(t, []string{allowedHost}, logger)
 
 	// Override transport to route all dials to the real upstream
 	p.transport = &http.Transport{
@@ -406,9 +342,6 @@ func TestIntegration_SOCKS5(t *testing.T) {
 			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
 		},
 	}
-
-	caPool := x509.NewCertPool()
-	caPool.AddCert(caCert)
 
 	// Helper: perform SOCKS5 handshake with domain-name address type
 	socks5Connect := func(t *testing.T, conn net.Conn, host string, port uint16) {
@@ -443,7 +376,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		return reply[1] // status
 	}
 
-	// 5. Test: allowed SOCKS5 -> TLS MITM -> success
+	// 2. Test: allowed SOCKS5 -> TLS MITM -> success
 	t.Run("allowed_tls", func(t *testing.T) {
 		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
 		require.NoError(t, err)
@@ -477,7 +410,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		require.Equal(t, "socks5 integration response", string(body))
 	})
 
-	// 6. Test: denied SOCKS5 -> connection not allowed
+	// 3. Test: denied SOCKS5 -> connection not allowed
 	t.Run("denied", func(t *testing.T) {
 		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
 		require.NoError(t, err)
@@ -488,7 +421,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		require.Equal(t, byte(0x02), status, "expected SOCKS5 connection not allowed")
 	})
 
-	// 7. Test: allowed SOCKS5 -> plain HTTP
+	// 4. Test: allowed SOCKS5 -> plain HTTP
 	t.Run("allowed_plain_http", func(t *testing.T) {
 		plainUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -527,7 +460,7 @@ func TestIntegration_SOCKS5(t *testing.T) {
 		require.Equal(t, "socks5 plain http", string(body))
 	})
 
-	// 8. Test: non-HTTP/TLS protocol -> proxy closes the connection
+	// 5. Test: non-HTTP/TLS protocol -> proxy closes the connection
 	t.Run("unsupported_protocol", func(t *testing.T) {
 		conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
 		require.NoError(t, err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,23 +20,28 @@ import (
 
 // Proxy is the HTTP/HTTPS MITM proxy server.
 type Proxy struct {
-	httpServer  *http.Server
-	httpsServer *http.Server
-	tlsListener net.Listener
-	certCache   *certcache.Cache
-	pipeline    *transform.Pipeline
-	transport   *http.Transport
-	logger      *slog.Logger
+	httpServer      *http.Server
+	httpsServer     *http.Server
+	tlsListener     net.Listener
+	tunnelAddr      string
+	tunnelListener  net.Listener
+	tunnelDone      chan struct{}
+	certCache       *certcache.Cache
+	pipeline        *transform.Pipeline
+	transport       *http.Transport
+	logger          *slog.Logger
 }
 
 // New creates a new Proxy. If resolver is non-nil, it is used to resolve
 // upstream hostnames instead of the OS default resolver.
-func New(httpAddr, httpsAddr string, certCache *certcache.Cache, pipeline *transform.Pipeline, resolver *net.Resolver, logger *slog.Logger) *Proxy {
+func New(httpAddr, httpsAddr, tunnelAddr string, certCache *certcache.Cache, pipeline *transform.Pipeline, resolver *net.Resolver, logger *slog.Logger) *Proxy {
 	p := &Proxy{
-		certCache: certCache,
-		pipeline:  pipeline,
-		transport: buildTransport(resolver),
-		logger:    logger,
+		tunnelAddr: tunnelAddr,
+		tunnelDone: make(chan struct{}),
+		certCache:  certCache,
+		pipeline:   pipeline,
+		transport:  buildTransport(resolver),
+		logger:     logger,
 	}
 
 	p.httpServer = &http.Server{
@@ -55,10 +60,14 @@ func New(httpAddr, httpsAddr string, certCache *certcache.Cache, pipeline *trans
 	return p
 }
 
-// ListenAndServe starts both HTTP and HTTPS listeners. It blocks until
-// both servers have stopped.
+// ListenAndServe starts the HTTP, HTTPS, and (optionally) tunnel listeners.
+// It blocks until any server has stopped.
 func (p *Proxy) ListenAndServe() error {
-	errc := make(chan error, 2)
+	n := 2
+	if p.tunnelAddr != "" {
+		n = 3
+	}
+	errc := make(chan error, n)
 
 	go func() {
 		p.logger.Info("http proxy starting", slog.String("addr", p.httpServer.Addr))
@@ -77,13 +86,26 @@ func (p *Proxy) ListenAndServe() error {
 		errc <- fmt.Errorf("https: %w", p.httpsServer.Serve(tlsLn))
 	}()
 
+	if p.tunnelAddr != "" {
+		go func() {
+			errc <- fmt.Errorf("tunnel: %w", p.listenTunnel())
+		}()
+	}
+
 	return <-errc
 }
 
-// Shutdown gracefully stops both servers.
+// Shutdown gracefully stops all servers.
 func (p *Proxy) Shutdown(ctx context.Context) error {
 	errHTTP := p.httpServer.Shutdown(ctx)
 	errHTTPS := p.httpsServer.Shutdown(ctx)
+
+	// Signal tunnel accept loop to stop, then close the listener.
+	close(p.tunnelDone)
+	if p.tunnelListener != nil {
+		p.tunnelListener.Close()
+	}
+
 	if errHTTP != nil {
 		return errHTTP
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -99,7 +99,7 @@ func startProxyWithTransforms(t *testing.T, transforms []transform.Transformer) 
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
-	p := New("127.0.0.1:0", "127.0.0.1:0", cache, pipeline, nil, testLogger())
+	p := New("127.0.0.1:0", "127.0.0.1:0", "", cache, pipeline, nil, testLogger())
 
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -79,7 +79,9 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
 	}
 
 	if req.Method != http.MethodConnect {
-		_, _ = fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+		if _, err := fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n"); err != nil {
+			p.logger.Debug("tunnel write 405 error", slog.String("error", err.Error()))
+		}
 		return
 	}
 
@@ -91,12 +93,17 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
 	p.logger.Debug("tunnel CONNECT", slog.String("target", host))
 
 	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), host) {
-		_, _ = fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n")
+		if _, err := fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n"); err != nil {
+			p.logger.Debug("tunnel write 403 error", slog.String("error", err.Error()))
+		}
 		return
 	}
 
 	// Send 200 to signal tunnel established
-	_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		p.logger.Warn("tunnel write 200 error", slog.String("target", host), slog.String("error", err.Error()))
+		return
+	}
 
 	p.serveTunnel(conn, host)
 }
@@ -136,11 +143,16 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	}
 	if !hasNoAuth {
 		// Reply with 0xFF = no acceptable methods
-		_, _ = conn.Write([]byte{0x05, 0xFF})
+		if _, err := conn.Write([]byte{0x05, 0xFF}); err != nil {
+			p.logger.Debug("socks5 write no-acceptable-methods error", slog.String("error", err.Error()))
+		}
 		return
 	}
 	// Reply: use no-auth
-	_, _ = conn.Write([]byte{0x05, 0x00})
+	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
+		p.logger.Debug("socks5 write auth reply error", slog.String("error", err.Error()))
+		return
+	}
 
 	// --- Connect request ---
 	// +----+-----+-------+------+----------+----------+
@@ -209,7 +221,10 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	// |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
 	// +----+-----+-------+------+----------+----------+
 	reply := []byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
-	_, _ = conn.Write(reply)
+	if _, err := conn.Write(reply); err != nil {
+		p.logger.Warn("socks5 write success reply error", slog.String("target", target), slog.String("error", err.Error()))
+		return
+	}
 
 	p.serveTunnel(conn, target)
 }
@@ -217,7 +232,9 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 // socks5Reply sends a SOCKS5 reply with the given status code.
 func (p *Proxy) socks5Reply(conn net.Conn, status byte) {
 	reply := []byte{0x05, status, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
-	_, _ = conn.Write(reply)
+	if _, err := conn.Write(reply); err != nil {
+		p.logger.Debug("socks5 write reply error", slog.Int("status", int(status)), slog.String("error", err.Error()))
+	}
 }
 
 // tunnelTransformCheck runs a synthetic CONNECT request through the transform

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -79,7 +79,7 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
 	}
 
 	if req.Method != http.MethodConnect {
-		fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n")
 		return
 	}
 
@@ -91,12 +91,12 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
 	p.logger.Debug("tunnel CONNECT", slog.String("target", host))
 
 	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), host) {
-		fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n")
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n")
 		return
 	}
 
 	// Send 200 to signal tunnel established
-	fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
 
 	p.serveTunnel(conn, host)
 }
@@ -136,11 +136,11 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	}
 	if !hasNoAuth {
 		// Reply with 0xFF = no acceptable methods
-		conn.Write([]byte{0x05, 0xFF})
+		_, _ = conn.Write([]byte{0x05, 0xFF})
 		return
 	}
 	// Reply: use no-auth
-	conn.Write([]byte{0x05, 0x00})
+	_, _ = conn.Write([]byte{0x05, 0x00})
 
 	// --- Connect request ---
 	// +----+-----+-------+------+----------+----------+
@@ -209,7 +209,7 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	// |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
 	// +----+-----+-------+------+----------+----------+
 	reply := []byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
-	conn.Write(reply)
+	_, _ = conn.Write(reply)
 
 	p.serveTunnel(conn, target)
 }
@@ -217,7 +217,7 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 // socks5Reply sends a SOCKS5 reply with the given status code.
 func (p *Proxy) socks5Reply(conn net.Conn, status byte) {
 	reply := []byte{0x05, status, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
-	conn.Write(reply)
+	_, _ = conn.Write(reply)
 }
 
 // tunnelTransformCheck runs a synthetic CONNECT request through the transform
@@ -325,7 +325,7 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) {
 	tlsConn := tls.Server(clientConn, &tls.Config{
 		GetCertificate: p.getCertificate,
 	})
-	defer tlsConn.Close()
+	defer func() { _ = tlsConn.Close() }()
 
 	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
 		p.logger.Debug("tunnel MITM TLS handshake failed",
@@ -339,7 +339,7 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) {
 	srv := &http.Server{
 		Handler: http.HandlerFunc(p.handleHTTP),
 	}
-	srv.Serve(ln)
+	_ = srv.Serve(ln)
 }
 
 // serveTunnelHTTP serves plain HTTP requests through the normal handleHTTP handler.
@@ -350,7 +350,7 @@ func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string) {
 	srv := &http.Server{
 		Handler: http.HandlerFunc(p.handleHTTP),
 	}
-	srv.Serve(ln)
+	_ = srv.Serve(ln)
 }
 
 // isHTTPMethodByte returns true if b could be the first byte of an HTTP method.

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -43,6 +43,7 @@ func (p *Proxy) listenTunnel() error {
 }
 
 // handleTunnel peeks at the first byte to dispatch to CONNECT or SOCKS5.
+// This is the single logging point for tunnel connection errors.
 func (p *Proxy) handleTunnel(conn net.Conn) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -60,29 +61,32 @@ func (p *Proxy) handleTunnel(conn net.Conn) {
 
 	// SOCKS5 starts with version byte 0x05
 	if first[0] == 0x05 {
-		p.handleSOCKS5(conn, br)
+		if err := p.handleSOCKS5(conn, br); err != nil {
+			p.logger.Debug("tunnel socks5 error", slog.String("error", err.Error()))
+		}
 		return
 	}
 
 	// Otherwise assume HTTP CONNECT
-	p.handleCONNECT(conn, br)
+	if err := p.handleCONNECT(conn, br); err != nil {
+		p.logger.Debug("tunnel connect error", slog.String("error", err.Error()))
+	}
 }
 
 // handleCONNECT handles HTTP CONNECT tunnel requests.
-func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
+func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) error {
 	defer conn.Close()
 
 	req, err := http.ReadRequest(br)
 	if err != nil {
-		p.logger.Debug("tunnel CONNECT read error", slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("read request: %w", err)
 	}
 
 	if req.Method != http.MethodConnect {
 		if _, err := fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n"); err != nil {
-			p.logger.Debug("tunnel write 405 error", slog.String("error", err.Error()))
+			return fmt.Errorf("write 405: %w", err)
 		}
-		return
+		return nil
 	}
 
 	host := req.Host
@@ -94,43 +98,39 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
 
 	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), host) {
 		if _, err := fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n"); err != nil {
-			p.logger.Debug("tunnel write 403 error", slog.String("error", err.Error()))
+			return fmt.Errorf("write 403: %w", err)
 		}
-		return
+		return nil
 	}
 
 	// Send 200 to signal tunnel established
 	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
-		p.logger.Warn("tunnel write 200 error", slog.String("target", host), slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("write 200: %w", err)
 	}
 
-	p.serveTunnel(conn, host)
+	return p.serveTunnel(conn, host)
 }
 
 // handleSOCKS5 handles SOCKS5 tunnel requests.
-func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
+func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) error {
 	defer conn.Close()
 
 	// --- Auth negotiation ---
-	// +----+----------+----------+
-	// |VER | NMETHODS | METHODS  |
-	// +----+----------+----------+
-	// | 1  |    1     | 1 to 255 |
-	// +----+----------+----------+
 	ver, err := br.ReadByte()
-	if err != nil || ver != 0x05 {
-		p.logger.Debug("socks5 bad version", slog.Any("ver", ver))
-		return
+	if err != nil {
+		return fmt.Errorf("read version: %w", err)
+	}
+	if ver != 0x05 {
+		return fmt.Errorf("unsupported socks version: %d", ver)
 	}
 
 	nmethods, err := br.ReadByte()
 	if err != nil {
-		return
+		return fmt.Errorf("read nmethods: %w", err)
 	}
 	methods := make([]byte, nmethods)
 	if _, err := io.ReadFull(br, methods); err != nil {
-		return
+		return fmt.Errorf("read methods: %w", err)
 	}
 
 	// We only support no-auth (0x00)
@@ -142,34 +142,29 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 		}
 	}
 	if !hasNoAuth {
-		// Reply with 0xFF = no acceptable methods
-		if _, err := conn.Write([]byte{0x05, 0xFF}); err != nil {
-			p.logger.Debug("socks5 write no-acceptable-methods error", slog.String("error", err.Error()))
+		if err := p.socks5Reply(conn, 0xFF); err != nil {
+			return fmt.Errorf("write no-acceptable-methods: %w", err)
 		}
-		return
+		return nil
 	}
 	// Reply: use no-auth
 	if _, err := conn.Write([]byte{0x05, 0x00}); err != nil {
-		p.logger.Debug("socks5 write auth reply error", slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("write auth reply: %w", err)
 	}
 
 	// --- Connect request ---
-	// +----+-----+-------+------+----------+----------+
-	// |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
-	// +----+-----+-------+------+----------+----------+
-	// | 1  |  1  | X'00' |  1   | Variable |    2     |
-	// +----+-----+-------+------+----------+----------+
 	header := make([]byte, 4)
 	if _, err := io.ReadFull(br, header); err != nil {
-		return
+		return fmt.Errorf("read connect header: %w", err)
 	}
 	if header[0] != 0x05 {
-		return
+		return fmt.Errorf("unexpected socks version in connect: %d", header[0])
 	}
 	if header[1] != 0x01 { // only CONNECT supported
-		p.socks5Reply(conn, 0x07) // command not supported
-		return
+		if err := p.socks5Reply(conn, 0x07); err != nil {
+			return fmt.Errorf("write command-not-supported: %w", err)
+		}
+		return nil
 	}
 
 	var targetHost string
@@ -178,33 +173,35 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	case 0x01: // IPv4
 		addr := make([]byte, 4)
 		if _, err := io.ReadFull(br, addr); err != nil {
-			return
+			return fmt.Errorf("read ipv4 addr: %w", err)
 		}
 		targetHost = net.IP(addr).String()
 	case 0x03: // Domain name
 		domainLen, err := br.ReadByte()
 		if err != nil {
-			return
+			return fmt.Errorf("read domain length: %w", err)
 		}
 		domain := make([]byte, domainLen)
 		if _, err := io.ReadFull(br, domain); err != nil {
-			return
+			return fmt.Errorf("read domain: %w", err)
 		}
 		targetHost = string(domain)
 	case 0x04: // IPv6
 		addr := make([]byte, 16)
 		if _, err := io.ReadFull(br, addr); err != nil {
-			return
+			return fmt.Errorf("read ipv6 addr: %w", err)
 		}
 		targetHost = net.IP(addr).String()
 	default:
-		p.socks5Reply(conn, 0x08) // address type not supported
-		return
+		if err := p.socks5Reply(conn, 0x08); err != nil {
+			return fmt.Errorf("write address-type-not-supported: %w", err)
+		}
+		return nil
 	}
 
 	portBuf := make([]byte, 2)
 	if _, err := io.ReadFull(br, portBuf); err != nil {
-		return
+		return fmt.Errorf("read port: %w", err)
 	}
 	port := binary.BigEndian.Uint16(portBuf)
 	target := net.JoinHostPort(targetHost, strconv.Itoa(int(port)))
@@ -212,29 +209,26 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
 	p.logger.Debug("tunnel SOCKS5 CONNECT", slog.String("target", target))
 
 	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), target) {
-		p.socks5Reply(conn, 0x02) // connection not allowed by ruleset
-		return
+		if err := p.socks5Reply(conn, 0x02); err != nil {
+			return fmt.Errorf("write connection-not-allowed: %w", err)
+		}
+		return nil
 	}
 
 	// Success reply
-	// +----+-----+-------+------+----------+----------+
-	// |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
-	// +----+-----+-------+------+----------+----------+
 	reply := []byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
 	if _, err := conn.Write(reply); err != nil {
-		p.logger.Warn("socks5 write success reply error", slog.String("target", target), slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("write success reply: %w", err)
 	}
 
-	p.serveTunnel(conn, target)
+	return p.serveTunnel(conn, target)
 }
 
 // socks5Reply sends a SOCKS5 reply with the given status code.
-func (p *Proxy) socks5Reply(conn net.Conn, status byte) {
+func (p *Proxy) socks5Reply(conn net.Conn, status byte) error {
 	reply := []byte{0x05, status, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
-	if _, err := conn.Write(reply); err != nil {
-		p.logger.Debug("socks5 write reply error", slog.Int("status", int(status)), slog.String("error", err.Error()))
-	}
+	_, err := conn.Write(reply)
+	return err
 }
 
 // tunnelTransformCheck runs a synthetic CONNECT request through the transform
@@ -304,15 +298,11 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 // serveTunnel peeks at the client's first byte after the CONNECT/SOCKS5
 // handshake to detect TLS (0x16) vs plain HTTP. TLS connections get MITM'd;
 // plain HTTP is served directly through handleHTTP. Anything else is rejected.
-func (p *Proxy) serveTunnel(clientConn net.Conn, target string) {
+func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 	br := bufio.NewReader(clientConn)
 	first, err := br.Peek(1)
 	if err != nil {
-		p.logger.Debug("tunnel client peek error",
-			slog.String("target", target),
-			slog.String("error", err.Error()),
-		)
-		return
+		return fmt.Errorf("peek client protocol: %w", err)
 	}
 
 	// Wrap the conn so the peeked byte is not lost.
@@ -320,54 +310,45 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) {
 
 	if first[0] == 0x16 {
 		// TLS ClientHello: MITM
-		p.serveTunnelTLS(peekedConn, target)
-		return
+		return p.serveTunnelTLS(peekedConn, target)
 	}
 
 	if isHTTPMethodByte(first[0]) {
 		// Plain HTTP request
-		p.serveTunnelHTTP(peekedConn, target)
-		return
+		return p.serveTunnelHTTP(peekedConn, target)
 	}
 
-	p.logger.Warn("tunnel unsupported protocol",
-		slog.String("target", target),
-		slog.Int("first_byte", int(first[0])),
-	)
+	return fmt.Errorf("unsupported protocol (first byte 0x%02x) for target %s", first[0], target)
 }
 
 // serveTunnelTLS performs TLS MITM on the client connection, then serves
 // HTTP requests through the normal handleHTTP handler.
-func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) {
+func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
 	tlsConn := tls.Server(clientConn, &tls.Config{
 		GetCertificate: p.getCertificate,
 	})
 	defer func() { _ = tlsConn.Close() }()
 
 	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
-		p.logger.Debug("tunnel MITM TLS handshake failed",
-			slog.String("target", target),
-			slog.String("error", err.Error()),
-		)
-		return
+		return fmt.Errorf("TLS handshake for %s: %w", target, err)
 	}
 
 	ln := newOneConnListener(tlsConn)
 	srv := &http.Server{
 		Handler: http.HandlerFunc(p.handleHTTP),
 	}
-	_ = srv.Serve(ln)
+	return srv.Serve(ln)
 }
 
 // serveTunnelHTTP serves plain HTTP requests through the normal handleHTTP handler.
-func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string) {
+func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string) error {
 	defer clientConn.Close()
 
 	ln := newOneConnListener(clientConn)
 	srv := &http.Server{
 		Handler: http.HandlerFunc(p.handleHTTP),
 	}
-	_ = srv.Serve(ln)
+	return srv.Serve(ln)
 }
 
 // isHTTPMethodByte returns true if b could be the first byte of an HTTP method.
@@ -430,4 +411,3 @@ func newPeekedConn(conn net.Conn, r *bufio.Reader) *peekedConn {
 func (c *peekedConn) Read(p []byte) (int, error) {
 	return c.r.Read(p)
 }
-

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -1,0 +1,416 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// listenTunnel starts the CONNECT/SOCKS5 tunnel listener.
+func (p *Proxy) listenTunnel() error {
+	ln, err := net.Listen("tcp", p.tunnelAddr)
+	if err != nil {
+		return fmt.Errorf("tunnel listen: %w", err)
+	}
+	p.tunnelListener = ln
+	p.logger.Info("tunnel proxy starting", slog.String("addr", ln.Addr().String()))
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-p.tunnelDone:
+				return nil
+			default:
+			}
+			p.logger.Warn("tunnel accept error", slog.String("error", err.Error()))
+			continue
+		}
+		go p.handleTunnel(conn)
+	}
+}
+
+// handleTunnel peeks at the first byte to dispatch to CONNECT or SOCKS5.
+func (p *Proxy) handleTunnel(conn net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("tunnel panic", slog.Any("panic", r))
+		}
+	}()
+
+	br := bufio.NewReader(conn)
+	first, err := br.Peek(1)
+	if err != nil {
+		p.logger.Debug("tunnel peek error", slog.String("error", err.Error()))
+		conn.Close()
+		return
+	}
+
+	// SOCKS5 starts with version byte 0x05
+	if first[0] == 0x05 {
+		p.handleSOCKS5(conn, br)
+		return
+	}
+
+	// Otherwise assume HTTP CONNECT
+	p.handleCONNECT(conn, br)
+}
+
+// handleCONNECT handles HTTP CONNECT tunnel requests.
+func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) {
+	defer conn.Close()
+
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		p.logger.Debug("tunnel CONNECT read error", slog.String("error", err.Error()))
+		return
+	}
+
+	if req.Method != http.MethodConnect {
+		fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+		return
+	}
+
+	host := req.Host
+	if _, _, err := net.SplitHostPort(host); err != nil {
+		host = net.JoinHostPort(host, "443")
+	}
+
+	p.logger.Debug("tunnel CONNECT", slog.String("target", host))
+
+	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), host) {
+		fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n")
+		return
+	}
+
+	// Send 200 to signal tunnel established
+	fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+	p.serveTunnel(conn, host)
+}
+
+// handleSOCKS5 handles SOCKS5 tunnel requests.
+func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) {
+	defer conn.Close()
+
+	// --- Auth negotiation ---
+	// +----+----------+----------+
+	// |VER | NMETHODS | METHODS  |
+	// +----+----------+----------+
+	// | 1  |    1     | 1 to 255 |
+	// +----+----------+----------+
+	ver, err := br.ReadByte()
+	if err != nil || ver != 0x05 {
+		p.logger.Debug("socks5 bad version", slog.Any("ver", ver))
+		return
+	}
+
+	nmethods, err := br.ReadByte()
+	if err != nil {
+		return
+	}
+	methods := make([]byte, nmethods)
+	if _, err := io.ReadFull(br, methods); err != nil {
+		return
+	}
+
+	// We only support no-auth (0x00)
+	hasNoAuth := false
+	for _, m := range methods {
+		if m == 0x00 {
+			hasNoAuth = true
+			break
+		}
+	}
+	if !hasNoAuth {
+		// Reply with 0xFF = no acceptable methods
+		conn.Write([]byte{0x05, 0xFF})
+		return
+	}
+	// Reply: use no-auth
+	conn.Write([]byte{0x05, 0x00})
+
+	// --- Connect request ---
+	// +----+-----+-------+------+----------+----------+
+	// |VER | CMD |  RSV  | ATYP | DST.ADDR | DST.PORT |
+	// +----+-----+-------+------+----------+----------+
+	// | 1  |  1  | X'00' |  1   | Variable |    2     |
+	// +----+-----+-------+------+----------+----------+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(br, header); err != nil {
+		return
+	}
+	if header[0] != 0x05 {
+		return
+	}
+	if header[1] != 0x01 { // only CONNECT supported
+		p.socks5Reply(conn, 0x07) // command not supported
+		return
+	}
+
+	var targetHost string
+	atyp := header[3]
+	switch atyp {
+	case 0x01: // IPv4
+		addr := make([]byte, 4)
+		if _, err := io.ReadFull(br, addr); err != nil {
+			return
+		}
+		targetHost = net.IP(addr).String()
+	case 0x03: // Domain name
+		domainLen, err := br.ReadByte()
+		if err != nil {
+			return
+		}
+		domain := make([]byte, domainLen)
+		if _, err := io.ReadFull(br, domain); err != nil {
+			return
+		}
+		targetHost = string(domain)
+	case 0x04: // IPv6
+		addr := make([]byte, 16)
+		if _, err := io.ReadFull(br, addr); err != nil {
+			return
+		}
+		targetHost = net.IP(addr).String()
+	default:
+		p.socks5Reply(conn, 0x08) // address type not supported
+		return
+	}
+
+	portBuf := make([]byte, 2)
+	if _, err := io.ReadFull(br, portBuf); err != nil {
+		return
+	}
+	port := binary.BigEndian.Uint16(portBuf)
+	target := net.JoinHostPort(targetHost, strconv.Itoa(int(port)))
+
+	p.logger.Debug("tunnel SOCKS5 CONNECT", slog.String("target", target))
+
+	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), target) {
+		p.socks5Reply(conn, 0x02) // connection not allowed by ruleset
+		return
+	}
+
+	// Success reply
+	// +----+-----+-------+------+----------+----------+
+	// |VER | REP |  RSV  | ATYP | BND.ADDR | BND.PORT |
+	// +----+-----+-------+------+----------+----------+
+	reply := []byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	conn.Write(reply)
+
+	p.serveTunnel(conn, target)
+}
+
+// socks5Reply sends a SOCKS5 reply with the given status code.
+func (p *Proxy) socks5Reply(conn net.Conn, status byte) {
+	reply := []byte{0x05, status, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	conn.Write(reply)
+}
+
+// tunnelTransformCheck runs a synthetic CONNECT request through the transform
+// pipeline to decide whether the tunnel should be allowed.
+func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
+	host, _, _ := net.SplitHostPort(target)
+
+	req := &http.Request{
+		Method:     http.MethodConnect,
+		Host:       target,
+		URL:        &url.URL{Host: target},
+		Header:     http.Header{},
+		RemoteAddr: remoteAddr,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+	req.Body = transform.NewBufferedBody(http.NoBody, 0)
+
+	startedAt := time.Now()
+	tctx := &transform.TransformContext{
+		Logger: p.logger,
+		SNI:    host,
+	}
+
+	var reqTraces []transform.TransformTrace
+	result := &transform.PipelineResult{
+		Host:       target,
+		Method:     http.MethodConnect,
+		Path:       "",
+		RemoteAddr: remoteAddr,
+		SNI:        host,
+		StartedAt:  startedAt,
+	}
+	defer func() {
+		result.Duration = time.Since(startedAt)
+		result.RequestTransforms = reqTraces
+		p.pipeline.EmitAudit(result)
+	}()
+
+	rejectResp, err := p.pipeline.ProcessRequest(req.Context(), tctx, req, &reqTraces)
+	if err != nil {
+		result.Action = transform.ActionContinue
+		result.StatusCode = http.StatusBadGateway
+		result.Err = err
+		p.logger.Warn("tunnel transform error",
+			slog.String("target", target),
+			slog.String("error", err.Error()),
+		)
+		return false
+	}
+	if rejectResp != nil {
+		result.Action = transform.ActionReject
+		result.StatusCode = rejectResp.StatusCode
+		p.logger.Info("tunnel rejected by transform",
+			slog.String("target", target),
+			slog.Int("status", rejectResp.StatusCode),
+		)
+		return false
+	}
+
+	result.Action = transform.ActionContinue
+	result.StatusCode = http.StatusOK
+	return true
+}
+
+// serveTunnel peeks at the client's first byte after the CONNECT/SOCKS5
+// handshake to detect TLS (0x16) vs plain HTTP. TLS connections get MITM'd;
+// plain HTTP is served directly through handleHTTP. Anything else is rejected.
+func (p *Proxy) serveTunnel(clientConn net.Conn, target string) {
+	br := bufio.NewReader(clientConn)
+	first, err := br.Peek(1)
+	if err != nil {
+		p.logger.Debug("tunnel client peek error",
+			slog.String("target", target),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// Wrap the conn so the peeked byte is not lost.
+	peekedConn := newPeekedConn(clientConn, br)
+
+	if first[0] == 0x16 {
+		// TLS ClientHello: MITM
+		p.serveTunnelTLS(peekedConn, target)
+		return
+	}
+
+	if isHTTPMethodByte(first[0]) {
+		// Plain HTTP request
+		p.serveTunnelHTTP(peekedConn, target)
+		return
+	}
+
+	p.logger.Warn("tunnel unsupported protocol",
+		slog.String("target", target),
+		slog.Int("first_byte", int(first[0])),
+	)
+}
+
+// serveTunnelTLS performs TLS MITM on the client connection, then serves
+// HTTP requests through the normal handleHTTP handler.
+func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) {
+	tlsConn := tls.Server(clientConn, &tls.Config{
+		GetCertificate: p.getCertificate,
+	})
+	defer tlsConn.Close()
+
+	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
+		p.logger.Debug("tunnel MITM TLS handshake failed",
+			slog.String("target", target),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	ln := newOneConnListener(tlsConn)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(p.handleHTTP),
+	}
+	srv.Serve(ln)
+}
+
+// serveTunnelHTTP serves plain HTTP requests through the normal handleHTTP handler.
+func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string) {
+	defer clientConn.Close()
+
+	ln := newOneConnListener(clientConn)
+	srv := &http.Server{
+		Handler: http.HandlerFunc(p.handleHTTP),
+	}
+	srv.Serve(ln)
+}
+
+// isHTTPMethodByte returns true if b could be the first byte of an HTTP method.
+func isHTTPMethodByte(b byte) bool {
+	// HTTP methods start with uppercase ASCII: GET, HEAD, POST, PUT, DELETE,
+	// CONNECT, OPTIONS, TRACE, PATCH
+	return b >= 'A' && b <= 'Z'
+}
+
+// oneConnListener is a net.Listener that returns a single connection, then
+// blocks until Close is called. This lets us serve a single hijacked
+// connection using http.Server.Serve.
+type oneConnListener struct {
+	conn net.Conn
+	once sync.Once
+	done chan struct{}
+}
+
+func newOneConnListener(conn net.Conn) *oneConnListener {
+	return &oneConnListener{
+		conn: conn,
+		done: make(chan struct{}),
+	}
+}
+
+func (l *oneConnListener) Accept() (net.Conn, error) {
+	var c net.Conn
+	l.once.Do(func() { c = l.conn })
+	if c != nil {
+		return c, nil
+	}
+	<-l.done
+	return nil, net.ErrClosed
+}
+
+func (l *oneConnListener) Close() error {
+	select {
+	case <-l.done:
+	default:
+		close(l.done)
+	}
+	return nil
+}
+
+func (l *oneConnListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
+}
+
+// peekedConn wraps a net.Conn with a bufio.Reader so that bytes consumed
+// by Peek are still available for subsequent reads.
+type peekedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func newPeekedConn(conn net.Conn, r *bufio.Reader) *peekedConn {
+	return &peekedConn{Conn: conn, r: r}
+}
+
+func (c *peekedConn) Read(p []byte) (int, error) {
+	return c.r.Read(p)
+}
+

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -1,0 +1,365 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/certcache"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func startTunnelProxy(t *testing.T, transforms []transform.Transformer) (*Proxy, string, *x509.CertPool) {
+	t.Helper()
+
+	caCert, caKey := generateTestCA(t)
+	cache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+
+	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", cache, pipeline, nil, testLogger())
+
+	// Start tunnel listener
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+
+	t.Cleanup(func() {
+		tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	return p, tunnelAddr, pool
+}
+
+func TestTunnel_CONNECT_HTTP(t *testing.T) {
+	// Start an upstream HTTP server
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Tunnel", "true")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "hello from tunnel")
+	}))
+	defer upstream.Close()
+
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	// Send CONNECT request
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	target := upstream.Listener.Addr().String()
+	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+
+	// Read 200 Connection Established
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Now send an HTTP request through the tunnel (raw tunnel, not MITM)
+	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+
+	resp2, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	require.Equal(t, "true", resp2.Header.Get("X-Tunnel"))
+
+	body, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello from tunnel", string(body))
+}
+
+func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
+	// Start an upstream HTTPS server
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "hello from tls tunnel")
+	}))
+	defer upstream.Close()
+
+	p, tunnelAddr, caPool := startTunnelProxy(t, nil)
+
+	// Override transport to route to the upstream
+	upstreamAddr := upstream.Listener.Addr().String()
+	p.transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
+		},
+	}
+
+	const fakeHost = "mitm.example.com"
+
+	// Send CONNECT to port 443 (triggers MITM)
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", fakeHost, fakeHost)
+
+	// Read 200 Connection Established
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Now do TLS handshake on the tunneled connection
+	tlsConn := tls.Client(conn, &tls.Config{
+		RootCAs:    caPool,
+		ServerName: fakeHost,
+	})
+	defer tlsConn.Close()
+
+	err = tlsConn.Handshake()
+	require.NoError(t, err)
+
+	// Send HTTP request through the TLS tunnel
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/test", fakeHost), nil)
+	require.NoError(t, err)
+
+	err = req.Write(tlsConn)
+	require.NoError(t, err)
+
+	tlsBr := bufio.NewReader(tlsConn)
+	resp2, err := http.ReadResponse(tlsBr, req)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	body, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello from tls tunnel", string(body))
+}
+
+func TestTunnel_CONNECT_MethodNotAllowed(t *testing.T) {
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestTunnel_SOCKS5_HTTP(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Socks", "true")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "hello from socks5")
+	}))
+	defer upstream.Close()
+
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	upstreamHost, upstreamPortStr, _ := net.SplitHostPort(upstream.Listener.Addr().String())
+
+	// SOCKS5 auth negotiation: version 5, 1 method (no auth)
+	conn.Write([]byte{0x05, 0x01, 0x00})
+
+	// Read auth response
+	authResp := make([]byte, 2)
+	_, err = io.ReadFull(conn, authResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), authResp[0])
+	require.Equal(t, byte(0x00), authResp[1])
+
+	// SOCKS5 connect request: IPv4
+	ip := net.ParseIP(upstreamHost).To4()
+	require.NotNil(t, ip)
+
+	var port uint16
+	fmt.Sscanf(upstreamPortStr, "%d", &port)
+
+	connectReq := []byte{0x05, 0x01, 0x00, 0x01} // ver, cmd=connect, rsv, atyp=IPv4
+	connectReq = append(connectReq, ip...)
+	portBuf := make([]byte, 2)
+	binary.BigEndian.PutUint16(portBuf, port)
+	connectReq = append(connectReq, portBuf...)
+
+	conn.Write(connectReq)
+
+	// Read connect response
+	connectResp := make([]byte, 10)
+	_, err = io.ReadFull(conn, connectResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), connectResp[0]) // version
+	require.Equal(t, byte(0x00), connectResp[1]) // success
+
+	// Now send HTTP through the tunnel
+	target := upstream.Listener.Addr().String()
+	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "true", resp.Header.Get("X-Socks"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello from socks5", string(body))
+}
+
+func TestTunnel_SOCKS5_DomainName(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "domain ok")
+	}))
+	defer upstream.Close()
+
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, upstreamPortStr, _ := net.SplitHostPort(upstream.Listener.Addr().String())
+	var port uint16
+	fmt.Sscanf(upstreamPortStr, "%d", &port)
+
+	// Auth negotiation
+	conn.Write([]byte{0x05, 0x01, 0x00})
+	authResp := make([]byte, 2)
+	io.ReadFull(conn, authResp)
+
+	// Connect with domain name type (0x03) pointing to 127.0.0.1
+	domain := "127.0.0.1" // using IP as "domain" for test simplicity
+	connectReq := []byte{0x05, 0x01, 0x00, 0x03, byte(len(domain))}
+	connectReq = append(connectReq, []byte(domain)...)
+	portBuf := make([]byte, 2)
+	binary.BigEndian.PutUint16(portBuf, port)
+	connectReq = append(connectReq, portBuf...)
+
+	conn.Write(connectReq)
+
+	connectResp := make([]byte, 10)
+	_, err = io.ReadFull(conn, connectResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x00), connectResp[1]) // success
+
+	// Send HTTP request
+	target := upstream.Listener.Addr().String()
+	fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestTunnel_SOCKS5_NoAuth_Required(t *testing.T) {
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Offer only username/password auth (0x02), no no-auth
+	conn.Write([]byte{0x05, 0x01, 0x02})
+
+	resp := make([]byte, 2)
+	_, err = io.ReadFull(conn, resp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), resp[0])
+	require.Equal(t, byte(0xFF), resp[1]) // no acceptable methods
+}
+
+func TestTunnel_TransformReject(t *testing.T) {
+	// Use a transform that rejects everything
+	rejecter := &rejectTransform{}
+
+	_, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{rejecter})
+
+	// Test CONNECT rejection
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestTunnel_SOCKS5_TransformReject(t *testing.T) {
+	rejecter := &rejectTransform{}
+
+	_, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{rejecter})
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Auth
+	conn.Write([]byte{0x05, 0x01, 0x00})
+	authResp := make([]byte, 2)
+	io.ReadFull(conn, authResp)
+
+	// Connect to some target
+	connectReq := []byte{0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0x00, 0x50} // 127.0.0.1:80
+	conn.Write(connectReq)
+
+	connectResp := make([]byte, 10)
+	_, err = io.ReadFull(conn, connectResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x02), connectResp[1]) // connection not allowed
+}
+
+// rejectTransform rejects all requests.
+type rejectTransform struct{}
+
+func (r *rejectTransform) Name() string { return "rejecter" }
+
+func (r *rejectTransform) TransformRequest(_ context.Context, _ *transform.TransformContext, _ *http.Request) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionReject}, nil
+}
+
+func (r *rejectTransform) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -62,7 +62,7 @@ func TestTunnel_CONNECT_HTTP(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Tunnel", "true")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "hello from tunnel")
+		_, _ = fmt.Fprint(w, "hello from tunnel")
 	}))
 	defer upstream.Close()
 
@@ -74,7 +74,8 @@ func TestTunnel_CONNECT_HTTP(t *testing.T) {
 	defer conn.Close()
 
 	target := upstream.Listener.Addr().String()
-	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	require.NoError(t, err)
 
 	// Read 200 Connection Established
 	br := bufio.NewReader(conn)
@@ -83,7 +84,8 @@ func TestTunnel_CONNECT_HTTP(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Now send an HTTP request through the tunnel (raw tunnel, not MITM)
-	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	require.NoError(t, err)
 
 	resp2, err := http.ReadResponse(br, nil)
 	require.NoError(t, err)
@@ -101,7 +103,7 @@ func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 	// Start an upstream HTTPS server
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "hello from tls tunnel")
+		_, _ = fmt.Fprint(w, "hello from tls tunnel")
 	}))
 	defer upstream.Close()
 
@@ -125,7 +127,8 @@ func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", fakeHost, fakeHost)
+	_, err = fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", fakeHost, fakeHost)
+	require.NoError(t, err)
 
 	// Read 200 Connection Established
 	br := bufio.NewReader(conn)
@@ -138,7 +141,7 @@ func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 		RootCAs:    caPool,
 		ServerName: fakeHost,
 	})
-	defer tlsConn.Close()
+	defer func() { _ = tlsConn.Close() }()
 
 	err = tlsConn.Handshake()
 	require.NoError(t, err)
@@ -169,7 +172,8 @@ func TestTunnel_CONNECT_MethodNotAllowed(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	require.NoError(t, err)
 
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, nil)
@@ -181,7 +185,7 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Socks", "true")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "hello from socks5")
+		_, _ = fmt.Fprint(w, "hello from socks5")
 	}))
 	defer upstream.Close()
 
@@ -194,7 +198,8 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 	upstreamHost, upstreamPortStr, _ := net.SplitHostPort(upstream.Listener.Addr().String())
 
 	// SOCKS5 auth negotiation: version 5, 1 method (no auth)
-	conn.Write([]byte{0x05, 0x01, 0x00})
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
 
 	// Read auth response
 	authResp := make([]byte, 2)
@@ -208,7 +213,8 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 	require.NotNil(t, ip)
 
 	var port uint16
-	fmt.Sscanf(upstreamPortStr, "%d", &port)
+	_, err = fmt.Sscanf(upstreamPortStr, "%d", &port)
+	require.NoError(t, err)
 
 	connectReq := []byte{0x05, 0x01, 0x00, 0x01} // ver, cmd=connect, rsv, atyp=IPv4
 	connectReq = append(connectReq, ip...)
@@ -216,7 +222,8 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 	binary.BigEndian.PutUint16(portBuf, port)
 	connectReq = append(connectReq, portBuf...)
 
-	conn.Write(connectReq)
+	_, err = conn.Write(connectReq)
+	require.NoError(t, err)
 
 	// Read connect response
 	connectResp := make([]byte, 10)
@@ -227,7 +234,8 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 
 	// Now send HTTP through the tunnel
 	target := upstream.Listener.Addr().String()
-	fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	require.NoError(t, err)
 
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, nil)
@@ -245,7 +253,7 @@ func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 func TestTunnel_SOCKS5_DomainName(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "domain ok")
+		_, _ = fmt.Fprint(w, "domain ok")
 	}))
 	defer upstream.Close()
 
@@ -257,12 +265,15 @@ func TestTunnel_SOCKS5_DomainName(t *testing.T) {
 
 	_, upstreamPortStr, _ := net.SplitHostPort(upstream.Listener.Addr().String())
 	var port uint16
-	fmt.Sscanf(upstreamPortStr, "%d", &port)
+	_, err = fmt.Sscanf(upstreamPortStr, "%d", &port)
+	require.NoError(t, err)
 
 	// Auth negotiation
-	conn.Write([]byte{0x05, 0x01, 0x00})
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
 	authResp := make([]byte, 2)
-	io.ReadFull(conn, authResp)
+	_, err = io.ReadFull(conn, authResp)
+	require.NoError(t, err)
 
 	// Connect with domain name type (0x03) pointing to 127.0.0.1
 	domain := "127.0.0.1" // using IP as "domain" for test simplicity
@@ -272,7 +283,8 @@ func TestTunnel_SOCKS5_DomainName(t *testing.T) {
 	binary.BigEndian.PutUint16(portBuf, port)
 	connectReq = append(connectReq, portBuf...)
 
-	conn.Write(connectReq)
+	_, err = conn.Write(connectReq)
+	require.NoError(t, err)
 
 	connectResp := make([]byte, 10)
 	_, err = io.ReadFull(conn, connectResp)
@@ -281,7 +293,8 @@ func TestTunnel_SOCKS5_DomainName(t *testing.T) {
 
 	// Send HTTP request
 	target := upstream.Listener.Addr().String()
-	fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	_, err = fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	require.NoError(t, err)
 
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, nil)
@@ -299,7 +312,8 @@ func TestTunnel_SOCKS5_NoAuth_Required(t *testing.T) {
 	defer conn.Close()
 
 	// Offer only username/password auth (0x02), no no-auth
-	conn.Write([]byte{0x05, 0x01, 0x02})
+	_, err = conn.Write([]byte{0x05, 0x01, 0x02})
+	require.NoError(t, err)
 
 	resp := make([]byte, 2)
 	_, err = io.ReadFull(conn, resp)
@@ -319,7 +333,8 @@ func TestTunnel_TransformReject(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	fmt.Fprintf(conn, "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n")
+	_, err = fmt.Fprintf(conn, "CONNECT example.com:80 HTTP/1.1\r\nHost: example.com:80\r\n\r\n")
+	require.NoError(t, err)
 
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, nil)
@@ -337,13 +352,16 @@ func TestTunnel_SOCKS5_TransformReject(t *testing.T) {
 	defer conn.Close()
 
 	// Auth
-	conn.Write([]byte{0x05, 0x01, 0x00})
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
 	authResp := make([]byte, 2)
-	io.ReadFull(conn, authResp)
+	_, err = io.ReadFull(conn, authResp)
+	require.NoError(t, err)
 
 	// Connect to some target
 	connectReq := []byte{0x05, 0x01, 0x00, 0x01, 127, 0, 0, 1, 0x00, 0x50} // 127.0.0.1:80
-	conn.Write(connectReq)
+	_, err = conn.Write(connectReq)
+	require.NoError(t, err)
 
 	connectResp := make([]byte, 10)
 	_, err = io.ReadFull(conn, connectResp)


### PR DESCRIPTION
Adds an optional `tunnel_listen` address to the proxy config stanza that accepts CONNECT and SOCKS5 tunnel requests. The listener peeks at the first byte to distinguish the two protocols, runs the target through the transform pipeline (so allowlists etc. apply), then serves traffic through `handleHTTP`. TLS connections are MITM'd; plain HTTP is served directly; non-HTTP/TLS protocols are rejected.

```yaml
proxy:
  tunnel_listen: ":1080"
```