### PR TITLE
feat: add TransformsFromSync and PipelineHolder for dynamic config

### DIFF
--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TransformsFromSync builds a []Transform from the control plane's rules JSON
+// payload. If rules is nil or JSON null, an empty slice is returned.
+func TransformsFromSync(rules json.RawMessage) ([]Transform, error) {
+	var transforms []Transform
+
+	if isNonNullJSON(rules) {
+		node, err := yamlNodeFromJSON(rules)
+		if err != nil {
+			return nil, fmt.Errorf("parsing rules: %w", err)
+		}
+		transforms = append(transforms, Transform{
+			Name:   "allowlist",
+			Config: node,
+		})
+	}
+
+	return transforms, nil
+}
+
+// yamlNodeFromJSON converts a JSON byte slice into a yaml.Node. This works
+// because JSON is valid YAML, and gopkg.in/yaml.v3 handles it natively.
+func yamlNodeFromJSON(data json.RawMessage) (yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return yaml.Node{}, fmt.Errorf("unmarshaling JSON as YAML: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return yaml.Node{}, fmt.Errorf("unexpected YAML structure")
+	}
+	return *doc.Content[0], nil
+}
+
+func isNonNullJSON(data json.RawMessage) bool {
+	return len(data) > 0 && string(data) != "null"
+}

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformsFromSync_RulesPresent(t *testing.T) {
+	rules := json.RawMessage(`{"domains": ["*.example.com"], "warn": true}`)
+
+	transforms, err := TransformsFromSync(rules)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "allowlist", transforms[0].Name)
+}
+
+func TestTransformsFromSync_Nil(t *testing.T) {
+	transforms, err := TransformsFromSync(nil)
+	require.NoError(t, err)
+	require.Empty(t, transforms)
+}
+
+func TestTransformsFromSync_NullJSON(t *testing.T) {
+	transforms, err := TransformsFromSync(json.RawMessage("null"))
+	require.NoError(t, err)
+	require.Empty(t, transforms)
+}
+
+func TestTransformsFromSync_InvalidJSON(t *testing.T) {
+	_, err := TransformsFromSync(json.RawMessage(`{bad json`))
+	require.ErrorContains(t, err, "parsing rules")
+}
+
+func TestTransformsFromSync_RoundTrip_Allowlist(t *testing.T) {
+	rules := json.RawMessage(`{"domains": ["*.example.com", "api.test.io"], "warn": false}`)
+
+	transforms, err := TransformsFromSync(rules)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+
+	var decoded struct {
+		Domains []string `yaml:"domains"`
+		Warn    bool     `yaml:"warn"`
+	}
+	require.NoError(t, transforms[0].Config.Decode(&decoded))
+	require.Equal(t, []string{"*.example.com", "api.test.io"}, decoded.Domains)
+	require.False(t, decoded.Warn)
+}

--- a/internal/transform/holder.go
+++ b/internal/transform/holder.go
@@ -1,0 +1,29 @@
+package transform
+
+import "sync/atomic"
+
+// PipelineHolder holds an atomically swappable Pipeline pointer. It is safe
+// for concurrent use: readers call Load to get a snapshot, and a single writer
+// calls Store to swap the pipeline. Because Pipeline is immutable after
+// construction, no additional synchronization is needed per-request.
+type PipelineHolder struct {
+	p atomic.Pointer[Pipeline]
+}
+
+// NewPipelineHolder creates a PipelineHolder with the given initial pipeline.
+func NewPipelineHolder(initial *Pipeline) *PipelineHolder {
+	h := &PipelineHolder{}
+	h.p.Store(initial)
+	return h
+}
+
+// Load returns the current pipeline. Callers should capture the returned
+// pointer once per request to get snapshot semantics.
+func (h *PipelineHolder) Load() *Pipeline {
+	return h.p.Load()
+}
+
+// Store atomically replaces the current pipeline with next.
+func (h *PipelineHolder) Store(next *Pipeline) {
+	h.p.Store(next)
+}

--- a/internal/transform/holder_test.go
+++ b/internal/transform/holder_test.go
@@ -1,0 +1,53 @@
+package transform
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineHolder_LoadStore(t *testing.T) {
+	logger := slog.Default()
+	p1 := NewPipeline(nil, BodyLimits{}, logger)
+	h := NewPipelineHolder(p1)
+
+	require.Same(t, p1, h.Load())
+
+	p2 := NewPipeline(nil, BodyLimits{MaxRequestBodyBytes: 42}, logger)
+	h.Store(p2)
+	require.Same(t, p2, h.Load())
+}
+
+func TestPipelineHolder_ConcurrentAccess(t *testing.T) {
+	logger := slog.Default()
+	p1 := NewPipeline(nil, BodyLimits{}, logger)
+	h := NewPipelineHolder(p1)
+
+	var wg sync.WaitGroup
+	const readers = 100
+
+	// Spawn many concurrent readers.
+	wg.Add(readers)
+	for range readers {
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				pl := h.Load()
+				require.NotNil(t, pl)
+			}
+		}()
+	}
+
+	// Swap a few times while readers are active.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			h.Store(NewPipeline(nil, BodyLimits{}, logger))
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Adds two building blocks for dynamic config in managed mode:

- `config.TransformsFromSync(rules, secrets)` converts control plane JSON payloads into `[]config.Transform` by mapping rules to the allowlist transform. Uses `yaml.Unmarshal` on JSON since JSON is valid YAML, so existing transform factories work unchanged.
- `transform.PipelineHolder` wraps `atomic.Pointer[Pipeline]` for lock-free pipeline swapping at runtime. Each request loads the pointer once for snapshot semantics.