### PR TITLE
refactor: use PipelineHolder in proxy for atomic pipeline swapping

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -187,27 +187,15 @@ func runStandalone() {
 	}
 
 	// Build transform pipeline
-	var transformers []transform.Transformer
-	for _, tc := range cfg.Transforms {
-		factory, err := transform.Lookup(tc.Name)
-		if err != nil {
-			logger.Error("unknown transform", slog.String("name", tc.Name))
-			os.Exit(1)
-		}
-		t, err := factory(tc.Config)
-		if err != nil {
-			logger.Error("initializing transform",
-				slog.String("name", tc.Name),
-				slog.String("error", err.Error()),
-			)
-			os.Exit(1)
-		}
-		transformers = append(transformers, t)
-	}
-	pipeline := transform.NewPipeline(transformers, transform.BodyLimits{
+	bodyLimits := transform.BodyLimits{
 		MaxRequestBodyBytes:  cfg.Proxy.MaxRequestBodyBytes,
 		MaxResponseBodyBytes: cfg.Proxy.MaxResponseBodyBytes,
-	}, logger)
+	}
+	pipeline, err := buildPipeline(cfg.Transforms, bodyLimits, logger)
+	if err != nil {
+		logger.Error("building transform pipeline", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
 	auditFunc := transform.AuditFunc(transform.NewAuditLogger(logger))
 	if iotel.Enabled() {
 		otelProvider, err := iotel.NewLoggerProvider(context.Background())
@@ -226,6 +214,7 @@ func runStandalone() {
 		logger.Info("OTEL audit export enabled")
 	}
 	pipeline.SetAuditFunc(auditFunc)
+	holder := transform.NewPipelineHolder(pipeline)
 
 	// Build upstream resolver
 	resolver := net.DefaultResolver
@@ -248,7 +237,7 @@ func runStandalone() {
 	}
 
 	// Initialize proxy
-	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, cfg.Proxy.TunnelListen, certCache, pipeline, resolver, logger)
+	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, cfg.Proxy.TunnelListen, certCache, holder, resolver, logger)
 
 	// Initialize metrics server
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)
@@ -334,6 +323,23 @@ func resolveStateStore() (string, error) {
 	}
 
 	return stateStore, nil
+}
+
+// buildPipeline creates a transform.Pipeline from config transforms.
+func buildPipeline(transforms []config.Transform, bodyLimits transform.BodyLimits, logger *slog.Logger) (*transform.Pipeline, error) {
+	var transformers []transform.Transformer
+	for _, tc := range transforms {
+		factory, err := transform.Lookup(tc.Name)
+		if err != nil {
+			return nil, fmt.Errorf("unknown transform %q: %w", tc.Name, err)
+		}
+		t, err := factory(tc.Config)
+		if err != nil {
+			return nil, fmt.Errorf("initializing transform %q: %w", tc.Name, err)
+		}
+		transformers = append(transformers, t)
+	}
+	return transform.NewPipeline(transformers, bodyLimits, logger), nil
 }
 
 func envOrDefault(key, def string) string {

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -52,8 +52,9 @@ func startTunnelIntegrationProxy(t *testing.T, allowedHosts []string, logger *sl
 	al, err := allowlist.New(allowedHosts, nil, &staticResolver{})
 	require.NoError(t, err)
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
 
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", ca.certCache, pipeline, nil, logger)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", ca.certCache, holder, nil, logger)
 
 	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -111,9 +112,10 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
 
 	// 4. Start proxy with HTTPS
-	p := New("127.0.0.1:0", "127.0.0.1:0", "", ca.certCache, pipeline, nil, logger)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "", ca.certCache, holder, nil, logger)
 
 	// Start HTTP listener
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -27,14 +27,14 @@ type Proxy struct {
 	tunnelListener  net.Listener
 	tunnelDone      chan struct{}
 	certCache       *certcache.Cache
-	pipeline        *transform.Pipeline
+	pipeline        *transform.PipelineHolder
 	transport       *http.Transport
 	logger          *slog.Logger
 }
 
 // New creates a new Proxy. If resolver is non-nil, it is used to resolve
 // upstream hostnames instead of the OS default resolver.
-func New(httpAddr, httpsAddr, tunnelAddr string, certCache *certcache.Cache, pipeline *transform.Pipeline, resolver *net.Resolver, logger *slog.Logger) *Proxy {
+func New(httpAddr, httpsAddr, tunnelAddr string, certCache *certcache.Cache, pipeline *transform.PipelineHolder, resolver *net.Resolver, logger *slog.Logger) *Proxy {
 	p := &Proxy{
 		tunnelAddr: tunnelAddr,
 		tunnelDone: make(chan struct{}),
@@ -147,9 +147,13 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Snapshot the pipeline for this request so a concurrent swap does not
+	// affect in-flight processing.
+	pl := p.pipeline.Load()
+
 	// Build transform context and audit state
 	startedAt := time.Now()
-	bodyLimits := p.pipeline.BodyLimits()
+	bodyLimits := pl.BodyLimits()
 	tctx := &transform.TransformContext{
 		Logger: p.logger,
 	}
@@ -170,14 +174,14 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		result.Duration = time.Since(startedAt)
 		result.RequestTransforms = reqTraces
 		result.ResponseTransforms = respTraces
-		p.pipeline.EmitAudit(result)
+		pl.EmitAudit(result)
 	}()
 
 	// Wrap request body for lazy buffering by transforms.
 	r.Body = transform.NewBufferedBody(r.Body, bodyLimits.MaxRequestBodyBytes)
 
 	// Run request transforms
-	if rejectResp, err := p.pipeline.ProcessRequest(r.Context(), tctx, r, &reqTraces); err != nil {
+	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &reqTraces); err != nil {
 		result.Action = transform.ActionContinue // error, not reject
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
@@ -241,7 +245,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	resp.Body = transform.NewBufferedBody(resp.Body, bodyLimits.MaxResponseBodyBytes)
 
 	// Run response transforms
-	finalResp, err := p.pipeline.ProcessResponse(r.Context(), tctx, r, resp, &respTraces)
+	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &respTraces)
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -99,7 +99,8 @@ func startProxyWithTransforms(t *testing.T, transforms []transform.Transformer) 
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
-	p := New("127.0.0.1:0", "127.0.0.1:0", "", cache, pipeline, nil, testLogger())
+	holder := transform.NewPipelineHolder(pipeline)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "", cache, holder, nil, testLogger())
 
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -248,6 +248,8 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 	}
 	req.Body = transform.NewBufferedBody(http.NoBody, 0)
 
+	pl := p.pipeline.Load()
+
 	startedAt := time.Now()
 	tctx := &transform.TransformContext{
 		Logger: p.logger,
@@ -266,10 +268,10 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 	defer func() {
 		result.Duration = time.Since(startedAt)
 		result.RequestTransforms = reqTraces
-		p.pipeline.EmitAudit(result)
+		pl.EmitAudit(result)
 	}()
 
-	rejectResp, err := p.pipeline.ProcessRequest(req.Context(), tctx, req, &reqTraces)
+	rejectResp, err := pl.ProcessRequest(req.Context(), tctx, req, &reqTraces)
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -28,7 +28,8 @@ func startTunnelProxy(t *testing.T, transforms []transform.Transformer) (*Proxy,
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", cache, pipeline, nil, testLogger())
+	holder := transform.NewPipelineHolder(pipeline)
+	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", cache, holder, nil, testLogger())
 
 	// Start tunnel listener
 	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
Changes the proxy to use `PipelineHolder` (`atomic.Pointer[Pipeline]` wrapper) instead of a direct `*Pipeline` pointer. Each HTTP/tunnel handler loads the pipeline once at the top of the request for snapshot semantics, so a concurrent swap doesn't affect in-flight requests. Also extracts a `buildPipeline` helper in main.go for reuse by managed mode in the next PR.