### PR TITLE
fix: wrap rules array into allowlist config shape

### DIFF
--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -8,12 +8,15 @@ import (
 )
 
 // TransformsFromSync builds a []Transform from the control plane's rules JSON
-// payload. If rules is nil or JSON null, an empty slice is returned.
+// payload. The rules payload is a JSON array of rule objects that gets wrapped
+// into {"rules": [...]} to match the allowlist transform's expected config
+// shape. If rules is nil or JSON null, an empty slice is returned.
 func TransformsFromSync(rules json.RawMessage) ([]Transform, error) {
 	var transforms []Transform
 
 	if isNonNullJSON(rules) {
-		node, err := yamlNodeFromJSON(rules)
+		wrapped := map[string]json.RawMessage{"rules": rules}
+		node, err := yamlNodeFromJSON(wrapped)
 		if err != nil {
 			return nil, fmt.Errorf("parsing rules: %w", err)
 		}
@@ -26,9 +29,13 @@ func TransformsFromSync(rules json.RawMessage) ([]Transform, error) {
 	return transforms, nil
 }
 
-// yamlNodeFromJSON converts a JSON byte slice into a yaml.Node. This works
+// yamlNodeFromJSON marshals v to JSON, then parses as a yaml.Node. This works
 // because JSON is valid YAML, and gopkg.in/yaml.v3 handles it natively.
-func yamlNodeFromJSON(data json.RawMessage) (yaml.Node, error) {
+func yamlNodeFromJSON(v any) (yaml.Node, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshaling to JSON: %w", err)
+	}
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return yaml.Node{}, fmt.Errorf("unmarshaling JSON as YAML: %w", err)

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTransformsFromSync_RulesPresent(t *testing.T) {
-	rules := json.RawMessage(`{"domains": ["*.example.com"], "warn": true}`)
+	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)
 
 	transforms, err := TransformsFromSync(rules)
 	require.NoError(t, err)
@@ -33,18 +33,40 @@ func TestTransformsFromSync_InvalidJSON(t *testing.T) {
 	require.ErrorContains(t, err, "parsing rules")
 }
 
-func TestTransformsFromSync_RoundTrip_Allowlist(t *testing.T) {
-	rules := json.RawMessage(`{"domains": ["*.example.com", "api.test.io"], "warn": false}`)
+func TestTransformsFromSync_RoundTrip(t *testing.T) {
+	rules := json.RawMessage(`[{"host":"*.example.com","methods":["GET","POST"],"paths":["/api/*"]},{"host":"api.test.io","methods":["*"],"paths":["*"]}]`)
 
 	transforms, err := TransformsFromSync(rules)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 
 	var decoded struct {
-		Domains []string `yaml:"domains"`
-		Warn    bool     `yaml:"warn"`
+		Rules []struct {
+			Host    string   `yaml:"host"`
+			Methods []string `yaml:"methods"`
+			Paths   []string `yaml:"paths"`
+		} `yaml:"rules"`
 	}
 	require.NoError(t, transforms[0].Config.Decode(&decoded))
-	require.Equal(t, []string{"*.example.com", "api.test.io"}, decoded.Domains)
-	require.False(t, decoded.Warn)
+	require.Len(t, decoded.Rules, 2)
+	require.Equal(t, "*.example.com", decoded.Rules[0].Host)
+	require.Equal(t, []string{"GET", "POST"}, decoded.Rules[0].Methods)
+	require.Equal(t, []string{"/api/*"}, decoded.Rules[0].Paths)
+	require.Equal(t, "api.test.io", decoded.Rules[1].Host)
+}
+
+func TestTransformsFromSync_EmptyRules(t *testing.T) {
+	rules := json.RawMessage(`[]`)
+
+	transforms, err := TransformsFromSync(rules)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+
+	var decoded struct {
+		Rules []struct {
+			Host string `yaml:"host"`
+		} `yaml:"rules"`
+	}
+	require.NoError(t, transforms[0].Config.Decode(&decoded))
+	require.Empty(t, decoded.Rules)
 }

--- a/internal/controlplane/poller.go
+++ b/internal/controlplane/poller.go
@@ -10,7 +10,7 @@ import (
 )
 
 // PollInterval is the base interval between sync calls.
-const PollInterval = 30 * time.Second
+const PollInterval = 5 * time.Second
 
 // Poller periodically calls Sync and applies config updates.
 type Poller struct {


### PR DESCRIPTION
The control plane sends rules as a JSON array, but `TransformsFromSync` was passing it directly as the allowlist transform config. The allowlist expects an object with a `rules` key, so it failed with `cannot unmarshal !!seq into allowlist.allowlistConfig`. This wraps the array into `{"rules": [...]}` before converting to a YAML node.