### PR TITLE
feat: treat ["*"] methods as wildcard in host match rules

### DIFF
--- a/internal/hostmatch/rule.go
+++ b/internal/hostmatch/rule.go
@@ -68,7 +68,7 @@ func CompileRules(configs []RuleConfig, resolver Resolver, prefix string) ([]Rul
 		}
 
 		r := Rule{Matcher: m}
-		if len(rc.Methods) > 0 {
+		if !isWildcard(rc.Methods) {
 			r.Methods = make(map[string]bool, len(rc.Methods))
 			for _, method := range rc.Methods {
 				r.Methods[strings.ToUpper(method)] = true
@@ -81,6 +81,10 @@ func CompileRules(configs []RuleConfig, resolver Resolver, prefix string) ([]Rul
 		rules = append(rules, r)
 	}
 	return rules, nil
+}
+
+func isWildcard(methods []string) bool {
+	return len(methods) == 0 || (len(methods) == 1 && methods[0] == "*")
 }
 
 // MatchAnyRule returns true if the request matches any rule in the list.

--- a/internal/hostmatch/rule_test.go
+++ b/internal/hostmatch/rule_test.go
@@ -1,0 +1,49 @@
+package hostmatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileRules_WildcardMethodMatchesAll(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{
+		{Host: "example.com", Methods: []string{"*"}},
+	}, NullResolver{}, "test")
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	require.Nil(t, rules[0].Methods, "wildcard method should result in nil Methods (match all)")
+
+	ctx := context.Background()
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"} {
+		require.True(t, rules[0].Matches(ctx, "example.com", method, "/"), "method %s should match", method)
+	}
+}
+
+func TestCompileRules_ExplicitMethodsFiltered(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{
+		{Host: "example.com", Methods: []string{"GET", "post"}},
+	}, NullResolver{}, "test")
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	require.NotNil(t, rules[0].Methods)
+
+	ctx := context.Background()
+	require.True(t, rules[0].Matches(ctx, "example.com", "GET", "/"))
+	require.True(t, rules[0].Matches(ctx, "example.com", "POST", "/"))
+	require.False(t, rules[0].Matches(ctx, "example.com", "DELETE", "/"))
+}
+
+func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{
+		{Host: "example.com"},
+	}, NullResolver{}, "test")
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	require.Nil(t, rules[0].Methods)
+
+	ctx := context.Background()
+	require.True(t, rules[0].Matches(ctx, "example.com", "GET", "/"))
+	require.True(t, rules[0].Matches(ctx, "example.com", "DELETE", "/"))
+}


### PR DESCRIPTION
When a rule's methods are specified as `["*"]`, treat it as matching all HTTP methods instead of literally matching the string `"*"`. Adds an `isWildcard` helper to `CompileRules` and tests covering the wildcard, explicit, and empty method cases.