### PR TITLE
feat: support multiple secret sources with per-secret config

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,15 +239,16 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: OPENAI_API_KEY # Env var holding the real secret
+        - source:
+            type: env
+            var: OPENAI_API_KEY # Env var holding the real secret
           proxy_value: "proxy-token-123" # Token the sandbox sends
           match_headers: ["Authorization"]
           match_body: false
           require: true # Reject requests without the proxy token
-          hosts:
-            - name: "api.openai.com"
+          rules:
+            - host: "api.openai.com"
 
 log:
   level: "info" # debug, info, warn, error
@@ -571,19 +572,22 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: OPENAI_API_KEY
+        - source:
+            type: env
+            var: OPENAI_API_KEY
           proxy_value: "proxy-openai-abc123"
           match_headers: ["Authorization"]
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 
-        - var: INTERNAL_TOKEN
+        - source:
+            type: env
+            var: INTERNAL_TOKEN
           proxy_value: "proxy-internal-tok"
           match_headers: [] # scan all headers
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 ```
 
 The client script sends five requests to demonstrate each behavior:

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -356,7 +356,7 @@ func buildPipeline(transforms []config.Transform, bodyLimits transform.BodyLimit
 		if err != nil {
 			return nil, fmt.Errorf("unknown transform %q: %w", tc.Name, err)
 		}
-		t, err := factory(tc.Config)
+		t, err := factory(tc.Config, logger)
 		if err != nil {
 			return nil, fmt.Errorf("initializing transform %q: %w", tc.Name, err)
 		}

--- a/examples/docker-compose/proxy.yaml
+++ b/examples/docker-compose/proxy.yaml
@@ -24,21 +24,24 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: OPENAI_API_KEY
+        - source:
+            type: env
+            var: OPENAI_API_KEY
           proxy_value: "proxy-openai-abc123"
           match_headers: ["Authorization"]
           match_body: false
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 
-        - var: INTERNAL_TOKEN
+        - source:
+            type: env
+            var: INTERNAL_TOKEN
           proxy_value: "proxy-internal-tok"
           match_headers: []
           match_body: false
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 
 log:
   level: "info"

--- a/examples/nftables/proxy.yaml
+++ b/examples/nftables/proxy.yaml
@@ -24,21 +24,24 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: OPENAI_API_KEY
+        - source:
+            type: env
+            var: OPENAI_API_KEY
           proxy_value: "proxy-openai-abc123"
           match_headers: ["Authorization"]
           match_body: false
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 
-        - var: INTERNAL_TOKEN
+        - source:
+            type: env
+            var: INTERNAL_TOKEN
           proxy_value: "proxy-internal-tok"
           match_headers: []
           match_body: false
-          hosts:
-            - name: "httpbin.org"
+          rules:
+            - host: "httpbin.org"
 
 log:
   level: "info"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/miekg/dns v1.1.72
@@ -33,7 +34,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWUR
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5 h1:z2ayoK3pOvf8ODj/vPR0FgAS5ONruBq0F94SRoW/BIU=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5/go.mod h1:mpZB5HAl4ZIISod9qCi12xZ170TbHX9CCJV5y7nb7QU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=

--- a/internal/proxy/integration_grpc_test.go
+++ b/internal/proxy/integration_grpc_test.go
@@ -97,13 +97,14 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: TEST_SECRET
+        - source:
+            type: env
+            var: TEST_SECRET
           proxy_value: "proxy-token"
           match_headers: ["Authorization"]
-          hosts:
-            - name: "127.0.0.1"
+          rules:
+            - host: "127.0.0.1"
 
   - name: grpc
     config:

--- a/internal/transform/allowlist/allowlist.go
+++ b/internal/transform/allowlist/allowlist.go
@@ -4,6 +4,7 @@ package allowlist
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"gopkg.in/yaml.v3"
@@ -30,7 +31,7 @@ type allowlistConfig struct {
 	Warn    bool                   `yaml:"warn"`
 }
 
-func factory(cfg yaml.Node) (transform.Transformer, error) {
+func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	var c allowlistConfig
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing allowlist config: %w", err)

--- a/internal/transform/annotate/annotate.go
+++ b/internal/transform/annotate/annotate.go
@@ -5,6 +5,7 @@ package annotate
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"gopkg.in/yaml.v3"
@@ -37,7 +38,7 @@ type Annotate struct {
 	groups []compiledGroup
 }
 
-func factory(cfg yaml.Node) (transform.Transformer, error) {
+func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	var c annotateConfig
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing annotate config: %w", err)

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -51,7 +52,7 @@ type GRPCTransform struct {
 	client           transformv1.TransformServiceClient
 }
 
-func factory(cfg yaml.Node) (transform.Transformer, error) {
+func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	var c grpcConfig
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing grpc config: %w", err)

--- a/internal/transform/grpc/grpc_test.go
+++ b/internal/transform/grpc/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"testing"
@@ -326,7 +327,7 @@ send_request_body: true`, addr)
 	var node yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(cfgYAML), &node))
 
-	tr, err := f(*node.Content[0])
+	tr, err := f(*node.Content[0], slog.Default())
 	require.NoError(t, err)
 	require.Equal(t, "test-svc", tr.Name())
 }
@@ -338,7 +339,7 @@ func TestFactory_MissingName(t *testing.T) {
 	var node yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(`target: "localhost:9500"`), &node))
 
-	_, err = f(*node.Content[0])
+	_, err = f(*node.Content[0], slog.Default())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "name is required")
 }
@@ -350,7 +351,7 @@ func TestFactory_MissingTarget(t *testing.T) {
 	var node yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(`name: test`), &node))
 
-	_, err = f(*node.Content[0])
+	_, err = f(*node.Content[0], slog.Default())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "target is required")
 }
@@ -368,7 +369,7 @@ tls:
 	var node yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(cfgYAML), &node))
 
-	_, err = f(*node.Content[0])
+	_, err = f(*node.Content[0], slog.Default())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "both cert and key are required")
 }
@@ -386,7 +387,7 @@ tls:
 	var node yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(cfgYAML), &node))
 
-	_, err = f(*node.Content[0])
+	_, err = f(*node.Content[0], slog.Default())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "reading ca_cert")
 }

--- a/internal/transform/holder.go
+++ b/internal/transform/holder.go
@@ -23,7 +23,12 @@ func (h *PipelineHolder) Load() *Pipeline {
 	return h.p.Load()
 }
 
-// Store atomically replaces the current pipeline with next.
+// Store atomically replaces the current pipeline with next. The previous
+// pipeline is closed to release resources (background goroutines, connections).
 func (h *PipelineHolder) Store(next *Pipeline) {
-	h.p.Store(next)
+	old := h.p.Swap(next)
+	if old != nil {
+		// Best-effort close; errors are not actionable here.
+		_ = old.Close()
+	}
 }

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -150,6 +151,21 @@ func (p *Pipeline) BodyLimits() BodyLimits {
 // Empty returns true if the pipeline has no transforms.
 func (p *Pipeline) Empty() bool {
 	return len(p.transforms) == 0
+}
+
+// Close closes any transforms that implement io.Closer (e.g. to stop background
+// goroutines or release connections). Should be called when a pipeline is being
+// replaced.
+func (p *Pipeline) Close() error {
+	var firstErr error
+	for _, t := range p.transforms {
+		if c, ok := t.(io.Closer); ok {
+			if err := c.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
 }
 
 // Names returns the names of all transforms in the pipeline, for logging.

--- a/internal/transform/registry.go
+++ b/internal/transform/registry.go
@@ -2,13 +2,14 @@ package transform
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Factory creates a Transformer from a raw YAML config node.
-type Factory func(cfg yaml.Node) (Transformer, error)
+type Factory func(cfg yaml.Node, logger *slog.Logger) (Transformer, error)
 
 var (
 	registryMu sync.RWMutex

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -1,0 +1,254 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"gopkg.in/yaml.v3"
+)
+
+// secretResolver resolves a real secret value from a source configuration.
+// Each implementation defines and decodes its own config from the raw YAML node.
+type secretResolver interface {
+	// Resolve validates the source config and fetches the initial secret value.
+	// The returned ResolveResult includes a GetValue function that may lazily
+	// refresh the value (e.g., for sources with a TTL).
+	Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error)
+}
+
+// ResolveResult holds the resolved secret and a function to get its current value.
+type ResolveResult struct {
+	Name     string                                    // display name for logging
+	GetValue func(ctx context.Context) (string, error) // returns the current secret value
+}
+
+// sourceTypeHint is used to peek at the type field before dispatching to a resolver.
+type sourceTypeHint struct {
+	Type string `yaml:"type"`
+}
+
+// resolverRegistry maps source type names to their resolvers.
+type resolverRegistry map[string]secretResolver
+
+// --- env resolver ---
+
+// envResolver reads secrets from environment variables.
+type envResolver struct {
+	getenv func(string) string
+}
+
+type envConfig struct {
+	Type string `yaml:"type"`
+	Var  string `yaml:"var"`
+}
+
+func newEnvResolver() *envResolver {
+	return &envResolver{getenv: os.Getenv}
+}
+
+func (r *envResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+	var cfg envConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing env source config: %w", err)
+	}
+	if cfg.Var == "" {
+		return ResolveResult{}, fmt.Errorf("env source requires \"var\" field")
+	}
+	val := r.getenv(cfg.Var)
+	if val == "" {
+		return ResolveResult{}, fmt.Errorf("env var %q is not set or empty", cfg.Var)
+	}
+	return ResolveResult{
+		Name:     cfg.Var,
+		GetValue: staticValue(val),
+	}, nil
+}
+
+// staticValue returns a GetValue function that always returns the same value.
+func staticValue(val string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return val, nil }
+}
+
+// --- AWS Secrets Manager resolver ---
+
+// smClient is the subset of the AWS Secrets Manager API used by awsSMResolver.
+type smClient interface {
+	GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// awsSMResolver reads secrets from AWS Secrets Manager.
+type awsSMResolver struct {
+	mu        sync.Mutex
+	clients   map[string]smClient
+	clientFor func(ctx context.Context, region string) (smClient, error)
+	logger    *slog.Logger
+}
+
+type awsSMConfig struct {
+	Type     string `yaml:"type"`
+	SecretID string `yaml:"secret_id"`
+	Region   string `yaml:"region,omitempty"`
+	JSONKey  string `yaml:"json_key,omitempty"`
+	TTL      string `yaml:"ttl,omitempty"`
+}
+
+func newAWSSMResolver(logger *slog.Logger) *awsSMResolver {
+	r := &awsSMResolver{
+		clients: make(map[string]smClient),
+		logger:  logger,
+	}
+	r.clientFor = r.defaultClientFor
+	return r
+}
+
+func (r *awsSMResolver) defaultClientFor(ctx context.Context, region string) (smClient, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c, ok := r.clients[region]; ok {
+		return c, nil
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	c := secretsmanager.NewFromConfig(cfg)
+	r.clients[region] = c
+	return c, nil
+}
+
+func (r *awsSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+	var cfg awsSMConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing aws_sm source config: %w", err)
+	}
+	if cfg.SecretID == "" {
+		return ResolveResult{}, fmt.Errorf("aws_sm source requires \"secret_id\" field")
+	}
+
+	// Fetch initial value to validate config eagerly at startup.
+	val, err := r.fetchSecret(ctx, cfg)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+
+	var ttl time.Duration
+	if cfg.TTL != "" {
+		ttl, err = time.ParseDuration(cfg.TTL)
+		if err != nil {
+			return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
+		}
+	}
+
+	var getValue func(context.Context) (string, error)
+	if ttl > 0 {
+		cv := &cachedValue{
+			value:     val,
+			expiresAt: time.Now().Add(ttl),
+			ttl:       ttl,
+			logger:    r.logger,
+			name:      cfg.SecretID,
+			refresh: func(ctx context.Context) (string, error) {
+				return r.fetchSecret(ctx, cfg)
+			},
+		}
+		getValue = cv.get
+	} else {
+		getValue = staticValue(val)
+	}
+
+	return ResolveResult{Name: cfg.SecretID, GetValue: getValue}, nil
+}
+
+func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
+	client, err := r.clientFor(ctx, cfg.Region)
+	if err != nil {
+		return "", fmt.Errorf("creating AWS SM client: %w", err)
+	}
+	out, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(cfg.SecretID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("fetching secret %q: %w", cfg.SecretID, err)
+	}
+	val := aws.ToString(out.SecretString)
+	if cfg.JSONKey != "" {
+		val, err = extractJSONKey(val, cfg.JSONKey)
+		if err != nil {
+			return "", fmt.Errorf("extracting json_key %q from secret %q: %w", cfg.JSONKey, cfg.SecretID, err)
+		}
+	}
+	if val == "" {
+		return "", fmt.Errorf("secret %q resolved to empty value", cfg.SecretID)
+	}
+	return val, nil
+}
+
+// --- cached value (lazy TTL refresh) ---
+
+// cachedValue wraps a secret value with lazy TTL-based refresh. When get() is
+// called and the value has expired, it re-fetches inline. On refresh failure,
+// the stale value is returned and the error is logged.
+type cachedValue struct {
+	mu        sync.Mutex
+	value     string
+	expiresAt time.Time
+	ttl       time.Duration
+	logger    *slog.Logger
+	name      string
+	refresh   func(ctx context.Context) (string, error)
+}
+
+func (cv *cachedValue) get(ctx context.Context) (string, error) {
+	cv.mu.Lock()
+	defer cv.mu.Unlock()
+
+	if time.Now().Before(cv.expiresAt) {
+		return cv.value, nil
+	}
+
+	val, err := cv.refresh(ctx)
+	if err != nil {
+		cv.logger.Warn("failed to refresh secret, serving stale value",
+			"secret", cv.name,
+			"error", err,
+		)
+		// Retry again after half the TTL to avoid hammering on every request.
+		cv.expiresAt = time.Now().Add(cv.ttl / 2)
+		return cv.value, nil
+	}
+
+	cv.value = val
+	cv.expiresAt = time.Now().Add(cv.ttl)
+	return cv.value, nil
+}
+
+// --- JSON extraction ---
+
+// extractJSONKey parses raw as JSON and returns the string value at key.
+func extractJSONKey(raw, key string) (string, error) {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return "", fmt.Errorf("secret value is not valid JSON: %w", err)
+	}
+	v, ok := m[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in JSON", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("key %q is not a string (type %T)", key, v)
+	}
+	return s, nil
+}

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -1,0 +1,268 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// yamlNode marshals v to YAML and returns the resulting yaml.Node.
+func yamlNode(t *testing.T, v any) yaml.Node {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal(data, &node))
+	// yaml.Unmarshal wraps in a document node; return the first content node.
+	return *node.Content[0]
+}
+
+// --- envResolver tests ---
+
+func TestEnvResolver_HappyPath(t *testing.T) {
+	r := &envResolver{getenv: func(key string) string {
+		if key == "MY_SECRET" {
+			return "real-value"
+		}
+		return ""
+	}}
+	node := yamlNode(t, map[string]string{"type": "env", "var": "MY_SECRET"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "MY_SECRET", result.Name)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "real-value", val)
+}
+
+func TestEnvResolver_MissingVar(t *testing.T) {
+	r := &envResolver{getenv: func(string) string { return "" }}
+	node := yamlNode(t, map[string]string{"type": "env"})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "\"var\" field")
+}
+
+func TestEnvResolver_EmptyValue(t *testing.T) {
+	r := &envResolver{getenv: func(string) string { return "" }}
+	node := yamlNode(t, map[string]string{"type": "env", "var": "EMPTY_VAR"})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not set or empty")
+}
+
+// --- awsSMResolver tests ---
+
+type mockSMClient struct {
+	out *secretsmanager.GetSecretValueOutput
+	err error
+}
+
+func (m *mockSMClient) GetSecretValue(_ context.Context, _ *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.out, m.err
+}
+
+func newTestAWSSMResolver(client smClient) *awsSMResolver {
+	r := &awsSMResolver{
+		clients: make(map[string]smClient),
+		logger:  slog.Default(),
+	}
+	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
+		return client, nil
+	}
+	return r
+}
+
+func TestAWSSMResolver_PlainString(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("my-secret-value"),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:aws:sm:us-east-1:123:secret:foo"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "arn:aws:sm:us-east-1:123:secret:foo", result.Name)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "my-secret-value", val)
+}
+
+func TestAWSSMResolver_JSONKey(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(`{"api_key": "sk-abc123", "other": "val"}`),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:aws:sm:us-east-1:123:secret:foo",
+		"json_key":  "api_key",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "sk-abc123", val)
+}
+
+func TestAWSSMResolver_TTLReturnsCachedValue(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("value"),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:aws:sm:us-east-1:123:secret:foo",
+		"ttl":       "15m",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+
+	// GetValue should return cached value without re-fetching.
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}
+
+func TestAWSSMResolver_MissingSecretID(t *testing.T) {
+	r := newTestAWSSMResolver(&mockSMClient{})
+	node := yamlNode(t, map[string]string{"type": "aws_sm"})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "\"secret_id\" field")
+}
+
+func TestAWSSMResolver_AWSError(t *testing.T) {
+	client := &mockSMClient{err: fmt.Errorf("access denied")}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:foo"})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "access denied")
+}
+
+func TestAWSSMResolver_EmptySecretValue(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(""),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:foo"})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty value")
+}
+
+func TestAWSSMResolver_InvalidTTL(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("value"),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:foo",
+		"ttl":       "not-a-duration",
+	})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parsing ttl")
+}
+
+// --- extractJSONKey tests ---
+
+func TestExtractJSONKey_Valid(t *testing.T) {
+	val, err := extractJSONKey(`{"key": "value", "other": "data"}`, "key")
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}
+
+func TestExtractJSONKey_InvalidJSON(t *testing.T) {
+	_, err := extractJSONKey(`not json`, "key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestExtractJSONKey_MissingKey(t *testing.T) {
+	_, err := extractJSONKey(`{"other": "value"}`, "key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestExtractJSONKey_NonStringValue(t *testing.T) {
+	_, err := extractJSONKey(`{"key": 42}`, "key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a string")
+}
+
+func TestAWSSMResolver_JSONKeyInvalidJSON(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("not-json"),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:foo",
+		"json_key":  "api_key",
+	})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestAWSSMResolver_JSONKeyMissing(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(`{"other": "value"}`),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:foo",
+		"json_key":  "api_key",
+	})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestAWSSMResolver_JSONKeyNonString(t *testing.T) {
+	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(`{"api_key": 123}`),
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":      "aws_sm",
+		"secret_id": "arn:foo",
+		"json_key":  "api_key",
+	})
+	_, err := r.Resolve(context.Background(), node)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a string")
+}
+
+// --- cachedValue tests ---
+
+func TestCachedValue_ServesStaleOnError(t *testing.T) {
+	calls := 0
+	cv := &cachedValue{
+		value:     "initial",
+		ttl:       1, // expired immediately
+		logger:    slog.Default(),
+		name:      "test",
+		refresh: func(_ context.Context) (string, error) {
+			calls++
+			return "", fmt.Errorf("aws error")
+		},
+	}
+
+	val, err := cv.get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "initial", val)
+	require.Equal(t, 1, calls)
+}

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -8,10 +8,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -25,33 +26,27 @@ func init() {
 
 // secretsConfig is the YAML config structure.
 type secretsConfig struct {
-	Source  string        `yaml:"source"`
 	Secrets []secretEntry `yaml:"secrets"`
 }
 
 type secretEntry struct {
-	Var          string      `yaml:"var"`
-	ProxyValue   string      `yaml:"proxy_value"`
-	MatchHeaders []string    `yaml:"match_headers"`
-	MatchBody    bool        `yaml:"match_body"`
-	Require      bool        `yaml:"require"`
-	Hosts        []hostMatch `yaml:"hosts"`
+	Source       yaml.Node              `yaml:"source"`
+	ProxyValue   string                 `yaml:"proxy_value"`
+	MatchHeaders []string               `yaml:"match_headers"`
+	MatchBody    bool                   `yaml:"match_body"`
+	Require      bool                   `yaml:"require"`
+	Rules        []hostmatch.RuleConfig `yaml:"rules"`
 }
 
-type hostMatch struct {
-	Name string `yaml:"name,omitempty"`
-	CIDR string `yaml:"cidr,omitempty"`
-}
-
-// resolvedSecret is a secret ready for use after config parsing and env lookup.
+// resolvedSecret is a secret ready for use after config parsing and source resolution.
 type resolvedSecret struct {
-	name         string // env var name, for logging/metrics
+	name         string // source name, for logging/metrics
 	proxyValue   string
-	realValue    string
+	getValue     func(ctx context.Context) (string, error)
 	matchHeaders []string // empty = all headers
 	matchBody    bool
 	require      bool
-	matcher      *hostmatch.Matcher
+	rules        []hostmatch.Rule
 }
 
 // Secrets is the transform that swaps proxy tokens for real secrets.
@@ -59,63 +54,61 @@ type Secrets struct {
 	secrets []resolvedSecret
 }
 
-// envLookup is the function used to read environment variables.
-// Overridable in tests.
-var envLookup = os.Getenv
-
-func factory(cfg yaml.Node) (transform.Transformer, error) {
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
 	var c secretsConfig
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
-	return newFromConfig(c, envLookup)
+	registry := resolverRegistry{
+		"env":    newEnvResolver(),
+		"aws_sm": newAWSSMResolver(logger),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return newFromConfig(ctx, c, registry)
 }
 
-// newFromConfig creates a Secrets transform from a parsed config, using the
-// given env lookup function. Exported-via-test only.
-func newFromConfig(cfg secretsConfig, getenv func(string) string) (*Secrets, error) {
-	if cfg.Source != "env" {
-		return nil, fmt.Errorf("unsupported secrets source: %q (only \"env\" is supported)", cfg.Source)
-	}
-
+// newFromConfig creates a Secrets transform from a parsed config.
+func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegistry) (*Secrets, error) {
 	resolved := make([]resolvedSecret, 0, len(cfg.Secrets))
+
 	for i, entry := range cfg.Secrets {
 		if entry.ProxyValue == "" {
-			return nil, fmt.Errorf("secrets[%d] (%s): proxy_value is required", i, entry.Var)
+			return nil, fmt.Errorf("secrets[%d]: proxy_value is required", i)
 		}
 
-		realValue := getenv(entry.Var)
-		if realValue == "" {
-			return nil, fmt.Errorf("secrets[%d]: env var %q is not set or empty", i, entry.Var)
+		// Peek at source type to dispatch to the right resolver.
+		var hint sourceTypeHint
+		if err := entry.Source.Decode(&hint); err != nil {
+			return nil, fmt.Errorf("secrets[%d]: parsing source type: %w", i, err)
+		}
+		if hint.Type == "" {
+			return nil, fmt.Errorf("secrets[%d]: source.type is required", i)
 		}
 
-		var domains []string
-		var cidrs []string
-		for _, h := range entry.Hosts {
-			if h.Name != "" {
-				domains = append(domains, h.Name)
-			}
-			if h.CIDR != "" {
-				cidrs = append(cidrs, h.CIDR)
-			}
+		resolver, ok := registry[hint.Type]
+		if !ok {
+			return nil, fmt.Errorf("secrets[%d]: unsupported source type %q", i, hint.Type)
 		}
 
-		// Host matching doesn't need DNS resolution for the secrets transform —
-		// we only match against the request Host header, not resolved IPs,
-		// unless CIDRs are configured.
-		matcher, err := hostmatch.New(domains, cidrs, hostmatch.NullResolver{})
+		result, err := resolver.Resolve(ctx, entry.Source)
 		if err != nil {
-			return nil, fmt.Errorf("secrets[%d] (%s): %w", i, entry.Var, err)
+			return nil, fmt.Errorf("secrets[%d]: %w", i, err)
+		}
+
+		rules, err := hostmatch.CompileRules(entry.Rules, hostmatch.NullResolver{}, fmt.Sprintf("secrets[%d]", i))
+		if err != nil {
+			return nil, err
 		}
 
 		resolved = append(resolved, resolvedSecret{
-			name:         entry.Var,
+			name:         result.Name,
 			proxyValue:   entry.ProxyValue,
-			realValue:    realValue,
+			getValue:     result.GetValue,
 			matchHeaders: entry.MatchHeaders,
 			matchBody:    entry.MatchBody,
 			require:      entry.Require,
-			matcher:      matcher,
+			rules:        rules,
 		})
 	}
 
@@ -125,8 +118,6 @@ func newFromConfig(cfg secretsConfig, getenv func(string) string) (*Secrets, err
 func (s *Secrets) Name() string { return "secrets" }
 
 func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
-	host := hostmatch.StripPort(req.Host)
-
 	type swapRecord struct {
 		Secret    string   `json:"secret"`
 		Locations []string `json:"locations"`
@@ -134,16 +125,21 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	var swapped []swapRecord
 
 	for _, sec := range s.secrets {
-		if !sec.matcher.Matches(ctx, host) {
+		if !hostmatch.MatchAnyRule(ctx, sec.rules, req) {
 			continue
 		}
 
+		realValue, err := sec.getValue(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolving secret %q: %w", sec.name, err)
+		}
+
 		var locations []string
-		locations = append(locations, s.swapHeaders(req, &sec)...)
-		locations = append(locations, s.swapQuery(req, &sec)...)
+		locations = append(locations, s.swapHeaders(req, &sec, realValue)...)
+		locations = append(locations, s.swapQuery(req, &sec, realValue)...)
 
 		if sec.matchBody {
-			if loc := s.swapBody(req, &sec); loc != "" {
+			if loc := s.swapBody(req, &sec, realValue); loc != "" {
 				locations = append(locations, loc)
 			}
 		}
@@ -167,7 +163,7 @@ func (s *Secrets) TransformResponse(_ context.Context, _ *transform.TransformCon
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }
 
-func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret) []string {
+func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue string) []string {
 	var locations []string
 	if len(sec.matchHeaders) > 0 {
 		for _, name := range sec.matchHeaders {
@@ -180,7 +176,7 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret) []string {
 				}
 				req.Header.Del(name)
 				for _, v := range vals {
-					req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, sec.realValue))
+					req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, realValue))
 				}
 			}
 		}
@@ -188,7 +184,7 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret) []string {
 		for name, vals := range req.Header {
 			for i, v := range vals {
 				if headerContains(name, v, sec.proxyValue) {
-					req.Header[name][i] = replaceInHeader(name, v, sec.proxyValue, sec.realValue)
+					req.Header[name][i] = replaceInHeader(name, v, sec.proxyValue, realValue)
 					locations = append(locations, "header:"+name)
 				}
 			}
@@ -236,7 +232,7 @@ func decodeBasicAuth(value string) (string, bool) {
 	return string(decoded), true
 }
 
-func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret) []string {
+func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret, realValue string) []string {
 	raw := req.URL.RawQuery
 	if raw == "" || !strings.Contains(raw, sec.proxyValue) {
 		return nil
@@ -251,7 +247,7 @@ func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret) []string {
 	for key, vals := range params {
 		for i, v := range vals {
 			if strings.Contains(v, sec.proxyValue) {
-				params[key][i] = strings.ReplaceAll(v, sec.proxyValue, sec.realValue)
+				params[key][i] = strings.ReplaceAll(v, sec.proxyValue, realValue)
 				locations = append(locations, "query:"+key)
 			}
 		}
@@ -263,7 +259,7 @@ func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret) []string {
 	return locations
 }
 
-func (s *Secrets) swapBody(req *http.Request, sec *resolvedSecret) string {
+func (s *Secrets) swapBody(req *http.Request, sec *resolvedSecret, realValue string) string {
 	if req.Body == nil {
 		return ""
 	}
@@ -277,7 +273,7 @@ func (s *Secrets) swapBody(req *http.Request, sec *resolvedSecret) string {
 		return ""
 	}
 
-	replaced := bytes.ReplaceAll(data, []byte(sec.proxyValue), []byte(sec.realValue))
+	replaced := bytes.ReplaceAll(data, []byte(sec.proxyValue), []byte(realValue))
 	req.Body = transform.NewBufferedBodyFromBytes(replaced)
 	return "body"
 }

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -3,13 +3,18 @@ package secrets
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -667,5 +672,229 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 
 	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
 	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
+}
+
+// --- End-to-end tests with real awsSMResolver and mock AWS client ---
+
+// mockSMClientForTest wraps a function so we can change behavior between calls.
+type mockSMClientForTest struct {
+	fn func(ctx context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (m *mockSMClientForTest) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.fn(ctx, input)
+}
+
+func awsSMRegistry(client smClient) resolverRegistry {
+	r := &awsSMResolver{
+		clients: make(map[string]smClient),
+		logger:  slog.Default(),
+	}
+	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
+		return client, nil
+	}
+	return resolverRegistry{"aws_sm": r}
+}
+
+func TestAWSSM_EndToEnd_HeaderSwap(t *testing.T) {
+	client := &mockSMClientForTest{fn: func(_ context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		require.Equal(t, "arn:aws:sm:us-east-1:123:secret:openai", aws.ToString(input.SecretId))
+		return &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String("sk-real-openai-key"),
+		}, nil
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source:       yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:aws:sm:us-east-1:123:secret:openai"}),
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestAWSSM_EndToEnd_JSONKey(t *testing.T) {
+	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		return &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String(`{"api_key": "sk-from-json", "other": "ignored"}`),
+		}, nil
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source: yamlNode(t, map[string]string{
+			"type":      "aws_sm",
+			"secret_id": "arn:aws:sm:us-east-1:123:secret:multi",
+			"json_key":  "api_key",
+		}),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{"X-Api-Key"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1/data", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("X-Api-Key", "proxy-tok")
+
+	doTransform(t, s, req)
+	require.Equal(t, "sk-from-json", req.Header.Get("X-Api-Key"))
+}
+
+func TestAWSSM_EndToEnd_BodySwap(t *testing.T) {
+	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		return &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String("real-secret"),
+		}, nil
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source:     yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
+		ProxyValue: "proxy-tok",
+		MatchBody:  true,
+		Rules:      []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+
+	body := `{"key": "proxy-tok"}`
+	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
+	req := httptest.NewRequest("POST", "http://api.example.com/v1/data", nil)
+	req.Host = "api.example.com"
+	req.Body = rb
+
+	doTransform(t, s, req)
+
+	result, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(result), "real-secret")
+	require.NotContains(t, string(result), "proxy-tok")
+}
+
+func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
+	var callCount atomic.Int32
+	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		n := callCount.Add(1)
+		// Return a different value each call so we can observe the refresh.
+		return &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String(fmt.Sprintf("value-%d", n)),
+		}, nil
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source: yamlNode(t, map[string]string{
+			"type":      "aws_sm",
+			"secret_id": "arn:test",
+			"ttl":       "1ns", // expires immediately so each request triggers refresh
+		}),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+	// Initial resolve is call 1 (value-1).
+
+	// First request: TTL=1ns is already expired, so this triggers a refresh (call 2).
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer value-2", req.Header.Get("Authorization"))
+
+	// Second request: triggers another refresh (call 3).
+	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer value-3", req.Header.Get("Authorization"))
+
+	require.GreaterOrEqual(t, callCount.Load(), int32(3))
+}
+
+func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
+	var callCount atomic.Int32
+	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		n := callCount.Add(1)
+		// First call (initial resolve at startup) succeeds.
+		if n == 1 {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("good-value"),
+			}, nil
+		}
+		// All subsequent refresh attempts fail.
+		return nil, fmt.Errorf("aws transient error")
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source: yamlNode(t, map[string]string{
+			"type":      "aws_sm",
+			"secret_id": "arn:test",
+			"ttl":       "1ns",
+		}),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), callCount.Load()) // initial resolve
+
+	// First request: TTL expired, refresh fails, stale "good-value" served.
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer good-value", req.Header.Get("Authorization"))
+
+	// Second request: same — refresh fails again, stale value still served.
+	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer good-value", req.Header.Get("Authorization"))
+
+	// At least 2 refresh attempts beyond the initial resolve.
+	require.GreaterOrEqual(t, callCount.Load(), int32(3))
+}
+
+func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
+	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		return &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String("real-secret"),
+		}, nil
+	}}
+
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source:       yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{"Authorization"},
+		Require:      true,
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer wrong-token")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
 }
 

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -11,29 +11,67 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
+// fakeResolver is a test secretResolver that returns preconfigured values.
+type fakeResolver struct {
+	secrets map[string]string // keyed by env var name or secret ID
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+	// Try env config first, then aws_sm config.
+	var env envConfig
+	if err := raw.Decode(&env); err == nil && env.Var != "" {
+		val, ok := f.secrets[env.Var]
+		if !ok || val == "" {
+			return ResolveResult{}, &resolveError{env.Var}
+		}
+		return ResolveResult{Name: env.Var, GetValue: staticValue(val)}, nil
+	}
+	var sm awsSMConfig
+	if err := raw.Decode(&sm); err == nil && sm.SecretID != "" {
+		val, ok := f.secrets[sm.SecretID]
+		if !ok || val == "" {
+			return ResolveResult{}, &resolveError{sm.SecretID}
+		}
+		return ResolveResult{Name: sm.SecretID, GetValue: staticValue(val)}, nil
+	}
+	return ResolveResult{}, &resolveError{"unknown"}
+}
+
+type resolveError struct{ name string }
+
+func (e *resolveError) Error() string { return e.name + " not found" }
+
+func testRegistry() resolverRegistry {
+	return resolverRegistry{
+		"env": &fakeResolver{secrets: map[string]string{
+			"OPENAI_API_KEY":    "sk-real-openai-key",
+			"ANTHROPIC_API_KEY": "sk-real-anthropic-key",
+			"INTERNAL_TOKEN":    "real-internal-token",
+		}},
+		"aws_sm": &fakeResolver{secrets: map[string]string{
+			"arn:aws:sm:test": "aws-secret-value",
+		}},
+	}
+}
+
+func envSource(varName string) yaml.Node {
+	return yamlNode(&testing.T{}, map[string]string{"type": "env", "var": varName})
+}
+
+func awsSMSource(secretID string) yaml.Node {
+	return yamlNode(&testing.T{}, map[string]string{"type": "aws_sm", "secret_id": secretID})
+}
+
 func makeSecrets(t *testing.T, entries []secretEntry) *Secrets {
 	t.Helper()
-	cfg := secretsConfig{
-		Source:  "env",
-		Secrets: entries,
-	}
-	getenv := func(key string) string {
-		switch key {
-		case "OPENAI_API_KEY":
-			return "sk-real-openai-key"
-		case "ANTHROPIC_API_KEY":
-			return "sk-real-anthropic-key"
-		case "INTERNAL_TOKEN":
-			return "real-internal-token"
-		default:
-			return ""
-		}
-	}
-	s, err := newFromConfig(cfg, getenv)
+	cfg := secretsConfig{Secrets: entries}
+	s, err := newFromConfig(context.Background(), cfg, testRegistry())
 	require.NoError(t, err)
 	return s
 }
@@ -47,10 +85,10 @@ func doTransform(t *testing.T, s *Secrets, req *http.Request) {
 
 func TestSecrets_HeaderSwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
@@ -64,9 +102,9 @@ func TestSecrets_HeaderSwap(t *testing.T) {
 
 func TestSecrets_QueryParamSwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:        "OPENAI_API_KEY",
+		Source:     envSource("OPENAI_API_KEY"),
 		ProxyValue: "proxy-openai-abc123",
-		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat?token=proxy-openai-abc123&other=value", nil)
@@ -81,10 +119,10 @@ func TestSecrets_QueryParamSwap(t *testing.T) {
 
 func TestSecrets_BodySwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:        "OPENAI_API_KEY",
+		Source:     envSource("OPENAI_API_KEY"),
 		ProxyValue: "proxy-openai-abc123",
 		MatchBody:  true,
-		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	body := `{"api_key": "proxy-openai-abc123", "model": "gpt-4"}`
@@ -106,10 +144,10 @@ func TestSecrets_BodySwap(t *testing.T) {
 
 func TestSecrets_HostMatch(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
@@ -122,10 +160,10 @@ func TestSecrets_HostMatch(t *testing.T) {
 
 func TestSecrets_HostNoMatch(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://evil.com/steal", nil)
@@ -140,10 +178,10 @@ func TestSecrets_HostNoMatch(t *testing.T) {
 
 func TestSecrets_WildcardHost(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "ANTHROPIC_API_KEY",
+		Source:       envSource("ANTHROPIC_API_KEY"),
 		ProxyValue:   "proxy-anthropic-xyz789",
 		MatchHeaders: []string{"X-Api-Key"},
-		Hosts:        []hostMatch{{Name: "*.anthropic.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "*.anthropic.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.anthropic.com/v1/messages", nil)
@@ -157,16 +195,16 @@ func TestSecrets_WildcardHost(t *testing.T) {
 func TestSecrets_MultipleSecrets(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{
 		{
-			Var:          "OPENAI_API_KEY",
+			Source:       envSource("OPENAI_API_KEY"),
 			ProxyValue:   "proxy-openai-abc123",
 			MatchHeaders: []string{"Authorization"},
-			Hosts:        []hostMatch{{Name: "api.openai.com"}},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 		},
 		{
-			Var:          "INTERNAL_TOKEN",
+			Source:       envSource("INTERNAL_TOKEN"),
 			ProxyValue:   "proxy-internal-tok",
 			MatchHeaders: []string{"X-Internal"},
-			Hosts:        []hostMatch{{Name: "api.openai.com"}},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 		},
 	})
 
@@ -183,10 +221,10 @@ func TestSecrets_MultipleSecrets(t *testing.T) {
 
 func TestSecrets_MatchHeadersFiltering(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
@@ -203,10 +241,10 @@ func TestSecrets_MatchHeadersFiltering(t *testing.T) {
 
 func TestSecrets_EmptyMatchHeadersSearchesAll(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{}, // empty = all headers
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
@@ -222,53 +260,64 @@ func TestSecrets_EmptyMatchHeadersSearchesAll(t *testing.T) {
 
 func TestSecrets_MissingEnvVar(t *testing.T) {
 	cfg := secretsConfig{
-		Source: "env",
 		Secrets: []secretEntry{{
-			Var:        "NONEXISTENT_VAR",
+			Source:     envSource("NONEXISTENT_VAR"),
 			ProxyValue: "proxy-value",
-			Hosts:      []hostMatch{{Name: "example.com"}},
+			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
 		}},
 	}
-	getenv := func(string) string { return "" }
-
-	_, err := newFromConfig(cfg, getenv)
+	_, err := newFromConfig(context.Background(), cfg, testRegistry())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "NONEXISTENT_VAR")
-	require.Contains(t, err.Error(), "not set or empty")
 }
 
 func TestSecrets_EmptyProxyValue(t *testing.T) {
 	cfg := secretsConfig{
-		Source: "env",
 		Secrets: []secretEntry{{
-			Var:        "OPENAI_API_KEY",
+			Source:     envSource("OPENAI_API_KEY"),
 			ProxyValue: "",
-			Hosts:      []hostMatch{{Name: "example.com"}},
+			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
 		}},
 	}
-	getenv := func(string) string { return "real-value" }
-
-	_, err := newFromConfig(cfg, getenv)
+	_, err := newFromConfig(context.Background(), cfg, testRegistry())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "proxy_value is required")
 }
 
-func TestSecrets_UnsupportedSource(t *testing.T) {
+func TestSecrets_UnsupportedSourceType(t *testing.T) {
+	node := yamlNode(t, map[string]string{"type": "vault"})
 	cfg := secretsConfig{
-		Source:  "vault",
-		Secrets: nil,
+		Secrets: []secretEntry{{
+			Source:     node,
+			ProxyValue: "proxy-value",
+			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+		}},
 	}
-	_, err := newFromConfig(cfg, func(string) string { return "" })
+	_, err := newFromConfig(context.Background(), cfg, testRegistry())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported secrets source")
+	require.Contains(t, err.Error(), "unsupported source type")
+}
+
+func TestSecrets_MissingSourceType(t *testing.T) {
+	node := yamlNode(t, map[string]string{"var": "FOO"})
+	cfg := secretsConfig{
+		Secrets: []secretEntry{{
+			Source:     node,
+			ProxyValue: "proxy-value",
+			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+		}},
+	}
+	_, err := newFromConfig(context.Background(), cfg, testRegistry())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "source.type is required")
 }
 
 func TestSecrets_BodyTooLarge(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:        "OPENAI_API_KEY",
+		Source:     envSource("OPENAI_API_KEY"),
 		ProxyValue: "proxy-openai-abc123",
 		MatchBody:  true,
-		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Create a body larger than the max (1 MiB)
@@ -281,19 +330,14 @@ func TestSecrets_BodyTooLarge(t *testing.T) {
 
 	// Should not error — just skip body substitution
 	doTransform(t, s, req)
-
-	// Body should be unchanged (not buffered, so reads from original)
-	// The BufferedBody couldn't buffer, so reading it gives nothing useful
-	// since the original reader was partially consumed by the Buffer attempt.
-	// The key assertion is that the transform didn't error or reject.
 }
 
 func TestSecrets_HostWithPort(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com:443/v1/chat", nil)
@@ -307,9 +351,9 @@ func TestSecrets_HostWithPort(t *testing.T) {
 
 func TestSecrets_ResponseIsNoop(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:        "OPENAI_API_KEY",
+		Source:     envSource("OPENAI_API_KEY"),
 		ProxyValue: "proxy-openai-abc123",
-		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
@@ -321,10 +365,10 @@ func TestSecrets_ResponseIsNoop(t *testing.T) {
 
 func TestSecrets_ConcurrentSafety(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	var wg sync.WaitGroup
@@ -346,10 +390,10 @@ func TestSecrets_ConcurrentSafety(t *testing.T) {
 
 func TestSecrets_BasicAuthSwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Basic auth: "user:proxy-openai-abc123" base64-encoded
@@ -369,10 +413,10 @@ func TestSecrets_BasicAuthSwap(t *testing.T) {
 
 func TestSecrets_BasicAuthNoMatch(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Basic auth with no proxy token inside
@@ -389,10 +433,10 @@ func TestSecrets_BasicAuthNoMatch(t *testing.T) {
 
 func TestSecrets_BasicAuthAllHeaders(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{}, // all headers
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	creds := base64.StdEncoding.EncodeToString([]byte("proxy-openai-abc123:secret"))
@@ -410,10 +454,10 @@ func TestSecrets_BasicAuthAllHeaders(t *testing.T) {
 
 func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{}, // all headers
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// "Basic <base64>" on a non-Authorization header should not be decoded
@@ -430,11 +474,11 @@ func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
 
 func TestSecrets_RequireRejectsWithoutProxyToken(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		Require:      true,
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Request to matching host but with a different credential — should be rejected.
@@ -449,11 +493,11 @@ func TestSecrets_RequireRejectsWithoutProxyToken(t *testing.T) {
 
 func TestSecrets_RequireContinuesWithProxyToken(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		Require:      true,
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
@@ -466,11 +510,11 @@ func TestSecrets_RequireContinuesWithProxyToken(t *testing.T) {
 
 func TestSecrets_RequireDefaultFalseAllowsThrough(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		// Require defaults to false
-		Hosts: []hostMatch{{Name: "api.openai.com"}},
+		Rules: []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Request without proxy token — should still pass (require is false).
@@ -484,11 +528,11 @@ func TestSecrets_RequireDefaultFalseAllowsThrough(t *testing.T) {
 
 func TestSecrets_RequireNonMatchingHostAllowsThrough(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		Require:      true,
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Request to a different host — host doesn't match, so require doesn't apply.
@@ -502,11 +546,11 @@ func TestSecrets_RequireNonMatchingHostAllowsThrough(t *testing.T) {
 
 func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:          "OPENAI_API_KEY",
+		Source:       envSource("OPENAI_API_KEY"),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		Require:      true,
-		Hosts:        []hostMatch{{Name: "api.openai.com"}},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	// Request to matching host with no Authorization header at all.
@@ -520,11 +564,11 @@ func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
 
 func TestSecrets_RequireWithBodySwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{{
-		Var:        "OPENAI_API_KEY",
+		Source:     envSource("OPENAI_API_KEY"),
 		ProxyValue: "proxy-openai-abc123",
 		MatchBody:  true,
 		Require:    true,
-		Hosts:      []hostMatch{{Name: "api.openai.com"}},
+		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 	}})
 
 	body := `{"api_key": "proxy-openai-abc123"}`
@@ -545,3 +589,83 @@ func TestSecrets_Name(t *testing.T) {
 	s := makeSecrets(t, nil)
 	require.Equal(t, "secrets", s.Name())
 }
+
+// --- New tests for rules matching and mixed sources ---
+
+func TestSecrets_MethodFiltering(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Source:       envSource("OPENAI_API_KEY"),
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com", Methods: []string{"POST"}}},
+	}})
+
+	// GET request should NOT match the rule
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer proxy-openai-abc123", req.Header.Get("Authorization"))
+
+	// POST request should match
+	req = httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_PathFiltering(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Source:       envSource("OPENAI_API_KEY"),
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com", Paths: []string{"/v1/*"}}},
+	}})
+
+	// Path outside /v1/* should NOT match
+	req := httptest.NewRequest("GET", "http://api.openai.com/v2/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer proxy-openai-abc123", req.Header.Get("Authorization"))
+
+	// Path inside /v1/* should match
+	req = httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_MixedSourceTypes(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{
+		{
+			Source:       envSource("OPENAI_API_KEY"),
+			ProxyValue:   "proxy-openai-abc123",
+			MatchHeaders: []string{"Authorization"},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		},
+		{
+			Source:       awsSMSource("arn:aws:sm:test"),
+			ProxyValue:   "proxy-aws-tok",
+			MatchHeaders: []string{"X-Api-Key"},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+	req.Host = "api.openai.com"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+	req.Header.Set("X-Api-Key", "proxy-aws-tok")
+
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
+}
+

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -61,9 +61,10 @@ transforms:
 
   - name: secrets
     config:
-      source: env
       secrets:
-        - var: OPENAI_API_KEY
+        - source:
+            type: env
+            var: OPENAI_API_KEY
           proxy_value: "proxy-token-123"
           match_headers: ["Authorization"]
           match_body: false
@@ -71,8 +72,24 @@ transforms:
           # token are rejected (403). Prevents workloads from bypassing the
           # secret-swap mechanism with alternative credentials.
           require: true
-          hosts:
-            - name: "api.openai.com"
+          rules:
+            - host: "api.openai.com"
+              methods: ["POST"]
+              paths: ["/v1/*"]
+
+        # Example: secret from AWS Secrets Manager with background refresh
+        # - source:
+        #     type: aws_sm
+        #     secret_id: "arn:aws:secretsmanager:us-east-1:123456:secret:my-api-key"
+        #     region: "us-east-1"      # optional, falls back to AWS SDK default
+        #     json_key: "api_key"      # optional, extract a field from a JSON secret
+        #     ttl: "15m"               # optional, re-fetch interval; 0 = no refresh
+        #   proxy_value: "proxy-token-456"
+        #   match_headers: ["Authorization"]
+        #   rules:
+        #     - host: "*.anthropic.com"
+        #       methods: ["POST"]
+        #       paths: ["/v1/messages", "/v1/complete"]
 
   # gRPC transforms: each entry delegates to one external TransformService server.
   # Use multiple entries for multiple servers; they run in pipeline order.


### PR DESCRIPTION
Replaces the global `source: env` field with per-secret source declarations supporting `env` and `aws_sm` (AWS Secrets Manager). Each resolver owns its own config struct via raw `yaml.Node` dispatch, so adding new source types only requires implementing the `secretResolver` interface and registering it.

Also replaces simple `hosts` matching with full `rules` (host/CIDR + method + path) reusing `hostmatch.RuleConfig`, adds configurable TTL with lazy inline refresh for `aws_sm` secrets, threads `*slog.Logger` through the `Factory` signature, and adds `Pipeline.Close()` for transform resource cleanup on pipeline swap.