### PR TITLE
refactor: simplify secret manager test code

### DIFF
--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -23,6 +23,33 @@ func yamlNode(t *testing.T, v any) yaml.Node {
 	return *node.Content[0]
 }
 
+// mockSMClient is a configurable mock for the AWS Secrets Manager client.
+type mockSMClient struct {
+	fn func(ctx context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (m *mockSMClient) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.fn(ctx, input)
+}
+
+// staticSMClient returns a mockSMClient that always returns the given output/error.
+func staticSMClient(out *secretsmanager.GetSecretValueOutput, err error) *mockSMClient {
+	return &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		return out, err
+	}}
+}
+
+func newTestAWSSMResolver(client smClient) *awsSMResolver {
+	r := &awsSMResolver{
+		clients: make(map[string]smClient),
+		logger:  slog.Default(),
+	}
+	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
+		return client, nil
+	}
+	return r
+}
+
 // --- envResolver tests ---
 
 func TestEnvResolver_HappyPath(t *testing.T) {
@@ -42,48 +69,40 @@ func TestEnvResolver_HappyPath(t *testing.T) {
 	require.Equal(t, "real-value", val)
 }
 
-func TestEnvResolver_MissingVar(t *testing.T) {
-	r := &envResolver{getenv: func(string) string { return "" }}
-	node := yamlNode(t, map[string]string{"type": "env"})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "\"var\" field")
-}
-
-func TestEnvResolver_EmptyValue(t *testing.T) {
-	r := &envResolver{getenv: func(string) string { return "" }}
-	node := yamlNode(t, map[string]string{"type": "env", "var": "EMPTY_VAR"})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not set or empty")
+func TestEnvResolver_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		errMsg  string
+	}{
+		{
+			name:   "missing var field",
+			input:  map[string]string{"type": "env"},
+			errMsg: "\"var\" field",
+		},
+		{
+			name:   "empty value",
+			input:  map[string]string{"type": "env", "var": "EMPTY_VAR"},
+			errMsg: "not set or empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &envResolver{getenv: func(string) string { return "" }}
+			node := yamlNode(t, tt.input)
+			_, err := r.Resolve(context.Background(), node)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
 }
 
 // --- awsSMResolver tests ---
 
-type mockSMClient struct {
-	out *secretsmanager.GetSecretValueOutput
-	err error
-}
-
-func (m *mockSMClient) GetSecretValue(_ context.Context, _ *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
-	return m.out, m.err
-}
-
-func newTestAWSSMResolver(client smClient) *awsSMResolver {
-	r := &awsSMResolver{
-		clients: make(map[string]smClient),
-		logger:  slog.Default(),
-	}
-	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
-		return client, nil
-	}
-	return r
-}
-
 func TestAWSSMResolver_PlainString(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String("my-secret-value"),
-	}}
+	}, nil)
 	r := newTestAWSSMResolver(client)
 	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:aws:sm:us-east-1:123:secret:foo"})
 	result, err := r.Resolve(context.Background(), node)
@@ -96,9 +115,9 @@ func TestAWSSMResolver_PlainString(t *testing.T) {
 }
 
 func TestAWSSMResolver_JSONKey(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String(`{"api_key": "sk-abc123", "other": "val"}`),
-	}}
+	}, nil)
 	r := newTestAWSSMResolver(client)
 	node := yamlNode(t, map[string]string{
 		"type":      "aws_sm",
@@ -114,9 +133,9 @@ func TestAWSSMResolver_JSONKey(t *testing.T) {
 }
 
 func TestAWSSMResolver_TTLReturnsCachedValue(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String("value"),
-	}}
+	}, nil)
 	r := newTestAWSSMResolver(client)
 	node := yamlNode(t, map[string]string{
 		"type":      "aws_sm",
@@ -132,118 +151,124 @@ func TestAWSSMResolver_TTLReturnsCachedValue(t *testing.T) {
 	require.Equal(t, "value", val)
 }
 
-func TestAWSSMResolver_MissingSecretID(t *testing.T) {
-	r := newTestAWSSMResolver(&mockSMClient{})
-	node := yamlNode(t, map[string]string{"type": "aws_sm"})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "\"secret_id\" field")
-}
-
-func TestAWSSMResolver_AWSError(t *testing.T) {
-	client := &mockSMClient{err: fmt.Errorf("access denied")}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:foo"})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "access denied")
-}
-
-func TestAWSSMResolver_EmptySecretValue(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
-		SecretString: aws.String(""),
-	}}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:foo"})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "empty value")
-}
-
-func TestAWSSMResolver_InvalidTTL(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
-		SecretString: aws.String("value"),
-	}}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{
-		"type":      "aws_sm",
-		"secret_id": "arn:foo",
-		"ttl":       "not-a-duration",
-	})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parsing ttl")
+func TestAWSSMResolver_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *mockSMClient
+		input  map[string]string
+		errMsg string
+	}{
+		{
+			name:   "missing secret_id",
+			client: staticSMClient(nil, nil),
+			input:  map[string]string{"type": "aws_sm"},
+			errMsg: "\"secret_id\" field",
+		},
+		{
+			name:   "aws error",
+			client: staticSMClient(nil, fmt.Errorf("access denied")),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo"},
+			errMsg: "access denied",
+		},
+		{
+			name: "empty secret value",
+			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(""),
+			}, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo"},
+			errMsg: "empty value",
+		},
+		{
+			name: "invalid TTL",
+			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("value"),
+			}, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+		},
+		{
+			name: "json_key with invalid JSON",
+			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("not-json"),
+			}, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
+			errMsg: "not valid JSON",
+		},
+		{
+			name: "json_key not found",
+			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"other": "value"}`),
+			}, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
+			errMsg: "not found",
+		},
+		{
+			name: "json_key non-string value",
+			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"api_key": 123}`),
+			}, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
+			errMsg: "not a string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestAWSSMResolver(tt.client)
+			node := yamlNode(t, tt.input)
+			_, err := r.Resolve(context.Background(), node)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
 }
 
 // --- extractJSONKey tests ---
 
-func TestExtractJSONKey_Valid(t *testing.T) {
-	val, err := extractJSONKey(`{"key": "value", "other": "data"}`, "key")
-	require.NoError(t, err)
-	require.Equal(t, "value", val)
-}
-
-func TestExtractJSONKey_InvalidJSON(t *testing.T) {
-	_, err := extractJSONKey(`not json`, "key")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not valid JSON")
-}
-
-func TestExtractJSONKey_MissingKey(t *testing.T) {
-	_, err := extractJSONKey(`{"other": "value"}`, "key")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found")
-}
-
-func TestExtractJSONKey_NonStringValue(t *testing.T) {
-	_, err := extractJSONKey(`{"key": 42}`, "key")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not a string")
-}
-
-func TestAWSSMResolver_JSONKeyInvalidJSON(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
-		SecretString: aws.String("not-json"),
-	}}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{
-		"type":      "aws_sm",
-		"secret_id": "arn:foo",
-		"json_key":  "api_key",
-	})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not valid JSON")
-}
-
-func TestAWSSMResolver_JSONKeyMissing(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
-		SecretString: aws.String(`{"other": "value"}`),
-	}}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{
-		"type":      "aws_sm",
-		"secret_id": "arn:foo",
-		"json_key":  "api_key",
-	})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not found")
-}
-
-func TestAWSSMResolver_JSONKeyNonString(t *testing.T) {
-	client := &mockSMClient{out: &secretsmanager.GetSecretValueOutput{
-		SecretString: aws.String(`{"api_key": 123}`),
-	}}
-	r := newTestAWSSMResolver(client)
-	node := yamlNode(t, map[string]string{
-		"type":      "aws_sm",
-		"secret_id": "arn:foo",
-		"json_key":  "api_key",
-	})
-	_, err := r.Resolve(context.Background(), node)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not a string")
+func TestExtractJSONKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		key     string
+		want    string
+		errMsg  string
+	}{
+		{
+			name: "valid",
+			json: `{"key": "value", "other": "data"}`,
+			key:  "key",
+			want: "value",
+		},
+		{
+			name:   "invalid JSON",
+			json:   `not json`,
+			key:    "key",
+			errMsg: "not valid JSON",
+		},
+		{
+			name:   "missing key",
+			json:   `{"other": "value"}`,
+			key:    "key",
+			errMsg: "not found",
+		},
+		{
+			name:   "non-string value",
+			json:   `{"key": 42}`,
+			key:    "key",
+			errMsg: "not a string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := extractJSONKey(tt.json, tt.key)
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, val)
+			}
+		})
+	}
 }
 
 // --- cachedValue tests ---
@@ -251,10 +276,10 @@ func TestAWSSMResolver_JSONKeyNonString(t *testing.T) {
 func TestCachedValue_ServesStaleOnError(t *testing.T) {
 	calls := 0
 	cv := &cachedValue{
-		value:     "initial",
-		ttl:       1, // expired immediately
-		logger:    slog.Default(),
-		name:      "test",
+		value:  "initial",
+		ttl:    1, // expired immediately
+		logger: slog.Default(),
+		name:   "test",
 		refresh: func(_ context.Context) (string, error) {
 			calls++
 			return "", fmt.Errorf("aws error")

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -73,6 +73,21 @@ func awsSMSource(secretID string) yaml.Node {
 	return yamlNode(&testing.T{}, map[string]string{"type": "aws_sm", "secret_id": secretID})
 }
 
+// defaultEntry returns the most common secretEntry used across tests.
+// Use the opts functions to override specific fields.
+func defaultEntry(opts ...func(*secretEntry)) secretEntry {
+	e := secretEntry{
+		Source:       envSource("OPENAI_API_KEY"),
+		ProxyValue:   "proxy-openai-abc123",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+	}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
 func makeSecrets(t *testing.T, entries []secretEntry) *Secrets {
 	t.Helper()
 	cfg := secretsConfig{Secrets: entries}
@@ -88,16 +103,16 @@ func doTransform(t *testing.T, s *Secrets, req *http.Request) {
 	require.Equal(t, transform.ActionContinue, res.Action)
 }
 
-func TestSecrets_HeaderSwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
-
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
+func openaiReq(method, path string) *http.Request {
+	req := httptest.NewRequest(method, "http://api.openai.com"+path, nil)
 	req.Host = "api.openai.com"
+	return req
+}
+
+func TestSecrets_HeaderSwap(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
+
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -106,11 +121,9 @@ func TestSecrets_HeaderSwap(t *testing.T) {
 }
 
 func TestSecrets_QueryParamSwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:     envSource("OPENAI_API_KEY"),
-		ProxyValue: "proxy-openai-abc123",
-		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+	})})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat?token=proxy-openai-abc123&other=value", nil)
 	req.Host = "api.openai.com"
@@ -123,18 +136,15 @@ func TestSecrets_QueryParamSwap(t *testing.T) {
 }
 
 func TestSecrets_BodySwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:     envSource("OPENAI_API_KEY"),
-		ProxyValue: "proxy-openai-abc123",
-		MatchBody:  true,
-		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+		e.MatchBody = true
+	})})
 
 	body := `{"api_key": "proxy-openai-abc123", "model": "gpt-4"}`
 	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
 
-	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("POST", "/v1/chat")
 	req.Body = rb
 	req.ContentLength = int64(len(body))
 
@@ -148,15 +158,9 @@ func TestSecrets_BodySwap(t *testing.T) {
 }
 
 func TestSecrets_HostMatch(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -164,12 +168,7 @@ func TestSecrets_HostMatch(t *testing.T) {
 }
 
 func TestSecrets_HostNoMatch(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	req := httptest.NewRequest("GET", "http://evil.com/steal", nil)
 	req.Host = "evil.com"
@@ -182,12 +181,12 @@ func TestSecrets_HostNoMatch(t *testing.T) {
 }
 
 func TestSecrets_WildcardHost(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("ANTHROPIC_API_KEY"),
-		ProxyValue:   "proxy-anthropic-xyz789",
-		MatchHeaders: []string{"X-Api-Key"},
-		Rules:        []hostmatch.RuleConfig{{Host: "*.anthropic.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Source = envSource("ANTHROPIC_API_KEY")
+		e.ProxyValue = "proxy-anthropic-xyz789"
+		e.MatchHeaders = []string{"X-Api-Key"}
+		e.Rules = []hostmatch.RuleConfig{{Host: "*.anthropic.com"}}
+	})})
 
 	req := httptest.NewRequest("GET", "http://api.anthropic.com/v1/messages", nil)
 	req.Host = "api.anthropic.com"
@@ -199,22 +198,15 @@ func TestSecrets_WildcardHost(t *testing.T) {
 
 func TestSecrets_MultipleSecrets(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{
-		{
-			Source:       envSource("OPENAI_API_KEY"),
-			ProxyValue:   "proxy-openai-abc123",
-			MatchHeaders: []string{"Authorization"},
-			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-		},
-		{
-			Source:       envSource("INTERNAL_TOKEN"),
-			ProxyValue:   "proxy-internal-tok",
-			MatchHeaders: []string{"X-Internal"},
-			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-		},
+		defaultEntry(),
+		defaultEntry(func(e *secretEntry) {
+			e.Source = envSource("INTERNAL_TOKEN")
+			e.ProxyValue = "proxy-internal-tok"
+			e.MatchHeaders = []string{"X-Internal"}
+		}),
 	})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 	req.Header.Set("X-Internal", "proxy-internal-tok")
 
@@ -225,15 +217,9 @@ func TestSecrets_MultipleSecrets(t *testing.T) {
 }
 
 func TestSecrets_MatchHeadersFiltering(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 	req.Header.Set("X-Custom", "proxy-openai-abc123") // not in match_headers
 
@@ -245,15 +231,11 @@ func TestSecrets_MatchHeadersFiltering(t *testing.T) {
 }
 
 func TestSecrets_EmptyMatchHeadersSearchesAll(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{}, // empty = all headers
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{} // empty = all headers
+	})})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 	req.Header.Set("X-Custom", "proxy-openai-abc123")
 
@@ -263,74 +245,69 @@ func TestSecrets_EmptyMatchHeadersSearchesAll(t *testing.T) {
 	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Custom"))
 }
 
-func TestSecrets_MissingEnvVar(t *testing.T) {
-	cfg := secretsConfig{
-		Secrets: []secretEntry{{
-			Source:     envSource("NONEXISTENT_VAR"),
-			ProxyValue: "proxy-value",
-			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
-		}},
+func TestSecrets_ConfigErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    secretsConfig
+		errMsg string
+	}{
+		{
+			name: "missing env var",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     envSource("NONEXISTENT_VAR"),
+				ProxyValue: "proxy-value",
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "NONEXISTENT_VAR",
+		},
+		{
+			name: "empty proxy value",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     envSource("OPENAI_API_KEY"),
+				ProxyValue: "",
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "proxy_value is required",
+		},
+		{
+			name: "unsupported source type",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     yamlNode(&testing.T{}, map[string]string{"type": "vault"}),
+				ProxyValue: "proxy-value",
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "unsupported source type",
+		},
+		{
+			name: "missing source type",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     yamlNode(&testing.T{}, map[string]string{"var": "FOO"}),
+				ProxyValue: "proxy-value",
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "source.type is required",
+		},
 	}
-	_, err := newFromConfig(context.Background(), cfg, testRegistry())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "NONEXISTENT_VAR")
-}
-
-func TestSecrets_EmptyProxyValue(t *testing.T) {
-	cfg := secretsConfig{
-		Secrets: []secretEntry{{
-			Source:     envSource("OPENAI_API_KEY"),
-			ProxyValue: "",
-			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
-		}},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newFromConfig(context.Background(), tt.cfg, testRegistry())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
 	}
-	_, err := newFromConfig(context.Background(), cfg, testRegistry())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "proxy_value is required")
-}
-
-func TestSecrets_UnsupportedSourceType(t *testing.T) {
-	node := yamlNode(t, map[string]string{"type": "vault"})
-	cfg := secretsConfig{
-		Secrets: []secretEntry{{
-			Source:     node,
-			ProxyValue: "proxy-value",
-			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
-		}},
-	}
-	_, err := newFromConfig(context.Background(), cfg, testRegistry())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported source type")
-}
-
-func TestSecrets_MissingSourceType(t *testing.T) {
-	node := yamlNode(t, map[string]string{"var": "FOO"})
-	cfg := secretsConfig{
-		Secrets: []secretEntry{{
-			Source:     node,
-			ProxyValue: "proxy-value",
-			Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
-		}},
-	}
-	_, err := newFromConfig(context.Background(), cfg, testRegistry())
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "source.type is required")
 }
 
 func TestSecrets_BodyTooLarge(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:     envSource("OPENAI_API_KEY"),
-		ProxyValue: "proxy-openai-abc123",
-		MatchBody:  true,
-		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+		e.MatchBody = true
+	})})
 
 	// Create a body larger than the max (1 MiB)
 	bigBody := strings.Repeat("x", (1<<20)+100)
 	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(bigBody)), 1<<20)
 
-	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("POST", "/v1/chat")
 	req.Body = rb
 
 	// Should not error — just skip body substitution
@@ -338,12 +315,7 @@ func TestSecrets_BodyTooLarge(t *testing.T) {
 }
 
 func TestSecrets_HostWithPort(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com:443/v1/chat", nil)
 	req.Host = "api.openai.com:443"
@@ -355,11 +327,9 @@ func TestSecrets_HostWithPort(t *testing.T) {
 }
 
 func TestSecrets_ResponseIsNoop(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:     envSource("OPENAI_API_KEY"),
-		ProxyValue: "proxy-openai-abc123",
-		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+	})})
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
 	resp := &http.Response{StatusCode: http.StatusOK}
@@ -369,20 +339,14 @@ func TestSecrets_ResponseIsNoop(t *testing.T) {
 }
 
 func TestSecrets_ConcurrentSafety(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	var wg sync.WaitGroup
 	for range 50 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-			req.Host = "api.openai.com"
+			req := openaiReq("GET", "/v1/chat")
 			req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 			doTransform(t, s, req)
@@ -394,17 +358,11 @@ func TestSecrets_ConcurrentSafety(t *testing.T) {
 }
 
 func TestSecrets_BasicAuthSwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	// Basic auth: "user:proxy-openai-abc123" base64-encoded
 	creds := base64.StdEncoding.EncodeToString([]byte("user:proxy-openai-abc123"))
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Basic "+creds)
 
 	doTransform(t, s, req)
@@ -417,17 +375,11 @@ func TestSecrets_BasicAuthSwap(t *testing.T) {
 }
 
 func TestSecrets_BasicAuthNoMatch(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	// Basic auth with no proxy token inside
 	creds := base64.StdEncoding.EncodeToString([]byte("user:some-other-password"))
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Basic "+creds)
 
 	doTransform(t, s, req)
@@ -437,16 +389,12 @@ func TestSecrets_BasicAuthNoMatch(t *testing.T) {
 }
 
 func TestSecrets_BasicAuthAllHeaders(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{}, // all headers
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{} // all headers
+	})})
 
 	creds := base64.StdEncoding.EncodeToString([]byte("proxy-openai-abc123:secret"))
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Basic "+creds)
 
 	doTransform(t, s, req)
@@ -458,17 +406,13 @@ func TestSecrets_BasicAuthAllHeaders(t *testing.T) {
 }
 
 func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{}, // all headers
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{} // all headers
+	})})
 
 	// "Basic <base64>" on a non-Authorization header should not be decoded
 	creds := base64.StdEncoding.EncodeToString([]byte("proxy-openai-abc123:secret"))
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("X-Custom", "Basic "+creds)
 
 	doTransform(t, s, req)
@@ -478,17 +422,12 @@ func TestSecrets_BasicAuthIgnoredOnNonAuthHeader(t *testing.T) {
 }
 
 func TestSecrets_RequireRejectsWithoutProxyToken(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Require:      true,
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+	})})
 
 	// Request to matching host but with a different credential — should be rejected.
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer sk-some-other-key")
 
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
@@ -497,16 +436,11 @@ func TestSecrets_RequireRejectsWithoutProxyToken(t *testing.T) {
 }
 
 func TestSecrets_RequireContinuesWithProxyToken(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Require:      true,
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+	})})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -514,17 +448,10 @@ func TestSecrets_RequireContinuesWithProxyToken(t *testing.T) {
 }
 
 func TestSecrets_RequireDefaultFalseAllowsThrough(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		// Require defaults to false
-		Rules: []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry()})
 
 	// Request without proxy token — should still pass (require is false).
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer sk-some-other-key")
 
 	doTransform(t, s, req)
@@ -532,13 +459,9 @@ func TestSecrets_RequireDefaultFalseAllowsThrough(t *testing.T) {
 }
 
 func TestSecrets_RequireNonMatchingHostAllowsThrough(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Require:      true,
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+	})})
 
 	// Request to a different host — host doesn't match, so require doesn't apply.
 	req := httptest.NewRequest("GET", "http://other.com/v1/chat", nil)
@@ -550,17 +473,12 @@ func TestSecrets_RequireNonMatchingHostAllowsThrough(t *testing.T) {
 }
 
 func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Require:      true,
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+	})})
 
 	// Request to matching host with no Authorization header at all.
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
 	require.NoError(t, err)
@@ -568,19 +486,16 @@ func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
 }
 
 func TestSecrets_RequireWithBodySwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:     envSource("OPENAI_API_KEY"),
-		ProxyValue: "proxy-openai-abc123",
-		MatchBody:  true,
-		Require:    true,
-		Rules:      []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+		e.MatchBody = true
+		e.Require = true
+	})})
 
 	body := `{"api_key": "proxy-openai-abc123"}`
 	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
 
-	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("POST", "/v1/chat")
 	req.Body = rb
 
 	doTransform(t, s, req)
@@ -595,27 +510,22 @@ func TestSecrets_Name(t *testing.T) {
 	require.Equal(t, "secrets", s.Name())
 }
 
-// --- New tests for rules matching and mixed sources ---
+// --- Rules matching tests ---
 
 func TestSecrets_MethodFiltering(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com", Methods: []string{"POST"}}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Rules = []hostmatch.RuleConfig{{Host: "api.openai.com", Methods: []string{"POST"}}}
+	})})
 
 	// GET request should NOT match the rule
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
 	require.Equal(t, "Bearer proxy-openai-abc123", req.Header.Get("Authorization"))
 
 	// POST request should match
-	req = httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req = openaiReq("POST", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -623,24 +533,19 @@ func TestSecrets_MethodFiltering(t *testing.T) {
 }
 
 func TestSecrets_PathFiltering(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{{
-		Source:       envSource("OPENAI_API_KEY"),
-		ProxyValue:   "proxy-openai-abc123",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com", Paths: []string{"/v1/*"}}},
-	}})
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Rules = []hostmatch.RuleConfig{{Host: "api.openai.com", Paths: []string{"/v1/*"}}}
+	})})
 
 	// Path outside /v1/* should NOT match
-	req := httptest.NewRequest("GET", "http://api.openai.com/v2/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v2/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
 	require.Equal(t, "Bearer proxy-openai-abc123", req.Header.Get("Authorization"))
 
 	// Path inside /v1/* should match
-	req = httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req = openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -649,22 +554,15 @@ func TestSecrets_PathFiltering(t *testing.T) {
 
 func TestSecrets_MixedSourceTypes(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{
-		{
-			Source:       envSource("OPENAI_API_KEY"),
-			ProxyValue:   "proxy-openai-abc123",
-			MatchHeaders: []string{"Authorization"},
-			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-		},
-		{
-			Source:       awsSMSource("arn:aws:sm:test"),
-			ProxyValue:   "proxy-aws-tok",
-			MatchHeaders: []string{"X-Api-Key"},
-			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-		},
+		defaultEntry(),
+		defaultEntry(func(e *secretEntry) {
+			e.Source = awsSMSource("arn:aws:sm:test")
+			e.ProxyValue = "proxy-aws-tok"
+			e.MatchHeaders = []string{"X-Api-Key"}
+		}),
 	})
 
-	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 	req.Header.Set("X-Api-Key", "proxy-aws-tok")
 
@@ -675,15 +573,6 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 }
 
 // --- End-to-end tests with real awsSMResolver and mock AWS client ---
-
-// mockSMClientForTest wraps a function so we can change behavior between calls.
-type mockSMClientForTest struct {
-	fn func(ctx context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
-}
-
-func (m *mockSMClientForTest) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
-	return m.fn(ctx, input)
-}
 
 func awsSMRegistry(client smClient) resolverRegistry {
 	r := &awsSMResolver{
@@ -696,26 +585,30 @@ func awsSMRegistry(client smClient) resolverRegistry {
 	return resolverRegistry{"aws_sm": r}
 }
 
+func makeAWSSMSecrets(t *testing.T, client smClient, entries []secretEntry) *Secrets {
+	t.Helper()
+	cfg := secretsConfig{Secrets: entries}
+	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	require.NoError(t, err)
+	return s
+}
+
 func TestAWSSM_EndToEnd_HeaderSwap(t *testing.T) {
-	client := &mockSMClientForTest{fn: func(_ context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	client := &mockSMClient{fn: func(_ context.Context, input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 		require.Equal(t, "arn:aws:sm:us-east-1:123:secret:openai", aws.ToString(input.SecretId))
 		return &secretsmanager.GetSecretValueOutput{
 			SecretString: aws.String("sk-real-openai-key"),
 		}, nil
 	}}
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
 		Source:       yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:aws:sm:us-east-1:123:secret:openai"}),
 		ProxyValue:   "proxy-openai-abc123",
 		MatchHeaders: []string{"Authorization"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
-	}}}
+	}})
 
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
-
-	req := httptest.NewRequest("POST", "http://api.openai.com/v1/chat", nil)
-	req.Host = "api.openai.com"
+	req := openaiReq("POST", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	doTransform(t, s, req)
@@ -723,13 +616,11 @@ func TestAWSSM_EndToEnd_HeaderSwap(t *testing.T) {
 }
 
 func TestAWSSM_EndToEnd_JSONKey(t *testing.T) {
-	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
-		return &secretsmanager.GetSecretValueOutput{
-			SecretString: aws.String(`{"api_key": "sk-from-json", "other": "ignored"}`),
-		}, nil
-	}}
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(`{"api_key": "sk-from-json", "other": "ignored"}`),
+	}, nil)
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
 		Source: yamlNode(t, map[string]string{
 			"type":      "aws_sm",
 			"secret_id": "arn:aws:sm:us-east-1:123:secret:multi",
@@ -738,10 +629,7 @@ func TestAWSSM_EndToEnd_JSONKey(t *testing.T) {
 		ProxyValue:   "proxy-tok",
 		MatchHeaders: []string{"X-Api-Key"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
+	}})
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1/data", nil)
 	req.Host = "api.example.com"
@@ -752,21 +640,16 @@ func TestAWSSM_EndToEnd_JSONKey(t *testing.T) {
 }
 
 func TestAWSSM_EndToEnd_BodySwap(t *testing.T) {
-	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
-		return &secretsmanager.GetSecretValueOutput{
-			SecretString: aws.String("real-secret"),
-		}, nil
-	}}
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("real-secret"),
+	}, nil)
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
-		Source:     yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
+		Source:    yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
 		ProxyValue: "proxy-tok",
-		MatchBody:  true,
-		Rules:      []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
+		MatchBody: true,
+		Rules:     []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}})
 
 	body := `{"key": "proxy-tok"}`
 	rb := transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
@@ -784,7 +667,7 @@ func TestAWSSM_EndToEnd_BodySwap(t *testing.T) {
 
 func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
 	var callCount atomic.Int32
-	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	client := &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 		n := callCount.Add(1)
 		// Return a different value each call so we can observe the refresh.
 		return &secretsmanager.GetSecretValueOutput{
@@ -792,7 +675,7 @@ func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
 		}, nil
 	}}
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
 		Source: yamlNode(t, map[string]string{
 			"type":      "aws_sm",
 			"secret_id": "arn:test",
@@ -801,10 +684,7 @@ func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
 		ProxyValue:   "proxy-tok",
 		MatchHeaders: []string{"Authorization"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
+	}})
 	// Initial resolve is call 1 (value-1).
 
 	// First request: TTL=1ns is already expired, so this triggers a refresh (call 2).
@@ -826,7 +706,7 @@ func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
 
 func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 	var callCount atomic.Int32
-	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	client := &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 		n := callCount.Add(1)
 		// First call (initial resolve at startup) succeeds.
 		if n == 1 {
@@ -838,7 +718,7 @@ func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 		return nil, fmt.Errorf("aws transient error")
 	}}
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
 		Source: yamlNode(t, map[string]string{
 			"type":      "aws_sm",
 			"secret_id": "arn:test",
@@ -847,10 +727,7 @@ func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 		ProxyValue:   "proxy-tok",
 		MatchHeaders: []string{"Authorization"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
+	}})
 	require.Equal(t, int32(1), callCount.Load()) // initial resolve
 
 	// First request: TTL expired, refresh fails, stale "good-value" served.
@@ -872,22 +749,17 @@ func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 }
 
 func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
-	client := &mockSMClientForTest{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
-		return &secretsmanager.GetSecretValueOutput{
-			SecretString: aws.String("real-secret"),
-		}, nil
-	}}
+	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String("real-secret"),
+	}, nil)
 
-	cfg := secretsConfig{Secrets: []secretEntry{{
+	s := makeAWSSMSecrets(t, client, []secretEntry{{
 		Source:       yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
 		ProxyValue:   "proxy-tok",
 		MatchHeaders: []string{"Authorization"},
 		Require:      true,
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
-	require.NoError(t, err)
+	}})
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
 	req.Host = "api.example.com"
@@ -897,4 +769,3 @@ func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
 }
-


### PR DESCRIPTION
Reduces test verbosity by ~100 lines. Consolidates the two duplicate SM mock types into one, converts several groups of near-identical test functions into table-driven tests, and adds `defaultEntry()` / `openaiReq()` helpers to eliminate repeated secretEntry and request construction in `secrets_test.go`.