### PR TITLE
feat: add inject mode for secrets

### DIFF
--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"text/template"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -30,23 +31,60 @@ type secretsConfig struct {
 }
 
 type secretEntry struct {
-	Source       yaml.Node              `yaml:"source"`
-	ProxyValue   string                 `yaml:"proxy_value"`
-	MatchHeaders []string               `yaml:"match_headers"`
-	MatchBody    bool                   `yaml:"match_body"`
-	Require      bool                   `yaml:"require"`
-	Rules        []hostmatch.RuleConfig `yaml:"rules"`
+	Source  yaml.Node              `yaml:"source"`
+	Rules   []hostmatch.RuleConfig `yaml:"rules"`
+	Inject  *injectConfig          `yaml:"inject,omitempty"`
+	Replace *replaceConfig         `yaml:"replace,omitempty"`
+
+	// Deprecated top-level fields for backwards compatibility.
+	// Users should migrate to the replace block.
+	ProxyValue   string   `yaml:"proxy_value,omitempty"`
+	MatchHeaders []string `yaml:"match_headers,omitempty"`
+	MatchBody    bool     `yaml:"match_body,omitempty"`
+	Require      bool     `yaml:"require,omitempty"`
+}
+
+type replaceConfig struct {
+	ProxyValue   string   `yaml:"proxy_value"`
+	MatchHeaders []string `yaml:"match_headers,omitempty"`
+	MatchBody    bool     `yaml:"match_body,omitempty"`
+	Require      bool     `yaml:"require,omitempty"`
+}
+
+type injectConfig struct {
+	Header     string `yaml:"header,omitempty"`
+	QueryParam string `yaml:"query_param,omitempty"`
+	Formatter  string `yaml:"formatter,omitempty"`
 }
 
 // resolvedSecret is a secret ready for use after config parsing and source resolution.
 type resolvedSecret struct {
-	name         string // source name, for logging/metrics
+	name     string // source name, for logging/metrics
+	mode     string // "replace" or "inject"
+	getValue func(ctx context.Context) (string, error)
+	rules    []hostmatch.Rule
+
+	// replace mode fields
 	proxyValue   string
-	getValue     func(ctx context.Context) (string, error)
 	matchHeaders []string // empty = all headers
 	matchBody    bool
 	require      bool
-	rules        []hostmatch.Rule
+
+	// inject mode fields
+	injectHeader     string
+	injectQueryParam string
+	formatter        *template.Template // nil = identity (raw value)
+}
+
+// formatterData is the template context for inject formatters.
+type formatterData struct {
+	Value string
+}
+
+var formatterFuncs = template.FuncMap{
+	"base64": func(parts ...string) string {
+		return base64.StdEncoding.EncodeToString([]byte(strings.Join(parts, "")))
+	},
 }
 
 // Secrets is the transform that swaps proxy tokens for real secrets.
@@ -73,8 +111,10 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 	resolved := make([]resolvedSecret, 0, len(cfg.Secrets))
 
 	for i, entry := range cfg.Secrets {
-		if entry.ProxyValue == "" {
-			return nil, fmt.Errorf("secrets[%d]: proxy_value is required", i)
+		// Normalize legacy top-level fields into a replace block.
+		replace, inject, err := normalizeEntry(i, &entry)
+		if err != nil {
+			return nil, err
 		}
 
 		// Peek at source type to dispatch to the right resolver.
@@ -101,28 +141,119 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 			return nil, err
 		}
 
-		resolved = append(resolved, resolvedSecret{
-			name:         result.Name,
-			proxyValue:   entry.ProxyValue,
-			getValue:     result.GetValue,
-			matchHeaders: entry.MatchHeaders,
-			matchBody:    entry.MatchBody,
-			require:      entry.Require,
-			rules:        rules,
-		})
+		if inject != nil {
+			sec := resolvedSecret{
+				name:             result.Name,
+				mode:             "inject",
+				getValue:         result.GetValue,
+				rules:            rules,
+				injectHeader:     inject.Header,
+				injectQueryParam: inject.QueryParam,
+			}
+			if inject.Formatter != "" {
+				tmpl, err := template.New(fmt.Sprintf("secrets[%d]", i)).Funcs(formatterFuncs).Parse(inject.Formatter)
+				if err != nil {
+					return nil, fmt.Errorf("secrets[%d]: parsing formatter template: %w", i, err)
+				}
+				sec.formatter = tmpl
+			}
+			resolved = append(resolved, sec)
+		} else {
+			resolved = append(resolved, resolvedSecret{
+				name:         result.Name,
+				mode:         "replace",
+				proxyValue:   replace.ProxyValue,
+				getValue:     result.GetValue,
+				matchHeaders: replace.MatchHeaders,
+				matchBody:    replace.MatchBody,
+				require:      replace.Require,
+				rules:        rules,
+			})
+		}
 	}
 
 	return &Secrets{secrets: resolved}, nil
 }
 
+// normalizeEntry validates the entry and returns either a replaceConfig or injectConfig.
+// It handles legacy top-level fields by normalizing them into a replaceConfig.
+func normalizeEntry(i int, entry *secretEntry) (*replaceConfig, *injectConfig, error) {
+	hasLegacy := entry.ProxyValue != "" || len(entry.MatchHeaders) > 0 || entry.MatchBody || entry.Require
+	hasReplace := entry.Replace != nil
+	hasInject := entry.Inject != nil
+
+	// Count how many modes are specified.
+	modeCount := 0
+	if hasLegacy {
+		modeCount++
+	}
+	if hasReplace {
+		modeCount++
+	}
+	if hasInject {
+		modeCount++
+	}
+
+	if modeCount == 0 {
+		return nil, nil, fmt.Errorf("secrets[%d]: must specify either inject or replace", i)
+	}
+	if modeCount > 1 {
+		if hasLegacy && hasReplace {
+			return nil, nil, fmt.Errorf("secrets[%d]: cannot use both top-level proxy_value/match_headers and replace block", i)
+		}
+		if hasLegacy && hasInject {
+			return nil, nil, fmt.Errorf("secrets[%d]: cannot use both top-level proxy_value/match_headers and inject block", i)
+		}
+		return nil, nil, fmt.Errorf("secrets[%d]: cannot specify both inject and replace", i)
+	}
+
+	if hasInject {
+		if err := validateInject(i, entry.Inject); err != nil {
+			return nil, nil, err
+		}
+		return nil, entry.Inject, nil
+	}
+
+	if hasReplace {
+		if entry.Replace.ProxyValue == "" {
+			return nil, nil, fmt.Errorf("secrets[%d]: replace.proxy_value is required", i)
+		}
+		return entry.Replace, nil, nil
+	}
+
+	// Legacy top-level fields: normalize into replaceConfig.
+	if entry.ProxyValue == "" {
+		return nil, nil, fmt.Errorf("secrets[%d]: proxy_value is required", i)
+	}
+	return &replaceConfig{
+		ProxyValue:   entry.ProxyValue,
+		MatchHeaders: entry.MatchHeaders,
+		MatchBody:    entry.MatchBody,
+		Require:      entry.Require,
+	}, nil, nil
+}
+
+func validateInject(i int, cfg *injectConfig) error {
+	hasHeader := cfg.Header != ""
+	hasQuery := cfg.QueryParam != ""
+
+	if !hasHeader && !hasQuery {
+		return fmt.Errorf("secrets[%d]: inject must specify either header or query_param", i)
+	}
+	if hasHeader && hasQuery {
+		return fmt.Errorf("secrets[%d]: inject cannot specify both header and query_param", i)
+	}
+	return nil
+}
+
 func (s *Secrets) Name() string { return "secrets" }
 
 func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
-	type swapRecord struct {
+	type secretRecord struct {
 		Secret    string   `json:"secret"`
 		Locations []string `json:"locations"`
 	}
-	var swapped []swapRecord
+	var swapped, injected []secretRecord
 
 	for _, sec := range s.secrets {
 		if !hostmatch.MatchAnyRule(ctx, sec.rules, req) {
@@ -132,6 +263,17 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		realValue, err := sec.getValue(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("resolving secret %q: %w", sec.name, err)
+		}
+
+		if sec.mode == "inject" {
+			locations, err := s.injectSecret(req, &sec, realValue)
+			if err != nil {
+				return nil, fmt.Errorf("injecting secret %q: %w", sec.name, err)
+			}
+			if len(locations) > 0 {
+				injected = append(injected, secretRecord{Secret: sec.name, Locations: locations})
+			}
+			continue
 		}
 
 		var locations []string
@@ -145,7 +287,7 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		}
 
 		if len(locations) > 0 {
-			swapped = append(swapped, swapRecord{Secret: sec.name, Locations: locations})
+			swapped = append(swapped, secretRecord{Secret: sec.name, Locations: locations})
 		} else if sec.require {
 			tctx.Annotate("rejected", sec.name)
 			return &transform.TransformResult{Action: transform.ActionReject}, nil
@@ -155,8 +297,42 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	if len(swapped) > 0 {
 		tctx.Annotate("swapped", swapped)
 	}
+	if len(injected) > 0 {
+		tctx.Annotate("injected", injected)
+	}
 
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (s *Secrets) injectSecret(req *http.Request, sec *resolvedSecret, realValue string) ([]string, error) {
+	formatted, err := s.formatValue(sec, realValue)
+	if err != nil {
+		return nil, err
+	}
+
+	var locations []string
+	if sec.injectHeader != "" {
+		req.Header.Set(sec.injectHeader, formatted)
+		locations = append(locations, "header:"+sec.injectHeader)
+	}
+	if sec.injectQueryParam != "" {
+		q := req.URL.Query()
+		q.Set(sec.injectQueryParam, formatted)
+		req.URL.RawQuery = q.Encode()
+		locations = append(locations, "query:"+sec.injectQueryParam)
+	}
+	return locations, nil
+}
+
+func (s *Secrets) formatValue(sec *resolvedSecret, realValue string) (string, error) {
+	if sec.formatter == nil {
+		return realValue, nil
+	}
+	var buf strings.Builder
+	if err := sec.formatter.Execute(&buf, formatterData{Value: realValue}); err != nil {
+		return "", fmt.Errorf("executing formatter: %w", err)
+	}
+	return buf.String(), nil
 }
 
 func (s *Secrets) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -261,13 +261,12 @@ func TestSecrets_ConfigErrors(t *testing.T) {
 			errMsg: "NONEXISTENT_VAR",
 		},
 		{
-			name: "empty proxy value",
+			name: "no mode specified",
 			cfg: secretsConfig{Secrets: []secretEntry{{
-				Source:     envSource("OPENAI_API_KEY"),
-				ProxyValue: "",
-				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+				Source: envSource("OPENAI_API_KEY"),
+				Rules:  []hostmatch.RuleConfig{{Host: "example.com"}},
 			}}},
-			errMsg: "proxy_value is required",
+			errMsg: "must specify either inject or replace",
 		},
 		{
 			name: "unsupported source type",
@@ -768,4 +767,225 @@ func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+// --- Inject mode tests ---
+
+func injectEntry(opts ...func(*secretEntry)) secretEntry {
+	e := secretEntry{
+		Source: envSource("OPENAI_API_KEY"),
+		Inject: &injectConfig{
+			Header:    "Authorization",
+			Formatter: "Bearer {{ .Value }}",
+		},
+		Rules: []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+	}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func TestInject_HeaderWithFormatter(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry()})
+
+	req := openaiReq("GET", "/v1/chat")
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestInject_HeaderNoFormatter(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
+		e.Inject.Formatter = ""
+		e.Inject.Header = "X-Api-Key"
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	doTransform(t, s, req)
+
+	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Api-Key"))
+}
+
+func TestInject_Base64Formatter(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
+		e.Inject.Formatter = `Basic {{ base64 "x-credential:" .Value }}`
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	doTransform(t, s, req)
+
+	got := req.Header.Get("Authorization")
+	require.True(t, strings.HasPrefix(got, "Basic "))
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(got, "Basic "))
+	require.NoError(t, err)
+	require.Equal(t, "x-credential:sk-real-openai-key", string(decoded))
+}
+
+func TestInject_QueryParam(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
+		e.Inject = &injectConfig{QueryParam: "key"}
+	})})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat?existing=value", nil)
+	req.Host = "api.openai.com"
+	doTransform(t, s, req)
+
+	require.Equal(t, "sk-real-openai-key", req.URL.Query().Get("key"))
+	require.Equal(t, "value", req.URL.Query().Get("existing"))
+}
+
+func TestInject_OverwritesExistingHeader(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry()})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("Authorization", "Bearer client-sent-token")
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestInject_NoMatchingHost(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry()})
+
+	req := httptest.NewRequest("GET", "http://evil.com/steal", nil)
+	req.Host = "evil.com"
+	doTransform(t, s, req)
+
+	require.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestInject_MixedWithReplace(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{
+		// Inject mode for OpenAI
+		injectEntry(),
+		// Replace mode for internal service
+		defaultEntry(func(e *secretEntry) {
+			e.Source = envSource("INTERNAL_TOKEN")
+			e.ProxyValue = "proxy-internal-tok"
+			e.MatchHeaders = []string{"X-Internal"}
+		}),
+	})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Internal", "proxy-internal-tok")
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+	require.Equal(t, "real-internal-token", req.Header.Get("X-Internal"))
+}
+
+func TestInject_ReplaceBlock(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{{
+		Source: envSource("OPENAI_API_KEY"),
+		Replace: &replaceConfig{
+			ProxyValue:   "proxy-openai-abc123",
+			MatchHeaders: []string{"Authorization"},
+		},
+		Rules: []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+	}})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestInject_ConfigErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    secretsConfig
+		errMsg string
+	}{
+		{
+			name: "both inject and replace",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:  envSource("OPENAI_API_KEY"),
+				Inject:  &injectConfig{Header: "Authorization"},
+				Replace: &replaceConfig{ProxyValue: "tok"},
+				Rules:   []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "cannot specify both inject and replace",
+		},
+		{
+			name: "inject with both header and query_param",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source: envSource("OPENAI_API_KEY"),
+				Inject: &injectConfig{Header: "Authorization", QueryParam: "key"},
+				Rules:  []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "cannot specify both header and query_param",
+		},
+		{
+			name: "inject with neither header nor query_param",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source: envSource("OPENAI_API_KEY"),
+				Inject: &injectConfig{},
+				Rules:  []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "must specify either header or query_param",
+		},
+		{
+			name: "replace block with empty proxy_value",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:  envSource("OPENAI_API_KEY"),
+				Replace: &replaceConfig{ProxyValue: ""},
+				Rules:   []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "replace.proxy_value is required",
+		},
+		{
+			name: "legacy fields with replace block",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     envSource("OPENAI_API_KEY"),
+				ProxyValue: "tok",
+				Replace:    &replaceConfig{ProxyValue: "tok"},
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "cannot use both top-level proxy_value/match_headers and replace block",
+		},
+		{
+			name: "legacy fields with inject block",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source:     envSource("OPENAI_API_KEY"),
+				ProxyValue: "tok",
+				Inject:     &injectConfig{Header: "Authorization"},
+				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "cannot use both top-level proxy_value/match_headers and inject block",
+		},
+		{
+			name: "invalid formatter template",
+			cfg: secretsConfig{Secrets: []secretEntry{{
+				Source: envSource("OPENAI_API_KEY"),
+				Inject: &injectConfig{Header: "Authorization", Formatter: "{{ .Invalid"},
+				Rules:  []hostmatch.RuleConfig{{Host: "example.com"}},
+			}}},
+			errMsg: "parsing formatter template",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newFromConfig(context.Background(), tt.cfg, testRegistry())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestInject_ConcurrentSafety(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{injectEntry()})
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := openaiReq("GET", "/v1/chat")
+			doTransform(t, s, req)
+			require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+		}()
+	}
+	wg.Wait()
 }

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -62,34 +62,78 @@ transforms:
   - name: secrets
     config:
       secrets:
+        # Inject mode: the proxy always sets the header on matching requests.
+        # The client does not need to send any credential.
         - source:
             type: env
             var: OPENAI_API_KEY
-          proxy_value: "proxy-token-123"
-          match_headers: ["Authorization"]
-          match_body: false
-          # When true, requests to a matching host that do not contain the proxy
-          # token are rejected (403). Prevents workloads from bypassing the
-          # secret-swap mechanism with alternative credentials.
-          require: true
+          inject:
+            header: "Authorization"
+            # Go template with .Value (the secret) and base64 (variadic concat+encode).
+            formatter: "Bearer {{ .Value }}"
           rules:
             - host: "api.openai.com"
               methods: ["POST"]
               paths: ["/v1/*"]
 
-        # Example: secret from AWS Secrets Manager with background refresh
+        # Inject mode with query parameter (no formatter needed):
+        # - source:
+        #     type: env
+        #     var: MAPS_API_KEY
+        #   inject:
+        #     query_param: "key"
+        #   rules:
+        #     - host: "maps.googleapis.com"
+
+        # Inject mode with base64 formatter (e.g. GitHub-style basic auth):
+        # - source:
+        #     type: env
+        #     var: GITHUB_TOKEN
+        #   inject:
+        #     header: "Authorization"
+        #     formatter: 'Basic {{ base64 "x-credential:" .Value }}'
+        #   rules:
+        #     - host: "api.github.com"
+
+        # Replace mode: the client sends a proxy token, and the proxy swaps it
+        # for the real secret before forwarding upstream.
+        - source:
+            type: env
+            var: ANTHROPIC_API_KEY
+          replace:
+            proxy_value: "proxy-token-123"
+            match_headers: ["X-Api-Key"]
+            # When true, requests to a matching host that do not contain the
+            # proxy token are rejected (403). Prevents workloads from bypassing
+            # the secret-swap mechanism with alternative credentials.
+            require: true
+          rules:
+            - host: "*.anthropic.com"
+              methods: ["POST"]
+              paths: ["/v1/messages", "/v1/complete"]
+
+        # Replace mode with AWS Secrets Manager and background refresh:
         # - source:
         #     type: aws_sm
         #     secret_id: "arn:aws:secretsmanager:us-east-1:123456:secret:my-api-key"
         #     region: "us-east-1"      # optional, falls back to AWS SDK default
         #     json_key: "api_key"      # optional, extract a field from a JSON secret
         #     ttl: "15m"               # optional, re-fetch interval; 0 = no refresh
-        #   proxy_value: "proxy-token-456"
-        #   match_headers: ["Authorization"]
+        #   replace:
+        #     proxy_value: "proxy-token-456"
+        #     match_headers: ["Authorization"]
         #   rules:
-        #     - host: "*.anthropic.com"
-        #       methods: ["POST"]
-        #       paths: ["/v1/messages", "/v1/complete"]
+        #     - host: "api.example.com"
+
+        # Legacy replace mode (top-level fields, still supported):
+        # - source:
+        #     type: env
+        #     var: OPENAI_API_KEY
+        #   proxy_value: "proxy-token-123"
+        #   match_headers: ["Authorization"]
+        #   require: true
+        #   rules:
+        #     - host: "api.openai.com"
 
   # gRPC transforms: each entry delegates to one external TransformService server.
   # Use multiple entries for multiple servers; they run in pipeline order.


### PR DESCRIPTION
Adds an inject mode to the secrets transform that always sets a header or query param on matching requests, without requiring a proxy token from the client. Uses a Go template `formatter` field with `.Value` and a variadic `base64` function for flexible value formatting (e.g. `Bearer {{ .Value }}`, `Basic {{ base64 "user:" .Value }}`).

Replace mode config moves into a dedicated `replace:` block for consistency; legacy top-level fields (`proxy_value`, `match_headers`, etc.) remain supported for backwards compatibility.