### PR TITLE
Add AWS SSM secret source

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,10 @@ transforms:
 
 The sandbox never holds real credentials. Instead:
 
-1. Set real secrets as environment variables on the iron-proxy container.
+1. Configure iron-proxy with the real secret source: environment variables,
+   AWS Secrets Manager, or AWS Systems Manager Parameter Store.
 2. Give the sandbox a proxy token (e.g., `proxy-openai-abc123`).
-3. Configure the `secrets` transform to map proxy tokens to env vars.
+3. Configure the `secrets` transform to map proxy tokens to those sources.
 
 iron-proxy scans outbound requests and replaces proxy tokens with the real
 values before forwarding upstream. You control where it looks:
@@ -326,6 +327,16 @@ values before forwarding upstream. You control where it looks:
 - **`hosts`:** restrict swapping to specific domains or CIDRs.
 
 Query parameters are always scanned.
+
+Secret sources:
+
+- **`env`:** reads `var` from the proxy process environment.
+- **`aws_sm`:** reads `secret_id` from AWS Secrets Manager. Optional `region`,
+  `json_key`, and `ttl` are supported.
+- **`aws_ssm`:** reads `name` from AWS Systems Manager Parameter Store. Optional
+  `region`, `with_decryption`, `json_key`, and `ttl` are supported.
+  `with_decryption` defaults to `true`, which is the expected setting for
+  `SecureString` parameters.
 
 ### Body limits
 

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -33,3 +33,4 @@ domains:
 
   # AWS (for integration tests)
   - "secretsmanager.us-west-1.amazonaws.com"
+  - "ssm.us-east-1.amazonaws.com"

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -33,4 +33,4 @@ domains:
 
   # AWS (for integration tests)
   - "secretsmanager.us-west-1.amazonaws.com"
-  - "ssm.us-east-1.amazonaws.com"
+  - "ssm.us-west-1.amazonaws.com"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/miekg/dns v1.1.72

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5 h1:z2ayoK3pOvf8ODj/v
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5/go.mod h1:mpZB5HAl4ZIISod9qCi12xZ170TbHX9CCJV5y7nb7QU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4 h1:5Wg8AAAnIWM2LE/0KFGqllZff96bm4dBs+uerYFfReE=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.4/go.mod h1:nph0ypDLWm9D9iA9zOX39W/N+A4GqwzlxA13jzXVD4k=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15/go.mod h1:WSvS1NLr7JaPunCXqpJnWk1Bjo7IxzZXrZi1QQCkuqM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=

--- a/integration_test/aws_ssm_test.go
+++ b/integration_test/aws_ssm_test.go
@@ -1,0 +1,62 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAWSSystemsManagerParameterStore boots the proxy with real AWS SSM
+// Parameter Store parameters and verifies proxy token replacement.
+func TestAWSSystemsManagerParameterStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+
+	// Upstream: echoes back the parameter headers so we can verify the swap.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Raw-Param", r.Header.Get("X-Raw-Param"))
+		w.Header().Set("X-Got-JSON-Param", r.Header.Get("X-JSON-Param"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfgPath := renderConfig(t, tmpDir, "aws_ssm.yaml", nil)
+	proxy := startProxy(t, binary, cfgPath, nil)
+	upstreamHost := upstream.Listener.Addr().String()
+
+	t.Run("raw_parameter", func(t *testing.T) {
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
+		require.NoError(t, err)
+		req.Host = upstreamHost
+		req.Header.Set("X-Raw-Param", "proxy-raw-param")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "example_raw_value", resp.Header.Get("X-Got-Raw-Param"))
+	})
+
+	t.Run("json_parameter", func(t *testing.T) {
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
+		require.NoError(t, err)
+		req.Host = upstreamHost
+		req.Header.Set("X-JSON-Param", "proxy-json-param")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "example_value", resp.Header.Get("X-Got-JSON-Param"))
+	})
+}

--- a/integration_test/testdata/aws_ssm.yaml
+++ b/integration_test/testdata/aws_ssm.yaml
@@ -22,7 +22,7 @@ transforms:
       secrets:
         - source:
             type: aws_ssm
-            name: "/ironsh/exmaple-raw-param"
+            name: "/ironsh/example-raw-param"
             region: "us-west-1"
             with_decryption: true
           proxy_value: "proxy-raw-param"

--- a/integration_test/testdata/aws_ssm.yaml
+++ b/integration_test/testdata/aws_ssm.yaml
@@ -1,0 +1,45 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+  - name: secrets
+    config:
+      secrets:
+        - source:
+            type: aws_ssm
+            name: "/ironsh/exmaple-raw-param"
+            region: "us-west-1"
+            with_decryption: true
+          proxy_value: "proxy-raw-param"
+          match_headers: ["X-Raw-Param"]
+          rules:
+            - host: "127.0.0.1"
+
+        - source:
+            type: aws_ssm
+            name: "/ironsh/example-json-param"
+            region: "us-west-1"
+            with_decryption: true
+            json_key: "example_key"
+          proxy_value: "proxy-json-param"
+          match_headers: ["X-JSON-Param"]
+          rules:
+            - host: "127.0.0.1"
+
+metrics:
+  listen: "127.0.0.1:0"

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"gopkg.in/yaml.v3"
 )
 
@@ -77,6 +78,64 @@ func staticValue(val string) func(context.Context) (string, error) {
 	return func(context.Context) (string, error) { return val, nil }
 }
 
+// --- shared AWS client cache ---
+
+// awsClientCache provides region-keyed caching for any AWS service client.
+type awsClientCache[C any] struct {
+	mu        sync.Mutex
+	clients   map[string]C
+	newClient func(cfg aws.Config) C
+}
+
+func (c *awsClientCache[C]) get(ctx context.Context, region string) (C, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if client, ok := c.clients[region]; ok {
+		return client, nil
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		var zero C
+		return zero, fmt.Errorf("loading AWS config: %w", err)
+	}
+	client := c.newClient(cfg)
+	c.clients[region] = client
+	return client, nil
+}
+
+// resolveWithTTL builds a ResolveResult with optional TTL-based caching.
+func resolveWithTTL(name, initialValue, ttlStr string, logger *slog.Logger, refresh func(context.Context) (string, error)) (ResolveResult, error) {
+	var ttl time.Duration
+	if ttlStr != "" {
+		var err error
+		ttl, err = time.ParseDuration(ttlStr)
+		if err != nil {
+			return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", ttlStr, err)
+		}
+	}
+
+	var getValue func(context.Context) (string, error)
+	if ttl > 0 {
+		cv := &cachedValue{
+			value:     initialValue,
+			expiresAt: time.Now().Add(ttl),
+			ttl:       ttl,
+			logger:    logger,
+			name:      name,
+			refresh:   refresh,
+		}
+		getValue = cv.get
+	} else {
+		getValue = staticValue(initialValue)
+	}
+
+	return ResolveResult{Name: name, GetValue: getValue}, nil
+}
+
 // --- AWS Secrets Manager resolver ---
 
 // smClient is the subset of the AWS Secrets Manager API used by awsSMResolver.
@@ -86,8 +145,6 @@ type smClient interface {
 
 // awsSMResolver reads secrets from AWS Secrets Manager.
 type awsSMResolver struct {
-	mu        sync.Mutex
-	clients   map[string]smClient
 	clientFor func(ctx context.Context, region string) (smClient, error)
 	logger    *slog.Logger
 }
@@ -101,31 +158,11 @@ type awsSMConfig struct {
 }
 
 func newAWSSMResolver(logger *slog.Logger) *awsSMResolver {
-	r := &awsSMResolver{
-		clients: make(map[string]smClient),
-		logger:  logger,
+	cache := &awsClientCache[smClient]{
+		clients:   make(map[string]smClient),
+		newClient: func(cfg aws.Config) smClient { return secretsmanager.NewFromConfig(cfg) },
 	}
-	r.clientFor = r.defaultClientFor
-	return r
-}
-
-func (r *awsSMResolver) defaultClientFor(ctx context.Context, region string) (smClient, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if c, ok := r.clients[region]; ok {
-		return c, nil
-	}
-	var opts []func(*awsconfig.LoadOptions) error
-	if region != "" {
-		opts = append(opts, awsconfig.WithRegion(region))
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
-	}
-	c := secretsmanager.NewFromConfig(cfg)
-	r.clients[region] = c
-	return c, nil
+	return &awsSMResolver{clientFor: cache.get, logger: logger}
 }
 
 func (r *awsSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
@@ -137,38 +174,14 @@ func (r *awsSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResu
 		return ResolveResult{}, fmt.Errorf("aws_sm source requires \"secret_id\" field")
 	}
 
-	// Fetch initial value to validate config eagerly at startup.
 	val, err := r.fetchSecret(ctx, cfg)
 	if err != nil {
 		return ResolveResult{}, err
 	}
 
-	var ttl time.Duration
-	if cfg.TTL != "" {
-		ttl, err = time.ParseDuration(cfg.TTL)
-		if err != nil {
-			return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
-		}
-	}
-
-	var getValue func(context.Context) (string, error)
-	if ttl > 0 {
-		cv := &cachedValue{
-			value:     val,
-			expiresAt: time.Now().Add(ttl),
-			ttl:       ttl,
-			logger:    r.logger,
-			name:      cfg.SecretID,
-			refresh: func(ctx context.Context) (string, error) {
-				return r.fetchSecret(ctx, cfg)
-			},
-		}
-		getValue = cv.get
-	} else {
-		getValue = staticValue(val)
-	}
-
-	return ResolveResult{Name: cfg.SecretID, GetValue: getValue}, nil
+	return resolveWithTTL(cfg.SecretID, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+		return r.fetchSecret(ctx, cfg)
+	})
 }
 
 func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
@@ -191,6 +204,87 @@ func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (strin
 	}
 	if val == "" {
 		return "", fmt.Errorf("secret %q resolved to empty value", cfg.SecretID)
+	}
+	return val, nil
+}
+
+// --- AWS Systems Manager Parameter Store resolver ---
+
+// ssmClient is the subset of the AWS SSM API used by awsSSMResolver.
+type ssmClient interface {
+	GetParameter(ctx context.Context, input *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+}
+
+// awsSSMResolver reads secrets from AWS Systems Manager Parameter Store.
+type awsSSMResolver struct {
+	clientFor func(ctx context.Context, region string) (ssmClient, error)
+	logger    *slog.Logger
+}
+
+type awsSSMConfig struct {
+	Type           string `yaml:"type"`
+	Name           string `yaml:"name"`
+	Region         string `yaml:"region,omitempty"`
+	WithDecryption *bool  `yaml:"with_decryption,omitempty"`
+	JSONKey        string `yaml:"json_key,omitempty"`
+	TTL            string `yaml:"ttl,omitempty"`
+}
+
+func (cfg awsSSMConfig) decryptValue() bool {
+	return cfg.WithDecryption == nil || *cfg.WithDecryption
+}
+
+func newAWSSSMResolver(logger *slog.Logger) *awsSSMResolver {
+	cache := &awsClientCache[ssmClient]{
+		clients:   make(map[string]ssmClient),
+		newClient: func(cfg aws.Config) ssmClient { return ssm.NewFromConfig(cfg) },
+	}
+	return &awsSSMResolver{clientFor: cache.get, logger: logger}
+}
+
+func (r *awsSSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+	var cfg awsSSMConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing aws_ssm source config: %w", err)
+	}
+	if cfg.Name == "" {
+		return ResolveResult{}, fmt.Errorf("aws_ssm source requires \"name\" field")
+	}
+
+	val, err := r.fetchParameter(ctx, cfg)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+
+	return resolveWithTTL(cfg.Name, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+		return r.fetchParameter(ctx, cfg)
+	})
+}
+
+func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (string, error) {
+	client, err := r.clientFor(ctx, cfg.Region)
+	if err != nil {
+		return "", fmt.Errorf("creating AWS SSM client: %w", err)
+	}
+	out, err := client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(cfg.Name),
+		WithDecryption: aws.Bool(cfg.decryptValue()),
+	})
+	if err != nil {
+		return "", fmt.Errorf("fetching parameter %q: %w", cfg.Name, err)
+	}
+	if out == nil || out.Parameter == nil {
+		return "", fmt.Errorf("parameter %q resolved without a value", cfg.Name)
+	}
+	val := aws.ToString(out.Parameter.Value)
+	if cfg.JSONKey != "" {
+		val, err = extractJSONKey(val, cfg.JSONKey)
+		if err != nil {
+			return "", fmt.Errorf("extracting json_key %q from parameter %q: %w", cfg.JSONKey, cfg.Name, err)
+		}
+	}
+	if val == "" {
+		return "", fmt.Errorf("parameter %q resolved to empty value", cfg.Name)
 	}
 	return val, nil
 }

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -40,14 +42,37 @@ func staticSMClient(out *secretsmanager.GetSecretValueOutput, err error) *mockSM
 }
 
 func newTestAWSSMResolver(client smClient) *awsSMResolver {
-	r := &awsSMResolver{
-		clients: make(map[string]smClient),
-		logger:  slog.Default(),
+	return &awsSMResolver{
+		clientFor: func(_ context.Context, _ string) (smClient, error) {
+			return client, nil
+		},
+		logger: slog.Default(),
 	}
-	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
-		return client, nil
+}
+
+// mockSSMClient is a configurable mock for the AWS SSM client.
+type mockSSMClient struct {
+	fn func(ctx context.Context, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+}
+
+func (m *mockSSMClient) GetParameter(ctx context.Context, input *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return m.fn(ctx, input)
+}
+
+// staticSSMClient returns a mockSSMClient that always returns the given output/error.
+func staticSSMClient(out *ssm.GetParameterOutput, err error) *mockSSMClient {
+	return &mockSSMClient{fn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+		return out, err
+	}}
+}
+
+func newTestAWSSSMResolver(client ssmClient) *awsSSMResolver {
+	return &awsSSMResolver{
+		clientFor: func(_ context.Context, _ string) (ssmClient, error) {
+			return client, nil
+		},
+		logger: slog.Default(),
 	}
-	return r
 }
 
 // --- envResolver tests ---
@@ -71,9 +96,9 @@ func TestEnvResolver_HappyPath(t *testing.T) {
 
 func TestEnvResolver_Errors(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   map[string]string
-		errMsg  string
+		name   string
+		input  map[string]string
+		errMsg string
 	}{
 		{
 			name:   "missing var field",
@@ -222,15 +247,201 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 	}
 }
 
+// --- awsSSMResolver tests ---
+
+func TestAWSSSMResolver_PlainString(t *testing.T) {
+	client := staticSSMClient(&ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Value: aws.String("my-param-value")},
+	}, nil)
+	r := newTestAWSSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_ssm", "name": "/myapp/api-key"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "/myapp/api-key", result.Name)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "my-param-value", val)
+}
+
+func TestAWSSSMResolver_JSONKey(t *testing.T) {
+	client := staticSSMClient(&ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Value: aws.String(`{"api_key": "sk-abc123", "other": "val"}`)},
+	}, nil)
+	r := newTestAWSSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":     "aws_ssm",
+		"name":     "/myapp/config",
+		"json_key": "api_key",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "sk-abc123", val)
+}
+
+func TestAWSSSMResolver_TTLReturnsCachedValue(t *testing.T) {
+	client := staticSSMClient(&ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
+	}, nil)
+	r := newTestAWSSSMResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type": "aws_ssm",
+		"name": "/myapp/secret",
+		"ttl":  "15m",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}
+
+func TestAWSSSMResolver_WithDecryption(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]any
+		want bool
+	}{
+		{
+			name: "defaults to true",
+			raw:  map[string]any{"type": "aws_ssm", "name": "/myapp/secret"},
+			want: true,
+		},
+		{
+			name: "explicit true",
+			raw:  map[string]any{"type": "aws_ssm", "name": "/myapp/secret", "with_decryption": true},
+			want: true,
+		},
+		{
+			name: "explicit false",
+			raw:  map[string]any{"type": "aws_ssm", "name": "/myapp/secret", "with_decryption": false},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedInput *ssm.GetParameterInput
+			client := &mockSSMClient{fn: func(_ context.Context, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+				capturedInput = input
+				return &ssm.GetParameterOutput{
+					Parameter: &ssmtypes.Parameter{Value: aws.String("decrypted-value")},
+				}, nil
+			}}
+			r := newTestAWSSSMResolver(client)
+			result, err := r.Resolve(context.Background(), yamlNode(t, tt.raw))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, aws.ToBool(capturedInput.WithDecryption))
+
+			val, err := result.GetValue(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, "decrypted-value", val)
+		})
+	}
+}
+
+func TestAWSSSMResolver_Region(t *testing.T) {
+	client := staticSSMClient(&ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
+	}, nil)
+	var gotRegion string
+	r := &awsSSMResolver{
+		clientFor: func(_ context.Context, region string) (ssmClient, error) {
+			gotRegion = region
+			return client, nil
+		},
+		logger: slog.Default(),
+	}
+
+	_, err := r.Resolve(context.Background(), yamlNode(t, map[string]string{
+		"type":   "aws_ssm",
+		"name":   "/myapp/secret",
+		"region": "us-east-1",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "us-east-1", gotRegion)
+}
+
+func TestAWSSSMResolver_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *mockSSMClient
+		input  map[string]string
+		errMsg string
+	}{
+		{
+			name:   "missing name",
+			client: staticSSMClient(nil, nil),
+			input:  map[string]string{"type": "aws_ssm"},
+			errMsg: "\"name\" field",
+		},
+		{
+			name:   "aws error",
+			client: staticSSMClient(nil, fmt.Errorf("parameter not found")),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/missing"},
+			errMsg: "parameter not found",
+		},
+		{
+			name: "empty parameter value",
+			client: staticSSMClient(&ssm.GetParameterOutput{
+				Parameter: &ssmtypes.Parameter{Value: aws.String("")},
+			}, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/empty"},
+			errMsg: "empty value",
+		},
+		{
+			name:   "missing parameter",
+			client: staticSSMClient(&ssm.GetParameterOutput{}, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/missing-value"},
+			errMsg: "without a value",
+		},
+		{
+			name:   "nil response",
+			client: staticSSMClient(nil, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/nil-response"},
+			errMsg: "without a value",
+		},
+		{
+			name: "invalid TTL",
+			client: staticSSMClient(&ssm.GetParameterOutput{
+				Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
+			}, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+		},
+		{
+			name: "json_key with invalid JSON",
+			client: staticSSMClient(&ssm.GetParameterOutput{
+				Parameter: &ssmtypes.Parameter{Value: aws.String("not-json")},
+			}, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "json_key": "api_key"},
+			errMsg: "not valid JSON",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestAWSSSMResolver(tt.client)
+			node := yamlNode(t, tt.input)
+			_, err := r.Resolve(context.Background(), node)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
 // --- extractJSONKey tests ---
 
 func TestExtractJSONKey(t *testing.T) {
 	tests := []struct {
-		name    string
-		json    string
-		key     string
-		want    string
-		errMsg  string
+		name   string
+		json   string
+		key    string
+		want   string
+		errMsg string
 	}{
 		{
 			name: "valid",

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -98,8 +98,9 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
 	registry := resolverRegistry{
-		"env":    newEnvResolver(),
-		"aws_sm": newAWSSMResolver(logger),
+		"env":     newEnvResolver(),
+		"aws_sm":  newAWSSMResolver(logger),
+		"aws_ssm": newAWSSSMResolver(logger),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
@@ -28,7 +30,7 @@ type fakeResolver struct {
 }
 
 func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
-	// Try env config first, then aws_sm config.
+	// Try env config first, then AWS-backed configs.
 	var env envConfig
 	if err := raw.Decode(&env); err == nil && env.Var != "" {
 		val, ok := f.secrets[env.Var]
@@ -44,6 +46,14 @@ func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult,
 			return ResolveResult{}, &resolveError{sm.SecretID}
 		}
 		return ResolveResult{Name: sm.SecretID, GetValue: staticValue(val)}, nil
+	}
+	var ssm awsSSMConfig
+	if err := raw.Decode(&ssm); err == nil && ssm.Name != "" {
+		val, ok := f.secrets[ssm.Name]
+		if !ok || val == "" {
+			return ResolveResult{}, &resolveError{ssm.Name}
+		}
+		return ResolveResult{Name: ssm.Name, GetValue: staticValue(val)}, nil
 	}
 	return ResolveResult{}, &resolveError{"unknown"}
 }
@@ -62,6 +72,9 @@ func testRegistry() resolverRegistry {
 		"aws_sm": &fakeResolver{secrets: map[string]string{
 			"arn:aws:sm:test": "aws-secret-value",
 		}},
+		"aws_ssm": &fakeResolver{secrets: map[string]string{
+			"/myapp/api-key": "ssm-secret-value",
+		}},
 	}
 }
 
@@ -71,6 +84,10 @@ func envSource(varName string) yaml.Node {
 
 func awsSMSource(secretID string) yaml.Node {
 	return yamlNode(&testing.T{}, map[string]string{"type": "aws_sm", "secret_id": secretID})
+}
+
+func awsSSMSource(name string) yaml.Node {
+	return yamlNode(&testing.T{}, map[string]string{"type": "aws_ssm", "name": name})
 }
 
 // defaultEntry returns the most common secretEntry used across tests.
@@ -559,29 +576,34 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 			e.ProxyValue = "proxy-aws-tok"
 			e.MatchHeaders = []string{"X-Api-Key"}
 		}),
+		defaultEntry(func(e *secretEntry) {
+			e.Source = awsSSMSource("/myapp/api-key")
+			e.ProxyValue = "proxy-ssm-tok"
+			e.MatchHeaders = []string{"X-SSM-Key"}
+		}),
 	})
 
 	req := openaiReq("GET", "/v1/chat")
 	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 	req.Header.Set("X-Api-Key", "proxy-aws-tok")
+	req.Header.Set("X-SSM-Key", "proxy-ssm-tok")
 
 	doTransform(t, s, req)
 
 	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
 	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
+	require.Equal(t, "ssm-secret-value", req.Header.Get("X-SSM-Key"))
 }
 
 // --- End-to-end tests with real awsSMResolver and mock AWS client ---
 
 func awsSMRegistry(client smClient) resolverRegistry {
-	r := &awsSMResolver{
-		clients: make(map[string]smClient),
-		logger:  slog.Default(),
-	}
-	r.clientFor = func(_ context.Context, _ string) (smClient, error) {
-		return client, nil
-	}
-	return resolverRegistry{"aws_sm": r}
+	return resolverRegistry{"aws_sm": &awsSMResolver{
+		clientFor: func(_ context.Context, _ string) (smClient, error) {
+			return client, nil
+		},
+		logger: slog.Default(),
+	}}
 }
 
 func makeAWSSMSecrets(t *testing.T, client smClient, entries []secretEntry) *Secrets {
@@ -644,10 +666,10 @@ func TestAWSSM_EndToEnd_BodySwap(t *testing.T) {
 	}, nil)
 
 	s := makeAWSSMSecrets(t, client, []secretEntry{{
-		Source:    yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
+		Source:     yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"}),
 		ProxyValue: "proxy-tok",
-		MatchBody: true,
-		Rules:     []hostmatch.RuleConfig{{Host: "api.example.com"}},
+		MatchBody:  true,
+		Rules:      []hostmatch.RuleConfig{{Host: "api.example.com"}},
 	}})
 
 	body := `{"key": "proxy-tok"}`
@@ -767,6 +789,57 @@ func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+// --- End-to-end tests with real awsSSMResolver and mock AWS client ---
+
+func awsSSMRegistry(client ssmClient) resolverRegistry {
+	return resolverRegistry{"aws_ssm": &awsSSMResolver{
+		clientFor: func(_ context.Context, _ string) (ssmClient, error) {
+			return client, nil
+		},
+		logger: slog.Default(),
+	}}
+}
+
+func makeAWSSSMSecrets(t *testing.T, client ssmClient, entries []secretEntry) *Secrets {
+	t.Helper()
+	cfg := secretsConfig{Secrets: entries}
+	s, err := newFromConfig(context.Background(), cfg, awsSSMRegistry(client))
+	require.NoError(t, err)
+	return s
+}
+
+func TestAWSSSM_EndToEnd_JSONKeyHeaderSwap(t *testing.T) {
+	client := &mockSSMClient{fn: func(_ context.Context, input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+		require.Equal(t, "/myapp/api-key", aws.ToString(input.Name))
+		require.True(t, aws.ToBool(input.WithDecryption))
+		return &ssm.GetParameterOutput{
+			Parameter: &ssmtypes.Parameter{Value: aws.String(`{"api_key":"sk-from-ssm"}`)},
+		}, nil
+	}}
+
+	s := makeAWSSSMSecrets(t, client, []secretEntry{{
+		Source: yamlNode(t, map[string]string{
+			"type":     "aws_ssm",
+			"name":     "/myapp/api-key",
+			"region":   "us-east-1",
+			"json_key": "api_key",
+			"ttl":      "15m",
+		}),
+		Replace: &replaceConfig{
+			ProxyValue:   "proxy-token-789",
+			MatchHeaders: []string{"Authorization"},
+		},
+		Rules: []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}})
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1/data", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-token-789")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-from-ssm", req.Header.Get("Authorization"))
 }
 
 // --- Inject mode tests ---

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -125,6 +125,20 @@ transforms:
         #   rules:
         #     - host: "api.example.com"
 
+        # Replace mode with AWS Systems Manager Parameter Store:
+        # - source:
+        #     type: aws_ssm
+        #     name: "/myapp/api-key"           # parameter name or ARN
+        #     region: "us-east-1"              # optional, falls back to AWS SDK default
+        #     with_decryption: true            # optional, defaults to true for SecureString params
+        #     json_key: "api_key"              # optional, extract a field from a JSON value
+        #     ttl: "15m"                       # optional, re-fetch interval; 0 = no refresh
+        #   replace:
+        #     proxy_value: "proxy-token-789"
+        #     match_headers: ["Authorization"]
+        #   rules:
+        #     - host: "api.example.com"
+
         # Legacy replace mode (top-level fields, still supported):
         # - source:
         #     type: env


### PR DESCRIPTION
- add `aws_ssm` as a secrets source backed by AWS Systems Manager Parameter Store
- support region, with_decryption, json_key, and ttl for SSM parameters
- default SSM decryption to true and guard malformed GetParameter responses
- document the new config shape and add test coverage