### PR TITLE
feat: add `iron-proxy init` command

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -56,8 +56,10 @@ func runInit(args []string) {
 	// 1. Generate CA certificate and key.
 	if *force {
 		// Remove existing files so cagen.WriteFiles doesn't refuse.
-		os.Remove(certPath)
-		os.Remove(keyPath)
+		// Errors are ignored: the files may not exist, and any real
+		// permission issue will surface in cagen.WriteFiles.
+		_ = os.Remove(certPath)
+		_ = os.Remove(keyPath)
 	}
 
 	result, err := cagen.Generate(cagen.Options{
@@ -303,7 +305,7 @@ Next steps:
   Config reference             https://docs.iron.sh/reference/configuration
   Enable secret proxying       https://docs.iron.sh/reference/secret-proxying
   Production deployment        https://docs.iron.sh/reference/deployment-methods
-`, tunnelPort, configDir, tunnelPort, configDir, tunnelPort, configDir)
+`, tunnelPort, configDir, tunnelPort, configDir, tunnelPort)
 }
 
 func printSuccessBackground(configDir, tunnelPort string, pid int) {
@@ -331,7 +333,7 @@ Next steps:
   Config reference             https://docs.iron.sh/reference/configuration
   Enable secret proxying       https://docs.iron.sh/reference/secret-proxying
   Production deployment        https://docs.iron.sh/reference/deployment-methods
-`, configDir, tunnelPort, configDir, tunnelPort, configDir, configDir)
+`, configDir, tunnelPort, configDir, tunnelPort, configDir)
 }
 
 func printSuccessNoStart(configDir, tunnelPort string) {

--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ironsh/iron-proxy/internal/cagen"
+)
+
+const (
+	defaultConfigDir  = "/etc/iron-proxy"
+	defaultTunnelPort = "1080"
+	defaultAllowList  = "httpbin.org"
+	defaultLogFile    = "/var/log/iron-proxy.log"
+)
+
+func runInit(args []string) {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	configDir := fs.String("config-dir", defaultConfigDir, "directory for config, CA cert, and CA key")
+	tunnelPort := fs.String("tunnel-port", defaultTunnelPort, "port for the CONNECT/SOCKS5 tunnel listener")
+	allow := fs.String("allow", defaultAllowList, "comma-separated domains for the initial allowlist")
+	noStart := fs.Bool("no-start", false, "generate config and unit file but don't start the service")
+	force := fs.Bool("force", false, "overwrite existing config and CA")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Require root.
+	if os.Getuid() != 0 {
+		fmt.Fprintln(os.Stderr, "iron-proxy init requires root. Run: sudo iron-proxy init")
+		os.Exit(1)
+	}
+
+	certPath := filepath.Join(*configDir, "ca.crt")
+	keyPath := filepath.Join(*configDir, "ca.key")
+	configPath := filepath.Join(*configDir, "proxy.yaml")
+
+	// Check for existing files unless --force.
+	if !*force {
+		for _, p := range []string{configPath, certPath} {
+			if _, err := os.Stat(p); err == nil {
+				fmt.Fprintf(os.Stderr, "iron-proxy is already configured. Use --force to overwrite.\n")
+				os.Exit(1)
+			}
+		}
+	}
+
+	// 1. Generate CA certificate and key.
+	if *force {
+		// Remove existing files so cagen.WriteFiles doesn't refuse.
+		os.Remove(certPath)
+		os.Remove(keyPath)
+	}
+
+	result, err := cagen.Generate(cagen.Options{
+		Name:        "iron-proxy CA",
+		ExpiryHours: 2160, // 90 days
+		Algorithm:   cagen.RSA4096,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error generating CA: %v\n", err)
+		os.Exit(1)
+	}
+
+	if _, _, err := cagen.WriteFiles(*configDir, result); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing CA files: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 2. Write default config.
+	domains := parseDomainList(*allow)
+	configYAML := generateConfig(*configDir, *tunnelPort, domains)
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing config: %v\n", err)
+		os.Exit(1)
+	}
+
+	// 3. Install and start the service.
+	execPath := resolveExecPath()
+
+	hasSystemd := hasSystemd()
+	if hasSystemd {
+		unitContent := generateSystemdUnit(execPath, configPath)
+		unitPath := "/etc/systemd/system/iron-proxy.service"
+		if err := os.WriteFile(unitPath, []byte(unitContent), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error writing systemd unit: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := runCommand("systemctl", "daemon-reload"); err != nil {
+			fmt.Fprintf(os.Stderr, "error: systemctl daemon-reload: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := runCommand("systemctl", "enable", "iron-proxy"); err != nil {
+			fmt.Fprintf(os.Stderr, "error: systemctl enable: %v\n", err)
+			os.Exit(1)
+		}
+
+		if !*noStart {
+			if err := runCommand("systemctl", "start", "iron-proxy"); err != nil {
+				fmt.Fprintf(os.Stderr, "error: systemctl start: %v\n", err)
+				os.Exit(1)
+			}
+
+			if err := waitForService(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: iron-proxy failed to start\n")
+				printLogTail()
+				os.Exit(1)
+			}
+		}
+
+		printSuccessSystemd(*configDir, *tunnelPort, *noStart)
+	} else {
+		// Non-systemd fallback: start as a background process.
+		if *noStart {
+			printSuccessNoStart(*configDir, *tunnelPort)
+			return
+		}
+
+		pid, err := startBackground(execPath, configPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error starting iron-proxy: %v\n", err)
+			os.Exit(1)
+		}
+
+		pidPath := filepath.Join(*configDir, "iron-proxy.pid")
+		if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error writing PID file: %v\n", err)
+			os.Exit(1)
+		}
+
+		printSuccessBackground(*configDir, *tunnelPort, pid)
+	}
+}
+
+func parseDomainList(s string) []string {
+	parts := strings.Split(s, ",")
+	domains := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			domains = append(domains, p)
+		}
+	}
+	return domains
+}
+
+func generateConfig(configDir, tunnelPort string, domains []string) string {
+	var domainLines string
+	for _, d := range domains {
+		domainLines += fmt.Sprintf("        - %q\n", d)
+	}
+
+	return fmt.Sprintf(`proxy:
+  http_listen: ":8080"
+  https_listen: ":8443"
+  tunnel_listen: ":%s"
+
+tls:
+  ca_cert: "%s/ca.crt"
+  ca_key: "%s/ca.key"
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+%s
+log:
+  level: "info"
+`, tunnelPort, configDir, configDir, domainLines)
+}
+
+func generateSystemdUnit(execPath, configPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=iron-proxy egress firewall
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s -config %s
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=-/etc/iron-proxy/env
+StandardOutput=append:/var/log/iron-proxy.log
+StandardError=append:/var/log/iron-proxy.log
+
+[Install]
+WantedBy=multi-user.target
+`, execPath, configPath)
+}
+
+func resolveExecPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "/usr/local/bin/iron-proxy"
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe
+	}
+	return resolved
+}
+
+func hasSystemd() bool {
+	_, err := exec.LookPath("systemctl")
+	return err == nil
+}
+
+func runCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func waitForService() error {
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("systemctl", "is-active", "iron-proxy").Output()
+		if err == nil && strings.TrimSpace(string(out)) == "active" {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("service did not become active within 3 seconds")
+}
+
+func printLogTail() {
+	data, err := os.ReadFile(defaultLogFile)
+	if err != nil {
+		return
+	}
+	lines := strings.Split(string(data), "\n")
+	start := 0
+	if len(lines) > 10 {
+		start = len(lines) - 10
+	}
+	fmt.Fprintln(os.Stderr, "\nLast log lines:")
+	for _, line := range lines[start:] {
+		if line != "" {
+			fmt.Fprintln(os.Stderr, "  "+line)
+		}
+	}
+}
+
+func startBackground(execPath, configPath string) (int, error) {
+	logFile, err := os.OpenFile(defaultLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("opening log file: %w", err)
+	}
+
+	cmd := exec.Command(execPath, "-config", configPath)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		return 0, fmt.Errorf("starting process: %w", err)
+	}
+
+	// Close our handle to the log file; the child has its own.
+	logFile.Close()
+
+	return cmd.Process.Pid, nil
+}
+
+func printSuccessSystemd(configDir, tunnelPort string, noStart bool) {
+	fmt.Printf("✓ Generated CA certificate     %s/ca.crt\n", configDir)
+	fmt.Printf("✓ Wrote config                 %s/proxy.yaml\n", configDir)
+	if noStart {
+		fmt.Println("✓ Installed systemd unit       systemctl start iron-proxy")
+	} else {
+		fmt.Println("✓ Started iron-proxy service   systemctl status iron-proxy")
+	}
+
+	fmt.Printf(`
+iron-proxy is running on :%s (CONNECT tunnel mode).
+
+Try it:
+
+  # Allowed (httpbin.org is in the allowlist)
+  curl --cacert %s/ca.crt --proxy http://localhost:%s https://httpbin.org/get
+
+  # Blocked (everything else returns 403)
+  curl --cacert %s/ca.crt --proxy http://localhost:%s https://example.com
+
+  # View audit logs
+  tail -f /var/log/iron-proxy.log
+
+Next steps:
+
+  Config reference             https://docs.iron.sh/reference/configuration
+  Enable secret proxying       https://docs.iron.sh/reference/secret-proxying
+  Production deployment        https://docs.iron.sh/reference/deployment-methods
+`, tunnelPort, configDir, tunnelPort, configDir, tunnelPort, configDir)
+}
+
+func printSuccessBackground(configDir, tunnelPort string, pid int) {
+	fmt.Printf("✓ Generated CA certificate     %s/ca.crt\n", configDir)
+	fmt.Printf("✓ Wrote config                 %s/proxy.yaml\n", configDir)
+	fmt.Printf("✓ iron-proxy running           pid %d → /var/log/iron-proxy.log\n", pid)
+
+	fmt.Printf(`
+Try it:
+
+  # Allowed (httpbin.org is in the allowlist)
+  curl --cacert %s/ca.crt --proxy http://localhost:%s https://httpbin.org/get
+
+  # Blocked (everything else returns 403)
+  curl --cacert %s/ca.crt --proxy http://localhost:%s https://example.com
+
+  # View audit logs
+  tail -f /var/log/iron-proxy.log
+
+  # Stop iron-proxy
+  kill $(cat %s/iron-proxy.pid)
+
+Next steps:
+
+  Config reference             https://docs.iron.sh/reference/configuration
+  Enable secret proxying       https://docs.iron.sh/reference/secret-proxying
+  Production deployment        https://docs.iron.sh/reference/deployment-methods
+`, configDir, tunnelPort, configDir, tunnelPort, configDir, configDir)
+}
+
+func printSuccessNoStart(configDir, tunnelPort string) {
+	fmt.Println("✓ Generated CA certificate     " + configDir + "/ca.crt")
+	fmt.Println("✓ Wrote config                 " + configDir + "/proxy.yaml")
+	fmt.Printf("\nConfig written. Start iron-proxy manually:\n\n")
+	fmt.Printf("  iron-proxy -config %s/proxy.yaml\n\n", configDir)
+}

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -41,6 +41,9 @@ func main() {
 		case "generate-ca":
 			runGenerateCA(os.Args[2:])
 			return
+		case "init":
+			runInit(os.Args[2:])
+			return
 		}
 	}
 

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -1,0 +1,238 @@
+package integration_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestInit runs "iron-proxy init" against a temp directory, then verifies
+// the generated files, their permissions, and that the proxy actually starts
+// and serves traffic using the generated config.
+func TestInit(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("test requires root (run with sudo)")
+	}
+
+	binary := proxyBinary(t)
+	configDir := t.TempDir()
+
+	// Pick a free port for the tunnel listener.
+	tunnelPort := freePort(t)
+
+	// Run: iron-proxy init --config-dir <tmp> --tunnel-port <port> --no-start --allow "httpbin.org,example.com"
+	cmd := exec.Command(binary, "init",
+		"--config-dir", configDir,
+		"--tunnel-port", tunnelPort,
+		"--no-start",
+		"--allow", "httpbin.org,example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "iron-proxy init failed: %s", string(out))
+
+	certPath := filepath.Join(configDir, "ca.crt")
+	keyPath := filepath.Join(configDir, "ca.key")
+	configPath := filepath.Join(configDir, "proxy.yaml")
+
+	t.Run("files exist", func(t *testing.T) {
+		for _, p := range []string{certPath, keyPath, configPath} {
+			_, err := os.Stat(p)
+			require.NoError(t, err, "expected %s to exist", p)
+		}
+	})
+
+	t.Run("ca key permissions", func(t *testing.T) {
+		info, err := os.Stat(keyPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "ca.key should be 0600")
+	})
+
+	t.Run("ca cert permissions", func(t *testing.T) {
+		info, err := os.Stat(certPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "ca.crt should be 0644")
+	})
+
+	t.Run("ca cert is valid", func(t *testing.T) {
+		certPEM, err := os.ReadFile(certPath)
+		require.NoError(t, err)
+
+		pool := x509.NewCertPool()
+		require.True(t, pool.AppendCertsFromPEM(certPEM), "ca.crt should contain a valid PEM certificate")
+
+		// Also verify we can build a TLS keypair from the generated cert+key.
+		keyPEM, err := os.ReadFile(keyPath)
+		require.NoError(t, err)
+		_, err = tls.X509KeyPair(certPEM, keyPEM)
+		require.NoError(t, err, "ca.crt and ca.key should form a valid TLS keypair")
+	})
+
+	t.Run("config structure", func(t *testing.T) {
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+
+		var cfg struct {
+			Proxy struct {
+				HTTPListen   string `yaml:"http_listen"`
+				HTTPSListen  string `yaml:"https_listen"`
+				TunnelListen string `yaml:"tunnel_listen"`
+			} `yaml:"proxy"`
+			TLS struct {
+				CACert string `yaml:"ca_cert"`
+				CAKey  string `yaml:"ca_key"`
+			} `yaml:"tls"`
+			Transforms []struct {
+				Name   string `yaml:"name"`
+				Config struct {
+					Domains []string `yaml:"domains"`
+				} `yaml:"config"`
+			} `yaml:"transforms"`
+			Log struct {
+				Level string `yaml:"level"`
+			} `yaml:"log"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+		require.Equal(t, ":8080", cfg.Proxy.HTTPListen)
+		require.Equal(t, ":8443", cfg.Proxy.HTTPSListen)
+		require.Equal(t, ":"+tunnelPort, cfg.Proxy.TunnelListen)
+		require.Equal(t, filepath.Join(configDir, "ca.crt"), cfg.TLS.CACert)
+		require.Equal(t, filepath.Join(configDir, "ca.key"), cfg.TLS.CAKey)
+		require.Len(t, cfg.Transforms, 1)
+		require.Equal(t, "allowlist", cfg.Transforms[0].Name)
+		require.Equal(t, []string{"httpbin.org", "example.com"}, cfg.Transforms[0].Config.Domains)
+		require.Equal(t, "info", cfg.Log.Level)
+	})
+
+	t.Run("refuses without force", func(t *testing.T) {
+		cmd := exec.Command(binary, "init",
+			"--config-dir", configDir,
+			"--no-start",
+		)
+		out, err := cmd.CombinedOutput()
+		require.Error(t, err, "init should refuse when files already exist")
+		require.Contains(t, string(out), "already configured")
+	})
+
+	t.Run("force overwrites", func(t *testing.T) {
+		cmd := exec.Command(binary, "init",
+			"--config-dir", configDir,
+			"--tunnel-port", tunnelPort,
+			"--no-start",
+			"--force",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "iron-proxy init --force failed: %s", string(out))
+
+		// Files should still exist after force overwrite.
+		for _, p := range []string{certPath, keyPath, configPath} {
+			_, err := os.Stat(p)
+			require.NoError(t, err, "expected %s to exist after --force", p)
+		}
+	})
+
+	t.Run("proxy serves traffic", func(t *testing.T) {
+		// Local upstream that echoes 200 OK.
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "ok")
+		}))
+		defer upstream.Close()
+		upstreamHost := upstream.Listener.Addr().String()
+
+		// Rewrite the config with :0 for all listeners and the upstream
+		// host in the allowlist so we stay entirely local.
+		rewriteConfig(t, configPath, configDir, "0", []string{upstreamHost})
+
+		proxy := startProxy(t, binary, configPath, nil)
+
+		// Allowed: request with Host matching the allowlist.
+		req, err := http.NewRequest("GET", "http://"+proxy.HTTPAddr+"/test", nil)
+		require.NoError(t, err)
+		req.Host = upstreamHost
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Blocked: request with Host not in the allowlist.
+		req, err = http.NewRequest("GET", "http://"+proxy.HTTPAddr+"/test", nil)
+		require.NoError(t, err)
+		req.Host = "not-allowed.example.com"
+
+		resp, err = http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+}
+
+// TestInitRequiresRoot verifies that init exits with an error when not root.
+func TestInitRequiresRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test must run as non-root")
+	}
+
+	binary := proxyBinary(t)
+	cmd := exec.Command(binary, "init")
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	require.Contains(t, string(out), "requires root")
+}
+
+// freePort asks the OS for a free port and returns it as a string.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return fmt.Sprintf("%d", port)
+}
+
+// rewriteConfig rewrites the proxy.yaml with dynamic listen ports and the
+// given allowlist domains so the test doesn't collide with other services.
+func rewriteConfig(t *testing.T, configPath, configDir, tunnelPort string, domains []string) {
+	t.Helper()
+	var domainLines string
+	for _, d := range domains {
+		domainLines += fmt.Sprintf("        - %q\n", d)
+	}
+	cfg := fmt.Sprintf(`dns:
+  listen: ":0"
+  proxy_ip: "127.0.0.1"
+
+proxy:
+  http_listen: ":8080"
+  https_listen: ":8443"
+  tunnel_listen: ":%s"
+
+tls:
+  ca_cert: "%s/ca.crt"
+  ca_key: "%s/ca.key"
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+%s
+log:
+  level: "info"
+`, tunnelPort, configDir, configDir, domainLines)
+	require.NoError(t, os.WriteFile(configPath, []byte(cfg), 0o644))
+}

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -147,7 +147,7 @@ func TestInit(t *testing.T) {
 		// Local upstream that echoes 200 OK.
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, "ok")
+			_, _ = fmt.Fprintln(w, "ok")
 		}))
 		defer upstream.Close()
 		upstreamHost := upstream.Listener.Addr().String()


### PR DESCRIPTION
Adds `iron-proxy init`, a single command that takes a fresh install to a running proxy. It generates an RSA-4096 CA certificate (90-day expiry), writes a default `proxy.yaml` with an httpbin.org allowlist, and starts the service via systemd or as a detached background process on non-systemd systems. Supports `--config-dir`, `--tunnel-port`, `--allow`, `--no-start`, and `--force` flags. Includes integration tests that run `init` against a temp directory, verify file permissions and config structure, and confirm the proxy serves traffic correctly.