### PR TITLE
feat: add bootstrap token support to init and refactor config loading

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -26,6 +26,7 @@ func runInit(args []string) {
 	configDir := fs.String("config-dir", defaultConfigDir, "directory for config, CA cert, and CA key")
 	tunnelPort := fs.String("tunnel-port", defaultTunnelPort, "port for the CONNECT/SOCKS5 tunnel listener")
 	allow := fs.String("allow", defaultAllowList, "comma-separated domains for the initial allowlist")
+	bootstrapToken := fs.String("bootstrap-token", "", "bootstrap token for control plane registration (managed mode)")
 	noStart := fs.Bool("no-start", false, "generate config and unit file but don't start the service")
 	force := fs.Bool("force", false, "overwrite existing config and CA")
 	if err := fs.Parse(args); err != nil {
@@ -78,8 +79,14 @@ func runInit(args []string) {
 	}
 
 	// 2. Write default config.
-	domains := parseDomainList(*allow)
-	configYAML := generateConfig(*configDir, *tunnelPort, domains)
+	managedMode := *bootstrapToken != ""
+	var configYAML string
+	if managedMode {
+		configYAML = generateManagedConfig(*configDir, *tunnelPort)
+	} else {
+		domains := parseDomainList(*allow)
+		configYAML = generateConfig(*configDir, *tunnelPort, domains)
+	}
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing config: %v\n", err)
 		os.Exit(1)
@@ -90,7 +97,7 @@ func runInit(args []string) {
 
 	hasSystemd := hasSystemd()
 	if hasSystemd {
-		unitContent := generateSystemdUnit(execPath, configPath)
+		unitContent := generateSystemdUnit(execPath, configPath, *bootstrapToken)
 		unitPath := "/etc/systemd/system/iron-proxy.service"
 		if err := os.WriteFile(unitPath, []byte(unitContent), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "error writing systemd unit: %v\n", err)
@@ -120,7 +127,11 @@ func runInit(args []string) {
 			}
 		}
 
-		printSuccessSystemd(*configDir, *tunnelPort, *noStart)
+		if managedMode {
+			printSuccessManagedSystemd(*configDir, *tunnelPort, *noStart)
+		} else {
+			printSuccessSystemd(*configDir, *tunnelPort, *noStart)
+		}
 	} else {
 		// Non-systemd fallback: start as a background process.
 		if *noStart {
@@ -128,7 +139,7 @@ func runInit(args []string) {
 			return
 		}
 
-		pid, err := startBackground(execPath, configPath)
+		pid, err := startBackground(execPath, configPath, *bootstrapToken)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error starting iron-proxy: %v\n", err)
 			os.Exit(1)
@@ -156,6 +167,23 @@ func parseDomainList(s string) []string {
 	return domains
 }
 
+// generateManagedConfig produces a YAML config for managed mode. It omits the
+// transforms section since transforms come from the control plane.
+func generateManagedConfig(configDir, tunnelPort string) string {
+	return fmt.Sprintf(`proxy:
+  http_listen: ":8080"
+  https_listen: ":8443"
+  tunnel_listen: ":%s"
+
+tls:
+  ca_cert: "%s/ca.crt"
+  ca_key: "%s/ca.key"
+
+log:
+  level: "info"
+`, tunnelPort, configDir, configDir)
+}
+
 func generateConfig(configDir, tunnelPort string, domains []string) string {
 	var domainLines string
 	for _, d := range domains {
@@ -181,7 +209,12 @@ log:
 `, tunnelPort, configDir, configDir, domainLines)
 }
 
-func generateSystemdUnit(execPath, configPath string) string {
+func generateSystemdUnit(execPath, configPath, bootstrapToken string) string {
+	var envLine string
+	if bootstrapToken != "" {
+		envLine = fmt.Sprintf("Environment=IRON_BOOTSTRAP_TOKEN=%s\n", bootstrapToken)
+	}
+
 	return fmt.Sprintf(`[Unit]
 Description=iron-proxy egress firewall
 After=network-online.target
@@ -192,13 +225,12 @@ Type=simple
 ExecStart=%s -config %s
 Restart=on-failure
 RestartSec=5
-EnvironmentFile=-/etc/iron-proxy/env
-StandardOutput=append:/var/log/iron-proxy.log
+%sStandardOutput=append:/var/log/iron-proxy.log
 StandardError=append:/var/log/iron-proxy.log
 
 [Install]
 WantedBy=multi-user.target
-`, execPath, configPath)
+`, execPath, configPath, envLine)
 }
 
 func resolveExecPath() string {
@@ -255,7 +287,7 @@ func printLogTail() {
 	}
 }
 
-func startBackground(execPath, configPath string) (int, error) {
+func startBackground(execPath, configPath, bootstrapToken string) (int, error) {
 	logFile, err := os.OpenFile(defaultLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return 0, fmt.Errorf("opening log file: %w", err)
@@ -266,6 +298,10 @@ func startBackground(execPath, configPath string) (int, error) {
 	cmd.Stderr = logFile
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
+	if bootstrapToken != "" {
+		cmd.Env = append(os.Environ(), "IRON_BOOTSTRAP_TOKEN="+bootstrapToken)
+	}
+
 	if err := cmd.Start(); err != nil {
 		logFile.Close()
 		return 0, fmt.Errorf("starting process: %w", err)
@@ -275,6 +311,30 @@ func startBackground(execPath, configPath string) (int, error) {
 	logFile.Close()
 
 	return cmd.Process.Pid, nil
+}
+
+func printSuccessManagedSystemd(configDir, tunnelPort string, noStart bool) {
+	fmt.Printf("✓ Generated CA certificate     %s/ca.crt\n", configDir)
+	fmt.Printf("✓ Wrote config                 %s/proxy.yaml\n", configDir)
+	if noStart {
+		fmt.Println("✓ Installed systemd unit       systemctl start iron-proxy")
+	} else {
+		fmt.Println("✓ Started iron-proxy service   systemctl status iron-proxy")
+	}
+
+	fmt.Printf(`
+iron-proxy is configured in managed mode (control plane).
+
+Transforms and rules will be fetched from the control plane.
+
+  # View audit logs
+  tail -f /var/log/iron-proxy.log
+
+Next steps:
+
+  Config reference             https://docs.iron.sh/reference/configuration
+  Control plane dashboard      https://app.iron.sh
+`)
 }
 
 func printSuccessSystemd(configDir, tunnelPort string, noStart bool) {

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -84,8 +84,8 @@ func main() {
 	}
 	cred, credErr := controlplane.LoadCredential(stateStore)
 	if credErr != nil && !errors.Is(credErr, os.ErrNotExist) {
-		logger.Error("loading credential", slog.String("error", credErr.Error()))
-		os.Exit(1)
+		logger.Warn("could not load credential, ignoring", slog.String("error", credErr.Error()))
+		cred = nil
 	}
 	managed := bootstrapToken != "" || cred != nil
 

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -73,21 +73,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Managed mode is determined by the presence of a bootstrap token or
-	// an existing credential, not by the absence of a config file. This
-	// allows a config file to provide base infrastructure settings while
-	// the control plane provides transforms.
+	// Managed mode is determined by the presence of a bootstrap token.
 	// CLI flag takes precedence over environment variable.
 	bootstrapToken := *bootstrapTokenFlag
 	if bootstrapToken == "" {
 		bootstrapToken = os.Getenv("IRON_BOOTSTRAP_TOKEN")
 	}
-	cred, credErr := controlplane.LoadCredential(stateStore)
-	if credErr != nil && !errors.Is(credErr, os.ErrNotExist) {
-		logger.Warn("could not load credential, ignoring", slog.String("error", credErr.Error()))
-		cred = nil
-	}
-	managed := bootstrapToken != "" || cred != nil
+	managed := bootstrapToken != ""
 
 	// Both modes produce a pipeline holder. Managed mode populates the
 	// initial transforms from the control plane and starts a poller that
@@ -102,10 +94,8 @@ func main() {
 	errc := make(chan error, 4)
 	var holder *transform.PipelineHolder
 
-	// 4. Fetch initial config from control plane (managed) or build
-	//    pipeline from file transforms (standalone) before validation.
 	if managed {
-		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
+		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, logger)
 	} else {
 		holder = initStandalone(cfg, bodyLimits, logger)
 	}
@@ -222,7 +212,13 @@ func main() {
 // initManaged registers with the control plane, performs an initial sync, builds
 // the initial pipeline, and starts the config poller. The poller runs until ctx
 // is canceled and sends fatal errors on errc.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) *transform.PipelineHolder {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, logger *slog.Logger) *transform.PipelineHolder {
+	cred, err := controlplane.LoadCredential(stateStore)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Error("loading credential", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	tags := parseTags(os.Getenv("IRON_TAGS"))
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -61,12 +61,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	stateStore, err := resolveStateStore()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-
 	logger, err := config.NewLogger(cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -95,6 +89,11 @@ func main() {
 	var holder *transform.PipelineHolder
 
 	if managed {
+		stateStore, stateErr := resolveStateStore()
+		if stateErr != nil {
+			logger.Error("resolving state store", slog.String("error", stateErr.Error()))
+			os.Exit(1)
+		}
 		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, logger)
 	} else {
 		holder = initStandalone(cfg, bodyLimits, logger)

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -48,23 +48,14 @@ func main() {
 	}
 
 	configPath := flag.String("config", "", "path to iron-proxy YAML config file")
+	bootstrapTokenFlag := flag.String("bootstrap-token", "", "bootstrap token for control plane registration")
 	flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Mode is determined exclusively by how config is provided:
-	//   -config flag  → standalone (YAML file)
-	//   no flag       → managed (env vars + control plane)
-	managed := *configPath == ""
-
-	var cfg *config.Config
-	var err error
-	if managed {
-		cfg, err = config.FromEnv()
-	} else {
-		cfg, err = config.LoadFile(*configPath)
-	}
+	// Load config: parse file (if provided) → env overrides → defaults.
+	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -82,6 +73,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Managed mode is determined by the presence of a bootstrap token or
+	// an existing credential, not by the absence of a config file. This
+	// allows a config file to provide base infrastructure settings while
+	// the control plane provides transforms.
+	// CLI flag takes precedence over environment variable.
+	bootstrapToken := *bootstrapTokenFlag
+	if bootstrapToken == "" {
+		bootstrapToken = os.Getenv("IRON_BOOTSTRAP_TOKEN")
+	}
+	cred, credErr := controlplane.LoadCredential(stateStore)
+	if credErr != nil && !errors.Is(credErr, os.ErrNotExist) {
+		logger.Error("loading credential", slog.String("error", credErr.Error()))
+		os.Exit(1)
+	}
+	managed := bootstrapToken != "" || cred != nil
+
 	// Both modes produce a pipeline holder. Managed mode populates the
 	// initial transforms from the control plane and starts a poller that
 	// hot-reloads the pipeline.
@@ -95,10 +102,18 @@ func main() {
 	errc := make(chan error, 4)
 	var holder *transform.PipelineHolder
 
+	// 4. Fetch initial config from control plane (managed) or build
+	//    pipeline from file transforms (standalone) before validation.
 	if managed {
-		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, logger)
+		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
 	} else {
 		holder = initStandalone(cfg, bodyLimits, logger)
+	}
+
+	// 5. Validate the fully-assembled config.
+	if err := config.Validate(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Set up audit function.
@@ -207,15 +222,7 @@ func main() {
 // initManaged registers with the control plane, performs an initial sync, builds
 // the initial pipeline, and starts the config poller. The poller runs until ctx
 // is canceled and sends fatal errors on errc.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore string, logger *slog.Logger) *transform.PipelineHolder {
-	bootstrapToken := os.Getenv("IRON_BOOTSTRAP_TOKEN")
-
-	cred, err := controlplane.LoadCredential(stateStore)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		logger.Error("loading credential", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) *transform.PipelineHolder {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	tags := parseTags(os.Getenv("IRON_TAGS"))
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -67,13 +67,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Managed mode is determined by the presence of a bootstrap token.
 	// CLI flag takes precedence over environment variable.
 	bootstrapToken := *bootstrapTokenFlag
 	if bootstrapToken == "" {
 		bootstrapToken = os.Getenv("IRON_BOOTSTRAP_TOKEN")
 	}
-	managed := bootstrapToken != ""
+
+	// Managed mode is determined by the presence of a bootstrap token or
+	// an existing credential from a prior registration.
+	stateStore, err := stateStorePath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	cred, credErr := controlplane.LoadCredential(stateStore)
+	if credErr != nil && !errors.Is(credErr, os.ErrNotExist) {
+		logger.Error("loading credential", slog.String("error", credErr.Error()))
+		os.Exit(1)
+	}
+	managed := bootstrapToken != "" || cred != nil
 
 	// Both modes produce a pipeline holder. Managed mode populates the
 	// initial transforms from the control plane and starts a poller that
@@ -89,12 +101,7 @@ func main() {
 	var holder *transform.PipelineHolder
 
 	if managed {
-		stateStore, stateErr := resolveStateStore()
-		if stateErr != nil {
-			logger.Error("resolving state store", slog.String("error", stateErr.Error()))
-			os.Exit(1)
-		}
-		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, logger)
+		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
 	} else {
 		holder = initStandalone(cfg, bodyLimits, logger)
 	}
@@ -211,13 +218,7 @@ func main() {
 // initManaged registers with the control plane, performs an initial sync, builds
 // the initial pipeline, and starts the config poller. The poller runs until ctx
 // is canceled and sends fatal errors on errc.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, logger *slog.Logger) *transform.PipelineHolder {
-	cred, err := controlplane.LoadCredential(stateStore)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		logger.Error("loading credential", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) *transform.PipelineHolder {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	tags := parseTags(os.Getenv("IRON_TAGS"))
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
@@ -238,6 +239,10 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		}
 		logger.Info("registered successfully", slog.String("proxy_id", cred.ProxyID))
 
+		if err := ensureStateStoreDir(stateStore); err != nil {
+			logger.Error("creating state store directory", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
 		if err := controlplane.SaveCredential(stateStore, cred); err != nil {
 			logger.Error("saving credential", slog.String("error", err.Error()))
 			os.Exit(1)
@@ -334,23 +339,25 @@ func parseTags(s string) []string {
 	return tags
 }
 
-// resolveStateStore returns the state store path, creating its parent directory
-// if needed. It honors IRON_STATE_STORE and falls back to the XDG config directory.
-func resolveStateStore() (string, error) {
-	stateStore := os.Getenv("IRON_STATE_STORE")
-	if stateStore == "" {
-		configDir, err := os.UserConfigDir()
-		if err != nil {
-			return "", fmt.Errorf("determining config directory: %w", err)
-		}
-		stateStore = filepath.Join(configDir, "iron-proxy", "state")
+// stateStorePath returns the state store path without creating any directories.
+// It honors IRON_STATE_STORE and falls back to the XDG config directory.
+func stateStorePath() (string, error) {
+	if v := os.Getenv("IRON_STATE_STORE"); v != "" {
+		return v, nil
 	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("determining config directory: %w", err)
+	}
+	return filepath.Join(configDir, "iron-proxy", "state"), nil
+}
 
+// ensureStateStoreDir creates the parent directory for the state store path.
+func ensureStateStoreDir(stateStore string) error {
 	if err := os.MkdirAll(filepath.Dir(stateStore), 0o700); err != nil {
-		return "", fmt.Errorf("creating state store directory: %w", err)
+		return fmt.Errorf("creating state store directory: %w", err)
 	}
-
-	return stateStore, nil
+	return nil
 }
 
 // buildPipeline creates a transform.Pipeline from config transforms.

--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -36,6 +36,7 @@ func startProxy(t *testing.T, binary, cfgPath string, env []string) *proxyInstan
 	cmd := exec.CommandContext(ctx, binary, "-config", cfgPath)
 	cmd.Dir = repoRoot(t)
 	cmd.Env = append(os.Environ(), env...)
+	cmd.Env = append(cmd.Env, "IRON_STATE_STORE="+t.TempDir())
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = stderrW
 	require.NoError(t, cmd.Start())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"gopkg.in/yaml.v3"
 )
@@ -69,39 +68,53 @@ type Log struct {
 	Level string `yaml:"level"`
 }
 
-// LoadFile reads and parses a YAML config from the given path. If the path is
-// an S3 URL (s3://bucket/key), the config is fetched from S3 using the default
-// AWS credential chain.
-func LoadFile(path string) (*Config, error) {
-	return loadFileOrS3(path)
-}
-
-// loadFromFile reads and parses a YAML config file from a local filesystem path.
-func loadFromFile(path string) (*Config, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening config file: %w", err)
+// LoadConfig is the primary entry point for building a Config. It parses an
+// optional YAML config file, layers in IRON_* environment variable overrides,
+// and applies defaults. If path is empty, the config is built entirely from
+// environment variables and defaults.
+//
+// Validation is intentionally not performed here so that callers can populate
+// additional fields (e.g. from a control plane sync) before calling Validate.
+func LoadConfig(path string) (*Config, error) {
+	var cfg Config
+	if path != "" {
+		parsed, err := parseFileOrS3(path)
+		if err != nil {
+			return nil, err
+		}
+		cfg = *parsed
 	}
-	defer f.Close()
 
-	return Load(f)
+	if err := applyEnvOverrides(&cfg); err != nil {
+		return nil, err
+	}
+
+	applyDefaults(&cfg)
+
+	return &cfg, nil
 }
 
-// Load parses a YAML config from the given reader and applies defaults.
+// Load parses a YAML config from the given reader, applies defaults, and
+// validates. This is a convenience for tests and standalone readers.
 func Load(r io.Reader) (*Config, error) {
+	cfg, err := parse(r)
+	if err != nil {
+		return nil, err
+	}
+	applyDefaults(cfg)
+	if err := Validate(cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
+	return cfg, nil
+}
+
+func parse(r io.Reader) (*Config, error) {
 	var cfg Config
 	dec := yaml.NewDecoder(r)
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
-
-	applyDefaults(&cfg)
-
-	if err := validate(&cfg); err != nil {
-		return nil, fmt.Errorf("validating config: %w", err)
-	}
-
 	return &cfg, nil
 }
 
@@ -133,7 +146,8 @@ func applyDefaults(cfg *Config) {
 	}
 }
 
-func validate(cfg *Config) error {
+// Validate checks required fields and value constraints.
+func Validate(cfg *Config) error {
 	if cfg.DNS.ProxyIP == "" {
 		return fmt.Errorf("dns.proxy_ip is required")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,25 @@ tls:
 `
 }
 
+func TestParse_NoDefaultsOrValidation(t *testing.T) {
+	// parse should not apply defaults or validate.
+	yaml := `
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+	cfg, err := parse(strings.NewReader(yaml))
+	require.NoError(t, err)
+
+	// dns.proxy_ip is missing but parse should not error.
+	require.Equal(t, "", cfg.DNS.ProxyIP)
+
+	// Defaults should not be applied.
+	require.Equal(t, "", cfg.DNS.Listen)
+	require.Equal(t, "", cfg.Proxy.HTTPListen)
+	require.Equal(t, "", cfg.Log.Level)
+}
+
 func TestLoad_ValidConfig(t *testing.T) {
 	cfg, err := Load(strings.NewReader(validYAML()))
 	require.NoError(t, err)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -6,39 +6,44 @@ import (
 	"strconv"
 )
 
-// FromEnv builds a Config by reading IRON_* environment variables.
-// String fields are read directly; integer fields are parsed with descriptive
-// errors. After reading, applyDefaults and validate are called just like the
-// YAML path. The Transforms slice is always empty (transforms come from the
-// control plane in managed mode).
-func FromEnv() (*Config, error) {
-	cfg := Config{
-		DNS: DNS{
-			Listen:           os.Getenv("IRON_DNS_LISTEN"),
-			ProxyIP:          os.Getenv("IRON_DNS_PROXY_IP"),
-			UpstreamResolver: os.Getenv("IRON_DNS_UPSTREAM_RESOLVER"),
-		},
-		Proxy: Proxy{
-			HTTPListen:   os.Getenv("IRON_PROXY_HTTP_LISTEN"),
-			HTTPSListen:  os.Getenv("IRON_PROXY_HTTPS_LISTEN"),
-			TunnelListen: os.Getenv("IRON_PROXY_TUNNEL_LISTEN"),
-		},
-		TLS: TLS{
-			CACert: os.Getenv("IRON_TLS_CA_CERT"),
-			CAKey:  os.Getenv("IRON_TLS_CA_KEY"),
-		},
-		Metrics: Metrics{
-			Listen: os.Getenv("IRON_METRICS_LISTEN"),
-		},
-		Log: Log{
-			Level: os.Getenv("IRON_LOG_LEVEL"),
-		},
+// applyEnvOverrides layers IRON_* environment variables on top of an existing
+// Config. Only non-empty environment variables override the corresponding field.
+func applyEnvOverrides(cfg *Config) error {
+	if v := os.Getenv("IRON_DNS_LISTEN"); v != "" {
+		cfg.DNS.Listen = v
+	}
+	if v := os.Getenv("IRON_DNS_PROXY_IP"); v != "" {
+		cfg.DNS.ProxyIP = v
+	}
+	if v := os.Getenv("IRON_DNS_UPSTREAM_RESOLVER"); v != "" {
+		cfg.DNS.UpstreamResolver = v
+	}
+	if v := os.Getenv("IRON_PROXY_HTTP_LISTEN"); v != "" {
+		cfg.Proxy.HTTPListen = v
+	}
+	if v := os.Getenv("IRON_PROXY_HTTPS_LISTEN"); v != "" {
+		cfg.Proxy.HTTPSListen = v
+	}
+	if v := os.Getenv("IRON_PROXY_TUNNEL_LISTEN"); v != "" {
+		cfg.Proxy.TunnelListen = v
+	}
+	if v := os.Getenv("IRON_TLS_CA_CERT"); v != "" {
+		cfg.TLS.CACert = v
+	}
+	if v := os.Getenv("IRON_TLS_CA_KEY"); v != "" {
+		cfg.TLS.CAKey = v
+	}
+	if v := os.Getenv("IRON_METRICS_LISTEN"); v != "" {
+		cfg.Metrics.Listen = v
+	}
+	if v := os.Getenv("IRON_LOG_LEVEL"); v != "" {
+		cfg.Log.Level = v
 	}
 
 	if v := os.Getenv("IRON_PROXY_MAX_REQUEST_BODY_BYTES"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("IRON_PROXY_MAX_REQUEST_BODY_BYTES: %w", err)
+			return fmt.Errorf("IRON_PROXY_MAX_REQUEST_BODY_BYTES: %w", err)
 		}
 		cfg.Proxy.MaxRequestBodyBytes = n
 	}
@@ -46,7 +51,7 @@ func FromEnv() (*Config, error) {
 	if v := os.Getenv("IRON_PROXY_MAX_RESPONSE_BODY_BYTES"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("IRON_PROXY_MAX_RESPONSE_BODY_BYTES: %w", err)
+			return fmt.Errorf("IRON_PROXY_MAX_RESPONSE_BODY_BYTES: %w", err)
 		}
 		cfg.Proxy.MaxResponseBodyBytes = n
 	}
@@ -54,7 +59,7 @@ func FromEnv() (*Config, error) {
 	if v := os.Getenv("IRON_TLS_CERT_CACHE_SIZE"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			return nil, fmt.Errorf("IRON_TLS_CERT_CACHE_SIZE: %w", err)
+			return fmt.Errorf("IRON_TLS_CERT_CACHE_SIZE: %w", err)
 		}
 		cfg.TLS.CertCacheSize = n
 	}
@@ -62,16 +67,10 @@ func FromEnv() (*Config, error) {
 	if v := os.Getenv("IRON_TLS_LEAF_CERT_EXPIRY_HOURS"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			return nil, fmt.Errorf("IRON_TLS_LEAF_CERT_EXPIRY_HOURS: %w", err)
+			return fmt.Errorf("IRON_TLS_LEAF_CERT_EXPIRY_HOURS: %w", err)
 		}
 		cfg.TLS.LeafCertExpiryHours = n
 	}
 
-	applyDefaults(&cfg)
-
-	if err := validate(&cfg); err != nil {
-		return nil, err
-	}
-
-	return &cfg, nil
+	return nil
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,19 +1,20 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestFromEnv_Defaults(t *testing.T) {
+func TestLoadConfig_EnvOnly_Defaults(t *testing.T) {
 	setEnvs(t, map[string]string{
 		"IRON_DNS_PROXY_IP": "127.0.0.1",
 		"IRON_TLS_CA_CERT":  "/ca.pem",
 		"IRON_TLS_CA_KEY":   "/ca-key.pem",
 	})
 
-	cfg, err := FromEnv()
+	cfg, err := LoadConfig("")
 	require.NoError(t, err)
 
 	require.Equal(t, ":53", cfg.DNS.Listen)
@@ -33,7 +34,7 @@ func TestFromEnv_Defaults(t *testing.T) {
 	require.Empty(t, cfg.Transforms)
 }
 
-func TestFromEnv_AllOverrides(t *testing.T) {
+func TestLoadConfig_EnvOnly_AllOverrides(t *testing.T) {
 	setEnvs(t, map[string]string{
 		"IRON_DNS_LISTEN":                    ":5353",
 		"IRON_DNS_PROXY_IP":                  "10.0.0.1",
@@ -51,7 +52,7 @@ func TestFromEnv_AllOverrides(t *testing.T) {
 		"IRON_LOG_LEVEL":                     "debug",
 	})
 
-	cfg, err := FromEnv()
+	cfg, err := LoadConfig("")
 	require.NoError(t, err)
 
 	require.Equal(t, ":5353", cfg.DNS.Listen)
@@ -70,54 +71,7 @@ func TestFromEnv_AllOverrides(t *testing.T) {
 	require.Equal(t, "debug", cfg.Log.Level)
 }
 
-func TestFromEnv_MissingRequired(t *testing.T) {
-	tests := []struct {
-		name    string
-		envs    map[string]string
-		wantErr string
-	}{
-		{
-			name: "missing proxy_ip",
-			envs: map[string]string{
-				"IRON_TLS_CA_CERT": "/ca.pem",
-				"IRON_TLS_CA_KEY":  "/ca-key.pem",
-			},
-			wantErr: "dns.proxy_ip is required",
-		},
-		{
-			name: "missing ca_cert",
-			envs: map[string]string{
-				"IRON_DNS_PROXY_IP": "127.0.0.1",
-				"IRON_TLS_CA_KEY":   "/ca-key.pem",
-			},
-			wantErr: "tls.ca_cert is required",
-		},
-		{
-			name: "missing ca_key",
-			envs: map[string]string{
-				"IRON_DNS_PROXY_IP": "127.0.0.1",
-				"IRON_TLS_CA_CERT":  "/ca.pem",
-			},
-			wantErr: "tls.ca_key is required",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setEnvs(t, tt.envs)
-			_, err := FromEnv()
-			require.ErrorContains(t, err, tt.wantErr)
-		})
-	}
-}
-
-func TestFromEnv_InvalidIntegers(t *testing.T) {
-	base := map[string]string{
-		"IRON_DNS_PROXY_IP": "127.0.0.1",
-		"IRON_TLS_CA_CERT":  "/ca.pem",
-		"IRON_TLS_CA_KEY":   "/ca-key.pem",
-	}
-
+func TestLoadConfig_EnvOnly_InvalidIntegers(t *testing.T) {
 	tests := []struct {
 		name    string
 		key     string
@@ -152,29 +106,130 @@ func TestFromEnv_InvalidIntegers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			envs := make(map[string]string)
-			for k, v := range base {
-				envs[k] = v
-			}
-			envs[tt.key] = tt.value
-			setEnvs(t, envs)
+			setEnvs(t, map[string]string{
+				tt.key: tt.value,
+			})
 
-			_, err := FromEnv()
+			_, err := LoadConfig("")
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }
 
-func TestFromEnv_InvalidLogLevel(t *testing.T) {
+func TestLoadConfig_FileWithEnvOverrides(t *testing.T) {
+	// Write a config file, then override some values via env.
+	cfgFile := t.TempDir() + "/proxy.yaml"
+	writeFile(t, cfgFile, `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  http_listen: ":8080"
+  https_listen: ":8443"
+tls:
+  ca_cert: "/file/ca.crt"
+  ca_key: "/file/ca.key"
+log:
+  level: "debug"
+`)
+
+	// Override proxy_ip and ca_cert via env.
 	setEnvs(t, map[string]string{
-		"IRON_DNS_PROXY_IP": "127.0.0.1",
-		"IRON_TLS_CA_CERT":  "/ca.pem",
-		"IRON_TLS_CA_KEY":   "/ca-key.pem",
-		"IRON_LOG_LEVEL":    "verbose",
+		"IRON_DNS_PROXY_IP": "10.0.0.99",
+		"IRON_TLS_CA_CERT":  "/env/ca.crt",
 	})
 
-	_, err := FromEnv()
-	require.ErrorContains(t, err, "log.level")
+	cfg, err := LoadConfig(cfgFile)
+	require.NoError(t, err)
+
+	// Overridden by env.
+	require.Equal(t, "10.0.0.99", cfg.DNS.ProxyIP)
+	require.Equal(t, "/env/ca.crt", cfg.TLS.CACert)
+
+	// From file (env was empty).
+	require.Equal(t, ":8080", cfg.Proxy.HTTPListen)
+	require.Equal(t, ":8443", cfg.Proxy.HTTPSListen)
+	require.Equal(t, "/file/ca.key", cfg.TLS.CAKey)
+	require.Equal(t, "debug", cfg.Log.Level)
+}
+
+func TestApplyEnvOverrides_OnlyOverridesSetVars(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"IRON_DNS_PROXY_IP":      "10.0.0.99",
+		"IRON_PROXY_HTTP_LISTEN": ":9090",
+	})
+
+	cfg := Config{
+		DNS: DNS{
+			Listen:  ":5353",
+			ProxyIP: "10.0.0.1",
+		},
+		Proxy: Proxy{
+			HTTPListen:  ":80",
+			HTTPSListen: ":443",
+		},
+		TLS: TLS{
+			CACert: "/original/ca.crt",
+			CAKey:  "/original/ca.key",
+		},
+		Log: Log{
+			Level: "debug",
+		},
+	}
+
+	err := applyEnvOverrides(&cfg)
+	require.NoError(t, err)
+
+	// Overridden by env vars.
+	require.Equal(t, "10.0.0.99", cfg.DNS.ProxyIP)
+	require.Equal(t, ":9090", cfg.Proxy.HTTPListen)
+
+	// Not overridden: env vars were empty.
+	require.Equal(t, ":5353", cfg.DNS.Listen)
+	require.Equal(t, ":443", cfg.Proxy.HTTPSListen)
+	require.Equal(t, "/original/ca.crt", cfg.TLS.CACert)
+	require.Equal(t, "/original/ca.key", cfg.TLS.CAKey)
+	require.Equal(t, "debug", cfg.Log.Level)
+}
+
+func TestApplyEnvOverrides_IntegerFields(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"IRON_PROXY_MAX_REQUEST_BODY_BYTES": "5242880",
+		"IRON_TLS_CERT_CACHE_SIZE":          "2000",
+		"IRON_TLS_LEAF_CERT_EXPIRY_HOURS":   "48",
+	})
+
+	cfg := Config{
+		Proxy: Proxy{
+			MaxRequestBodyBytes: 1024,
+		},
+		TLS: TLS{
+			CertCacheSize:       500,
+			LeafCertExpiryHours: 24,
+		},
+	}
+
+	err := applyEnvOverrides(&cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(5242880), cfg.Proxy.MaxRequestBodyBytes)
+	require.Equal(t, 2000, cfg.TLS.CertCacheSize)
+	require.Equal(t, 48, cfg.TLS.LeafCertExpiryHours)
+}
+
+func TestApplyEnvOverrides_InvalidInteger(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"IRON_PROXY_MAX_REQUEST_BODY_BYTES": "notanumber",
+	})
+
+	var cfg Config
+	err := applyEnvOverrides(&cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "IRON_PROXY_MAX_REQUEST_BODY_BYTES")
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
 // setEnvs sets environment variables for the duration of the test, clearing

--- a/internal/config/s3.go
+++ b/internal/config/s3.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -22,9 +23,9 @@ func parseS3URL(url string) (bucket, key string, err error) {
 	return rest[:idx], rest[idx+1:], nil
 }
 
-// loadS3 fetches a config file from S3 and parses it. It uses the default
-// AWS credential chain (env vars, shared config, IAM role, etc.).
-func loadS3(ctx context.Context, rawURL string) (*Config, error) {
+// parseS3 fetches a config file from S3 and parses it without applying defaults
+// or validation. It uses the default AWS credential chain.
+func parseS3(ctx context.Context, rawURL string) (*Config, error) {
 	bucket, key, err := parseS3URL(rawURL)
 	if err != nil {
 		return nil, err
@@ -45,15 +46,23 @@ func loadS3(ctx context.Context, rawURL string) (*Config, error) {
 	}
 	defer out.Body.Close()
 
-	return Load(out.Body)
+	return parse(out.Body)
 }
 
-// loadFileOrS3 loads a config from a local file path or an S3 URL.
-func loadFileOrS3(path string) (*Config, error) {
+// parseFileOrS3 parses a config from a local file path or an S3 URL without
+// applying defaults or validation.
+func parseFileOrS3(path string) (*Config, error) {
 	if strings.HasPrefix(path, "s3://") {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		return loadS3(ctx, path)
+		return parseS3(ctx, path)
 	}
-	return loadFromFile(path)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening config file: %w", err)
+	}
+	defer f.Close()
+
+	return parse(f)
 }


### PR DESCRIPTION
Adds `--bootstrap-token` flag to both `iron-proxy init` and the proxy itself (CLI flag takes precedence over `IRON_BOOTSTRAP_TOKEN` env var). When init receives a bootstrap token it generates a managed-mode config without transforms and embeds the token in the systemd unit via `Environment=`.

Refactors config loading into a single `LoadConfig(path)` entry point: parse file (if provided) → env var overrides → defaults. Validation is a separate `Validate()` call so the control plane sync can populate fields before validation runs. Managed mode is now determined by bootstrap token or existing credential, not by absence of a config file.