### PR TITLE
fix: check that systemd is PID 1 in init command

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -247,7 +247,17 @@ func resolveExecPath() string {
 
 func hasSystemd() bool {
 	_, err := exec.LookPath("systemctl")
-	return err == nil
+	if err != nil {
+		return false
+	}
+	// systemctl may be installed but systemd might not be running as the init
+	// system (e.g., in containers or WSL). Check that PID 1 is systemd.
+	out, err := exec.Command("ps", "-p", "1", "-o", "comm=").Output()
+	if err != nil {
+		return false
+	}
+	comm := strings.TrimSpace(string(out))
+	return comm == "systemd"
 }
 
 func runCommand(name string, args ...string) error {


### PR DESCRIPTION
The `hasSystemd()` check only verified that `systemctl` was on PATH. Some environments (containers, WSL) have `systemctl` installed but systemd isn't actually the init system. This adds a follow-up check that PID 1 is `systemd` before using the systemd service installation path.