### PR TITLE
fix: use console.iron.sh in init output

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -352,7 +352,7 @@ Transforms and rules will be fetched from the control plane.
 Next steps:
 
   Config reference             https://docs.iron.sh/reference/configuration
-  Control plane dashboard      https://app.iron.sh
+  Control plane dashboard      https://console.iron.sh
 `)
 }
 


### PR DESCRIPTION
The managed mode init success message pointed users to app.iron.sh instead of console.iron.sh for the control plane dashboard.