### PR TITLE
feat: add tags support to init command and config

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -82,12 +82,12 @@ func runInit(args []string) {
 
 	// 2. Write default config.
 	managedMode := *bootstrapToken != ""
-	tagList := parseDomainList(*tags)
+	tagList := splitCommaList(*tags)
 	var configYAML string
 	if managedMode {
 		configYAML = generateManagedConfig(*configDir, *tunnelPort, *proxyIP, tagList)
 	} else {
-		domains := parseDomainList(*allow)
+		domains := splitCommaList(*allow)
 		configYAML = generateConfig(*configDir, *tunnelPort, *proxyIP, domains, tagList)
 	}
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
@@ -158,16 +158,16 @@ func runInit(args []string) {
 	}
 }
 
-func parseDomainList(s string) []string {
+func splitCommaList(s string) []string {
 	parts := strings.Split(s, ",")
-	domains := make([]string, 0, len(parts))
+	out := make([]string, 0, len(parts))
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
 		if p != "" {
-			domains = append(domains, p)
+			out = append(out, p)
 		}
 	}
-	return domains
+	return out
 }
 
 // generateManagedConfig produces a YAML config for managed mode. It omits the

--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -28,6 +28,7 @@ func runInit(args []string) {
 	proxyIP := fs.String("proxy-ip", "127.0.0.1", "IP address the DNS server returns for proxied domains")
 	allow := fs.String("allow", defaultAllowList, "comma-separated domains for the initial allowlist")
 	bootstrapToken := fs.String("bootstrap-token", "", "bootstrap token for control plane registration (managed mode)")
+	tags := fs.String("tags", "", "comma-separated tags for control plane registration (managed mode)")
 	noStart := fs.Bool("no-start", false, "generate config and unit file but don't start the service")
 	force := fs.Bool("force", false, "overwrite existing config and CA")
 	if err := fs.Parse(args); err != nil {
@@ -81,12 +82,13 @@ func runInit(args []string) {
 
 	// 2. Write default config.
 	managedMode := *bootstrapToken != ""
+	tagList := parseDomainList(*tags)
 	var configYAML string
 	if managedMode {
-		configYAML = generateManagedConfig(*configDir, *tunnelPort, *proxyIP)
+		configYAML = generateManagedConfig(*configDir, *tunnelPort, *proxyIP, tagList)
 	} else {
 		domains := parseDomainList(*allow)
-		configYAML = generateConfig(*configDir, *tunnelPort, *proxyIP, domains)
+		configYAML = generateConfig(*configDir, *tunnelPort, *proxyIP, domains, tagList)
 	}
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing config: %v\n", err)
@@ -170,7 +172,7 @@ func parseDomainList(s string) []string {
 
 // generateManagedConfig produces a YAML config for managed mode. It omits the
 // transforms section since transforms come from the control plane.
-func generateManagedConfig(configDir, tunnelPort, proxyIP string) string {
+func generateManagedConfig(configDir, tunnelPort, proxyIP string, tags []string) string {
 	return fmt.Sprintf(`proxy:
   http_listen: ":8080"
   https_listen: ":8443"
@@ -183,13 +185,13 @@ dns:
 tls:
   ca_cert: "%s/ca.crt"
   ca_key: "%s/ca.key"
-
+%s
 log:
   level: "info"
-`, tunnelPort, proxyIP, configDir, configDir)
+`, tunnelPort, proxyIP, configDir, configDir, formatTags(tags))
 }
 
-func generateConfig(configDir, tunnelPort, proxyIP string, domains []string) string {
+func generateConfig(configDir, tunnelPort, proxyIP string, domains []string, tags []string) string {
 	var domainLines string
 	for _, d := range domains {
 		domainLines += fmt.Sprintf("        - %q\n", d)
@@ -212,10 +214,22 @@ transforms:
   - name: allowlist
     config:
       domains:
-%s
+%s%s
 log:
   level: "info"
-`, tunnelPort, proxyIP, configDir, configDir, domainLines)
+`, tunnelPort, proxyIP, configDir, configDir, domainLines, formatTags(tags))
+}
+
+func formatTags(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	var s string
+	s += "\ntags:\n"
+	for _, t := range tags {
+		s += fmt.Sprintf("  - %q\n", t)
+	}
+	return s
 }
 
 func generateSystemdUnit(execPath, configPath, bootstrapToken string) string {

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -220,7 +219,7 @@ func main() {
 // is canceled and sends fatal errors on errc.
 func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) *transform.PipelineHolder {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
-	tags := parseTags(os.Getenv("IRON_TAGS"))
+	tags := cfg.Tags
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
 	client := controlplane.NewClient(cpURL, logger)
@@ -322,21 +321,6 @@ func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger 
 		os.Exit(1)
 	}
 	return transform.NewPipelineHolder(pipeline)
-}
-
-func parseTags(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	tags := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			tags = append(tags, p)
-		}
-	}
-	return tags
 }
 
 // stateStorePath returns the state store path without creating any directories.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Transforms []Transform `yaml:"transforms"`
 	Metrics    Metrics    `yaml:"metrics"`
 	Log        Log        `yaml:"log"`
+	Tags       []string   `yaml:"tags"`
 }
 
 // DNS configures the built-in DNS server.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // applyEnvOverrides layers IRON_* environment variables on top of an existing
@@ -38,6 +39,16 @@ func applyEnvOverrides(cfg *Config) error {
 	}
 	if v := os.Getenv("IRON_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
+	}
+	if v := os.Getenv("IRON_TAGS"); v != "" {
+		tags := make([]string, 0)
+		for _, t := range strings.Split(v, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tags = append(tags, t)
+			}
+		}
+		cfg.Tags = tags
 	}
 
 	if v := os.Getenv("IRON_PROXY_MAX_REQUEST_BODY_BYTES"); v != "" {


### PR DESCRIPTION
Adds a `--tags` flag to `iron-proxy init` that writes tags into the generated config YAML as a top-level `tags` field. Tags can also be set via the `IRON_TAGS` environment variable, applied as an env override like the rest of the `IRON_*` vars. Main now reads tags from the parsed config rather than directly from the environment.