### PR TITLE
feat: add sni-only tls mode for certless operation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,3 +17,4 @@ linters:
         - (*net.TCPConn).CloseWrite
         - (*net.TCPListener).Close
         - (net.Listener).Close
+        - (*crypto/tls.Conn).Close

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -126,12 +126,18 @@ func main() {
 	}
 	holder.Load().SetAuditFunc(auditFunc)
 
-	// Initialize cert cache.
-	leafExpiry := time.Duration(cfg.TLS.LeafCertExpiryHours) * time.Hour
-	certCache, err := certcache.New(cfg.TLS.CACert, cfg.TLS.CAKey, cfg.TLS.CertCacheSize, leafExpiry)
-	if err != nil {
-		logger.Error("initializing cert cache", slog.String("error", err.Error()))
-		os.Exit(1)
+	// Initialize cert cache. Not needed in sni-only mode since TLS is never
+	// terminated and no leaf certs are generated.
+	var certCache *certcache.Cache
+	if cfg.TLS.Mode != config.TLSModeSNIOnly {
+		leafExpiry := time.Duration(cfg.TLS.LeafCertExpiryHours) * time.Hour
+		certCache, err = certcache.New(cfg.TLS.CACert, cfg.TLS.CAKey, cfg.TLS.CertCacheSize, leafExpiry)
+		if err != nil {
+			logger.Error("initializing cert cache", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+	} else if cfg.TLS.CACert != "" || cfg.TLS.CAKey != "" {
+		logger.Warn("tls.ca_cert and tls.ca_key are ignored when tls.mode=sni-only")
 	}
 
 	// Build upstream resolver.
@@ -155,7 +161,16 @@ func main() {
 	}
 
 	// Initialize proxy.
-	p := proxy.New(cfg.Proxy.HTTPListen, cfg.Proxy.HTTPSListen, cfg.Proxy.TunnelListen, certCache, holder, resolver, logger)
+	p := proxy.New(proxy.Options{
+		HTTPAddr:   cfg.Proxy.HTTPListen,
+		HTTPSAddr:  cfg.Proxy.HTTPSListen,
+		TunnelAddr: cfg.Proxy.TunnelListen,
+		TLSMode:    cfg.TLS.Mode,
+		CertCache:  certCache,
+		Pipeline:   holder,
+		Resolver:   resolver,
+		Logger:     logger,
+	})
 
 	// Initialize metrics server.
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,13 +10,13 @@ import (
 
 // Config is the top-level configuration for iron-proxy.
 type Config struct {
-	DNS        DNS        `yaml:"dns"`
-	Proxy      Proxy      `yaml:"proxy"`
-	TLS        TLS        `yaml:"tls"`
+	DNS        DNS         `yaml:"dns"`
+	Proxy      Proxy       `yaml:"proxy"`
+	TLS        TLS         `yaml:"tls"`
 	Transforms []Transform `yaml:"transforms"`
-	Metrics    Metrics    `yaml:"metrics"`
-	Log        Log        `yaml:"log"`
-	Tags       []string   `yaml:"tags"`
+	Metrics    Metrics     `yaml:"metrics"`
+	Log        Log         `yaml:"log"`
+	Tags       []string    `yaml:"tags"`
 }
 
 // DNS configures the built-in DNS server.
@@ -46,11 +46,23 @@ type Proxy struct {
 
 // TLS configures certificate authority and cert caching for MITM.
 type TLS struct {
-	CACert             string `yaml:"ca_cert"`
-	CAKey              string `yaml:"ca_key"`
-	CertCacheSize      int    `yaml:"cert_cache_size"`
-	LeafCertExpiryHours int   `yaml:"leaf_cert_expiry_hours"`
+	// Mode selects how the HTTPS listener handles TLS connections.
+	// "mitm" (default): terminate TLS, mint a leaf cert signed by the configured
+	// CA, and run the full request/response pipeline.
+	// "sni-only": peek the ClientHello SNI, run the pipeline with a host-only
+	// synthetic request, and TCP-passthrough to the upstream. No CA required.
+	Mode                string `yaml:"mode"`
+	CACert              string `yaml:"ca_cert"`
+	CAKey               string `yaml:"ca_key"`
+	CertCacheSize       int    `yaml:"cert_cache_size"`
+	LeafCertExpiryHours int    `yaml:"leaf_cert_expiry_hours"`
 }
+
+// TLS mode values.
+const (
+	TLSModeMITM    = "mitm"
+	TLSModeSNIOnly = "sni-only"
+)
 
 // Transform is a named transform with arbitrary config.
 // Config is a raw yaml.Node so each transform can decode it into its own typed struct.
@@ -133,6 +145,9 @@ func applyDefaults(cfg *Config) {
 		cfg.Proxy.MaxRequestBodyBytes = 1 << 20 // 1 MiB
 	}
 	// MaxResponseBodyBytes defaults to 0 (uncapped).
+	if cfg.TLS.Mode == "" {
+		cfg.TLS.Mode = TLSModeMITM
+	}
 	if cfg.TLS.CertCacheSize == 0 {
 		cfg.TLS.CertCacheSize = 1000
 	}
@@ -152,11 +167,19 @@ func Validate(cfg *Config) error {
 	if cfg.DNS.ProxyIP == "" {
 		return fmt.Errorf("dns.proxy_ip is required")
 	}
-	if cfg.TLS.CACert == "" {
-		return fmt.Errorf("tls.ca_cert is required")
-	}
-	if cfg.TLS.CAKey == "" {
-		return fmt.Errorf("tls.ca_key is required")
+
+	switch cfg.TLS.Mode {
+	case TLSModeMITM:
+		if cfg.TLS.CACert == "" {
+			return fmt.Errorf("tls.ca_cert is required")
+		}
+		if cfg.TLS.CAKey == "" {
+			return fmt.Errorf("tls.ca_key is required")
+		}
+	case TLSModeSNIOnly:
+		// CA cert/key are ignored in sni-only mode; no requirement.
+	default:
+		return fmt.Errorf("tls.mode must be %q or %q; got %q", TLSModeMITM, TLSModeSNIOnly, cfg.TLS.Mode)
 	}
 
 	if _, err := parseLogLevel(cfg.Log.Level); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -236,6 +236,45 @@ transforms:
 	require.Equal(t, []string{"10.0.0.0/8"}, allowCfg.CIDRs)
 }
 
+func TestLoad_SNIOnlyMode(t *testing.T) {
+	t.Run("ca cert not required", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  mode: "sni-only"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, "sni-only", cfg.TLS.Mode)
+		require.Equal(t, "", cfg.TLS.CACert)
+	})
+
+	t.Run("unknown mode rejected", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  mode: "hybrid"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tls.mode")
+	})
+
+	t.Run("mitm mode still requires ca_cert", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  mode: "mitm"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tls.ca_cert")
+	})
+}
+
 func TestLoad_DNSPassthroughAndRecords(t *testing.T) {
 	yaml := `
 dns:

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -28,6 +28,9 @@ func applyEnvOverrides(cfg *Config) error {
 	if v := os.Getenv("IRON_PROXY_TUNNEL_LISTEN"); v != "" {
 		cfg.Proxy.TunnelListen = v
 	}
+	if v := os.Getenv("IRON_TLS_MODE"); v != "" {
+		cfg.TLS.Mode = v
+	}
 	if v := os.Getenv("IRON_TLS_CA_CERT"); v != "" {
 		cfg.TLS.CACert = v
 	}

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -54,7 +54,14 @@ func startTunnelIntegrationProxy(t *testing.T, allowedHosts []string, logger *sl
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 	holder := transform.NewPipelineHolder(pipeline)
 
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", ca.certCache, holder, nil, logger)
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		HTTPSAddr:  "127.0.0.1:0",
+		TunnelAddr: "127.0.0.1:0",
+		CertCache:  ca.certCache,
+		Pipeline:   holder,
+		Logger:     logger,
+	})
 
 	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -115,7 +122,13 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	holder := transform.NewPipelineHolder(pipeline)
 
 	// 4. Start proxy with HTTPS
-	p := New("127.0.0.1:0", "127.0.0.1:0", "", ca.certCache, holder, nil, logger)
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		CertCache: ca.certCache,
+		Pipeline:  holder,
+		Logger:    logger,
+	})
 
 	// Start HTTP listener
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -40,6 +40,11 @@ type Proxy struct {
 	transport      *http.Transport
 	resolver       *net.Resolver
 	logger         *slog.Logger
+
+	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
+	// connections that would otherwise sit on blocking Reads.
+	shutdownCtx    context.Context
+	shutdownCancel context.CancelFunc
 }
 
 // Options configures Proxy construction.
@@ -60,16 +65,19 @@ func New(opts Options) *Proxy {
 	if opts.TLSMode == "" {
 		opts.TLSMode = "mitm"
 	}
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	p := &Proxy{
-		httpsAddr:  opts.HTTPSAddr,
-		tlsMode:    opts.TLSMode,
-		tunnelAddr: opts.TunnelAddr,
-		tunnelDone: make(chan struct{}),
-		certCache:  opts.CertCache,
-		pipeline:   opts.Pipeline,
-		transport:  buildTransport(opts.Resolver),
-		resolver:   opts.Resolver,
-		logger:     opts.Logger,
+		httpsAddr:      opts.HTTPSAddr,
+		tlsMode:        opts.TLSMode,
+		tunnelAddr:     opts.TunnelAddr,
+		tunnelDone:     make(chan struct{}),
+		certCache:      opts.CertCache,
+		pipeline:       opts.Pipeline,
+		transport:      buildTransport(opts.Resolver),
+		resolver:       opts.Resolver,
+		logger:         opts.Logger,
+		shutdownCtx:    shutdownCtx,
+		shutdownCancel: shutdownCancel,
 	}
 
 	p.httpServer = &http.Server{
@@ -171,6 +179,10 @@ func isClosedErr(err error) bool {
 
 // Shutdown gracefully stops all servers.
 func (p *Proxy) Shutdown(ctx context.Context) error {
+	// Cancel shutdownCtx first so any in-flight TCP-passthrough proxyBidi
+	// goroutines close their connections and unblock their blocking Reads.
+	p.shutdownCancel()
+
 	errHTTP := p.httpServer.Shutdown(ctx)
 
 	var errHTTPS error

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,15 +1,19 @@
-// Package proxy implements the iron-proxy HTTP/HTTPS MITM proxy.
+// Package proxy implements the iron-proxy HTTP/HTTPS proxy. The HTTPS
+// listener supports two modes: MITM (default), which terminates TLS using a
+// CA-signed leaf cert, and SNI-only, which peeks the ClientHello SNI and
+// TCP-passthroughs to the upstream without terminating TLS.
 package proxy
 
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"strconv"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,39 +22,63 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
-// Proxy is the HTTP/HTTPS MITM proxy server.
+// Proxy is the HTTP/HTTPS proxy server. When Mode is TLSModeMITM, the HTTPS
+// listener terminates TLS using certCache; when Mode is TLSModeSNIOnly, the
+// listener peeks the SNI from the ClientHello and TCP-passthroughs to the
+// upstream without terminating TLS.
 type Proxy struct {
-	httpServer      *http.Server
-	httpsServer     *http.Server
-	tlsListener     net.Listener
-	tunnelAddr      string
-	tunnelListener  net.Listener
-	tunnelDone      chan struct{}
-	certCache       *certcache.Cache
-	pipeline        *transform.PipelineHolder
-	transport       *http.Transport
-	logger          *slog.Logger
+	httpServer     *http.Server
+	httpsServer    *http.Server
+	httpsAddr      string
+	tlsMode        string
+	tlsListener    net.Listener
+	tunnelAddr     string
+	tunnelListener net.Listener
+	tunnelDone     chan struct{}
+	certCache      *certcache.Cache
+	pipeline       *transform.PipelineHolder
+	transport      *http.Transport
+	resolver       *net.Resolver
+	logger         *slog.Logger
 }
 
-// New creates a new Proxy. If resolver is non-nil, it is used to resolve
-// upstream hostnames instead of the OS default resolver.
-func New(httpAddr, httpsAddr, tunnelAddr string, certCache *certcache.Cache, pipeline *transform.PipelineHolder, resolver *net.Resolver, logger *slog.Logger) *Proxy {
+// Options configures Proxy construction.
+type Options struct {
+	HTTPAddr   string
+	HTTPSAddr  string
+	TunnelAddr string
+	TLSMode    string
+	CertCache  *certcache.Cache // required when TLSMode == "mitm"
+	Pipeline   *transform.PipelineHolder
+	Resolver   *net.Resolver
+	Logger     *slog.Logger
+}
+
+// New creates a new Proxy. In TLSModeMITM, certCache must be non-nil. In
+// TLSModeSNIOnly, certCache is unused and may be nil.
+func New(opts Options) *Proxy {
+	if opts.TLSMode == "" {
+		opts.TLSMode = "mitm"
+	}
 	p := &Proxy{
-		tunnelAddr: tunnelAddr,
+		httpsAddr:  opts.HTTPSAddr,
+		tlsMode:    opts.TLSMode,
+		tunnelAddr: opts.TunnelAddr,
 		tunnelDone: make(chan struct{}),
-		certCache:  certCache,
-		pipeline:   pipeline,
-		transport:  buildTransport(resolver),
-		logger:     logger,
+		certCache:  opts.CertCache,
+		pipeline:   opts.Pipeline,
+		transport:  buildTransport(opts.Resolver),
+		resolver:   opts.Resolver,
+		logger:     opts.Logger,
 	}
 
 	p.httpServer = &http.Server{
-		Addr:    httpAddr,
+		Addr:    opts.HTTPAddr,
 		Handler: http.HandlerFunc(p.handleHTTP),
 	}
 
 	p.httpsServer = &http.Server{
-		Addr:    httpsAddr,
+		Addr:    opts.HTTPSAddr,
 		Handler: http.HandlerFunc(p.handleHTTP),
 		TLSConfig: &tls.Config{
 			GetCertificate: p.getCertificate,
@@ -80,15 +108,7 @@ func (p *Proxy) ListenAndServe() error {
 	}()
 
 	go func() {
-		ln, err := net.Listen("tcp", p.httpsServer.Addr)
-		if err != nil {
-			errc <- fmt.Errorf("https listen: %w", err)
-			return
-		}
-		tlsLn := tls.NewListener(ln, p.httpsServer.TLSConfig)
-		p.tlsListener = tlsLn
-		p.logger.Info("https proxy starting", slog.String("addr", ln.Addr().String()))
-		errc <- fmt.Errorf("https: %w", p.httpsServer.Serve(tlsLn))
+		errc <- p.serveHTTPS()
 	}()
 
 	if p.tunnelAddr != "" {
@@ -100,10 +120,58 @@ func (p *Proxy) ListenAndServe() error {
 	return <-errc
 }
 
+// serveHTTPS runs the HTTPS listener. In MITM mode it terminates TLS and
+// serves through handleHTTP. In SNI-only mode it accepts raw TCP connections
+// and dispatches to handleSNIPassthrough.
+func (p *Proxy) serveHTTPS() error {
+	ln, err := net.Listen("tcp", p.httpsAddr)
+	if err != nil {
+		return fmt.Errorf("https listen: %w", err)
+	}
+
+	if p.tlsMode == "sni-only" {
+		p.tlsListener = ln
+		p.logger.Info("https proxy starting (sni-only)", slog.String("addr", ln.Addr().String()))
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-p.tunnelDone:
+					return nil
+				default:
+				}
+				if isClosedErr(err) {
+					return nil
+				}
+				p.logger.Warn("https accept error", slog.String("error", err.Error()))
+				continue
+			}
+			go p.handleSNIPassthrough(conn)
+		}
+	}
+
+	tlsLn := tls.NewListener(ln, p.httpsServer.TLSConfig)
+	p.tlsListener = tlsLn
+	p.logger.Info("https proxy starting", slog.String("addr", ln.Addr().String()))
+	return fmt.Errorf("https: %w", p.httpsServer.Serve(tlsLn))
+}
+
+func isClosedErr(err error) bool {
+	return err != nil && (errors.Is(err, net.ErrClosed))
+}
+
 // Shutdown gracefully stops all servers.
 func (p *Proxy) Shutdown(ctx context.Context) error {
 	errHTTP := p.httpServer.Shutdown(ctx)
-	errHTTPS := p.httpsServer.Shutdown(ctx)
+
+	var errHTTPS error
+	if p.tlsMode == "sni-only" {
+		if p.tlsListener != nil {
+			_ = p.tlsListener.Close()
+		}
+	} else {
+		errHTTPS = p.httpsServer.Shutdown(ctx)
+	}
 
 	// Signal tunnel accept loop to stop, then close the listener.
 	close(p.tunnelDone)
@@ -118,10 +186,26 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 }
 
 func (p *Proxy) getCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if p.certCache == nil {
+		return nil, fmt.Errorf("cert cache not configured")
+	}
 	if hello.ServerName == "" {
 		return nil, fmt.Errorf("no SNI provided")
 	}
 	return p.certCache.GetOrCreate(hello.ServerName)
+}
+
+// beginPipelineRun snapshots the current pipeline and returns a finish
+// function that computes Duration and emits the audit record. The caller is
+// responsible for populating result.Action, StatusCode, traces, and Err
+// before finish runs — typically via defer. StartedAt is set here.
+func (p *Proxy) beginPipelineRun(result *transform.PipelineResult) (*transform.Pipeline, func()) {
+	pl := p.pipeline.Load()
+	result.StartedAt = time.Now()
+	return pl, func() {
+		result.Duration = time.Since(result.StartedAt)
+		pl.EmitAudit(result)
+	}
 }
 
 func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
@@ -152,41 +236,32 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Snapshot the pipeline for this request so a concurrent swap does not
-	// affect in-flight processing.
-	pl := p.pipeline.Load()
-
 	// Build transform context and audit state
-	startedAt := time.Now()
-	bodyLimits := pl.BodyLimits()
 	tctx := &transform.TransformContext{
 		Logger: p.logger,
+		Mode:   transform.ModeMITM,
 	}
 	if r.TLS != nil {
 		tctx.SNI = r.TLS.ServerName
 	}
 
-	var reqTraces, respTraces []transform.TransformTrace
 	result := &transform.PipelineResult{
 		Host:       r.Host,
 		Method:     r.Method,
 		Path:       r.URL.Path,
 		RemoteAddr: r.RemoteAddr,
 		SNI:        tctx.SNI,
-		StartedAt:  startedAt,
+		Mode:       transform.ModeMITM,
 	}
-	defer func() {
-		result.Duration = time.Since(startedAt)
-		result.RequestTransforms = reqTraces
-		result.ResponseTransforms = respTraces
-		pl.EmitAudit(result)
-	}()
+	pl, finish := p.beginPipelineRun(result)
+	defer finish()
 
+	bodyLimits := pl.BodyLimits()
 	// Wrap request body for lazy buffering by transforms.
 	r.Body = transform.NewBufferedBody(r.Body, bodyLimits.MaxRequestBodyBytes)
 
 	// Run request transforms
-	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &reqTraces); err != nil {
+	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &result.RequestTransforms); err != nil {
 		result.Action = transform.ActionContinue // error, not reject
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
@@ -250,7 +325,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	resp.Body = transform.NewBufferedBody(resp.Body, bodyLimits.MaxResponseBodyBytes)
 
 	// Run response transforms
-	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &respTraces)
+	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &result.ResponseTransforms)
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
@@ -453,7 +528,7 @@ func buildTransport(resolver *net.Resolver) *http.Transport {
 		DialContext:           dialer.DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:  10 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 30 * time.Second,
 	}
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -108,7 +108,11 @@ func (p *Proxy) ListenAndServe() error {
 	}()
 
 	go func() {
-		errc <- p.serveHTTPS()
+		if p.tlsMode == "sni-only" {
+			errc <- p.serveHTTPSSNI()
+		} else {
+			errc <- p.serveHTTPSMITM()
+		}
 	}()
 
 	if p.tunnelAddr != "" {
@@ -120,40 +124,45 @@ func (p *Proxy) ListenAndServe() error {
 	return <-errc
 }
 
-// serveHTTPS runs the HTTPS listener. In MITM mode it terminates TLS and
-// serves through handleHTTP. In SNI-only mode it accepts raw TCP connections
-// and dispatches to handleSNIPassthrough.
-func (p *Proxy) serveHTTPS() error {
+// serveHTTPSMITM terminates TLS on the HTTPS listener and serves requests
+// through handleHTTP with leaf certs minted by the configured CA.
+func (p *Proxy) serveHTTPSMITM() error {
 	ln, err := net.Listen("tcp", p.httpsAddr)
 	if err != nil {
 		return fmt.Errorf("https listen: %w", err)
 	}
-
-	if p.tlsMode == "sni-only" {
-		p.tlsListener = ln
-		p.logger.Info("https proxy starting (sni-only)", slog.String("addr", ln.Addr().String()))
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				select {
-				case <-p.tunnelDone:
-					return nil
-				default:
-				}
-				if isClosedErr(err) {
-					return nil
-				}
-				p.logger.Warn("https accept error", slog.String("error", err.Error()))
-				continue
-			}
-			go p.handleSNIPassthrough(conn)
-		}
-	}
-
 	tlsLn := tls.NewListener(ln, p.httpsServer.TLSConfig)
 	p.tlsListener = tlsLn
 	p.logger.Info("https proxy starting", slog.String("addr", ln.Addr().String()))
 	return fmt.Errorf("https: %w", p.httpsServer.Serve(tlsLn))
+}
+
+// serveHTTPSSNI runs the HTTPS listener in sni-only mode: accepts raw TCP
+// connections, peeks the ClientHello SNI, and TCP-passthroughs to upstream
+// without terminating TLS.
+func (p *Proxy) serveHTTPSSNI() error {
+	ln, err := net.Listen("tcp", p.httpsAddr)
+	if err != nil {
+		return fmt.Errorf("https listen: %w", err)
+	}
+	p.tlsListener = ln
+	p.logger.Info("https proxy starting (sni-only)", slog.String("addr", ln.Addr().String()))
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-p.tunnelDone:
+				return nil
+			default:
+			}
+			if isClosedErr(err) {
+				return nil
+			}
+			p.logger.Warn("https accept error", slog.String("error", err.Error()))
+			continue
+		}
+		go p.handleSNIPassthrough(conn)
+	}
 }
 
 func isClosedErr(err error) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -45,6 +45,11 @@ type Proxy struct {
 	// connections that would otherwise sit on blocking Reads.
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
+
+	// sniUpstreamPort is the port dialed for SNI-only passthrough. Fixed at
+	// 443 in production so a client-supplied CONNECT port cannot pivot an
+	// allowlisted hostname onto a different port. Overridable in tests.
+	sniUpstreamPort string
 }
 
 // Options configures Proxy construction.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
+	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -58,7 +59,7 @@ type Options struct {
 	HTTPSAddr  string
 	TunnelAddr string
 	TLSMode    string
-	CertCache  *certcache.Cache // required when TLSMode == "mitm"
+	CertCache  *certcache.Cache // required when TLSMode == config.TLSModeMITM
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
 	Logger     *slog.Logger
@@ -68,7 +69,7 @@ type Options struct {
 // TLSModeSNIOnly, certCache is unused and may be nil.
 func New(opts Options) *Proxy {
 	if opts.TLSMode == "" {
-		opts.TLSMode = "mitm"
+		opts.TLSMode = config.TLSModeMITM
 	}
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	p := &Proxy{
@@ -121,7 +122,7 @@ func (p *Proxy) ListenAndServe() error {
 	}()
 
 	go func() {
-		if p.tlsMode == "sni-only" {
+		if p.tlsMode == config.TLSModeSNIOnly {
 			errc <- p.serveHTTPSSNI()
 		} else {
 			errc <- p.serveHTTPSMITM()
@@ -163,12 +164,7 @@ func (p *Proxy) serveHTTPSSNI() error {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
-			select {
-			case <-p.tunnelDone:
-				return nil
-			default:
-			}
-			if isClosedErr(err) {
+			if p.shutdownCtx.Err() != nil || errors.Is(err, net.ErrClosed) {
 				return nil
 			}
 			p.logger.Warn("https accept error", slog.String("error", err.Error()))
@@ -176,10 +172,6 @@ func (p *Proxy) serveHTTPSSNI() error {
 		}
 		go p.handleSNIPassthrough(conn)
 	}
-}
-
-func isClosedErr(err error) bool {
-	return err != nil && (errors.Is(err, net.ErrClosed))
 }
 
 // Shutdown gracefully stops all servers.
@@ -191,7 +183,7 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 	errHTTP := p.httpServer.Shutdown(ctx)
 
 	var errHTTPS error
-	if p.tlsMode == "sni-only" {
+	if p.tlsMode == config.TLSModeSNIOnly {
 		if p.tlsListener != nil {
 			_ = p.tlsListener.Close()
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -100,7 +100,13 @@ func startProxyWithTransforms(t *testing.T, transforms []transform.Transformer) 
 
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
 	holder := transform.NewPipelineHolder(pipeline)
-	p := New("127.0.0.1:0", "127.0.0.1:0", "", cache, holder, nil, testLogger())
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		CertCache: cache,
+		Pipeline:  holder,
+		Logger:    testLogger(),
+	})
 
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -138,14 +138,28 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn, targetPort string) erro
 	result.Action = transform.ActionContinue
 	result.StatusCode = http.StatusOK
 
-	// Proxy bidirectionally until either side closes.
-	proxyBidi(clientConn, upstream, p.logger)
+	// Proxy bidirectionally until either side closes or the proxy shuts down.
+	proxyBidi(p.shutdownCtx, clientConn, upstream, p.logger)
 	return nil
 }
 
 // proxyBidi copies bytes between two connections in both directions, closing
-// write halves on EOF and logging copy errors at debug level.
-func proxyBidi(a, b net.Conn, logger *slog.Logger) {
+// write halves on EOF and logging copy errors at debug level. If ctx is
+// canceled (e.g. by Proxy.Shutdown), both connections are closed to unblock
+// any in-flight Reads.
+func proxyBidi(ctx context.Context, a, b net.Conn, logger *slog.Logger) {
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = a.Close()
+			_ = b.Close()
+		case <-done:
+		}
+	}()
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -132,10 +132,9 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 	return nil
 }
 
-// proxyBidi copies bytes between two connections in both directions, closing
-// write halves on EOF and logging copy errors at debug level. If ctx is
-// canceled (e.g. by Proxy.Shutdown), both connections are closed to unblock
-// any in-flight Reads.
+// proxyBidi copies bytes between two connections in both directions. When
+// either direction ends (EOF, error, or ctx cancellation), both connections
+// are closed so the other direction unblocks.
 func proxyBidi(ctx context.Context, a, b net.Conn, logger *slog.Logger) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -154,9 +153,7 @@ func proxyBidi(ctx context.Context, a, b net.Conn, logger *slog.Logger) {
 		if _, err := io.Copy(b, a); err != nil {
 			logger.Debug("sni passthrough a->b copy error", slog.String("error", err.Error()))
 		}
-		if tc, ok := b.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
+		cancel()
 	}()
 
 	go func() {
@@ -164,9 +161,7 @@ func proxyBidi(ctx context.Context, a, b net.Conn, logger *slog.Logger) {
 		if _, err := io.Copy(a, b); err != nil {
 			logger.Debug("sni passthrough b->a copy error", slog.String("error", err.Error()))
 		}
-		if tc, ok := a.(*net.TCPConn); ok {
-			_ = tc.CloseWrite()
-		}
+		cancel()
 	}()
 
 	wg.Wait()

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	sniPeekTimeout  = 5 * time.Second
-	sniUpstreamDial = 30 * time.Second
+	sniPeekTimeout     = 5 * time.Second
+	sniUpstreamDial    = 30 * time.Second
+	defaultSNIUpstream = "443"
 )
 
 // handleSNIPassthrough is the connection handler used by the HTTPS listener
@@ -24,32 +25,22 @@ const (
 // the transform pipeline with a host-only synthetic request, and on accept
 // TCP-passthroughs the connection to the upstream server.
 func (p *Proxy) handleSNIPassthrough(clientConn net.Conn) {
-	target := net.JoinHostPort("", "443")
-	if err := p.serveSNIPassthrough(clientConn, target); err != nil {
+	if err := p.serveSNIPassthrough(clientConn); err != nil {
 		p.logger.Debug("sni passthrough error", slog.String("error", err.Error()))
 	}
 }
 
 // serveSNIPassthrough peeks SNI, runs the pipeline, and TCP-passthroughs the
-// connection if allowed. targetPort is "host:port" whose port is used as the
-// upstream port (host is filled in from the peeked SNI). Used by both the
-// HTTPS listener and the CONNECT/SOCKS5 tunnel TLS branch in sni-only mode.
-func (p *Proxy) serveSNIPassthrough(clientConn net.Conn, targetPort string) error {
+// connection to the SNI host on port 443 if allowed. Used by both the HTTPS
+// listener and the CONNECT/SOCKS5 tunnel TLS branch in sni-only mode. The
+// upstream port is fixed at 443 — a client-supplied CONNECT port is ignored
+// so an attacker cannot pivot an allowlisted hostname onto a different port.
+func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 	defer clientConn.Close()
 
 	sni, peeked, err := peekSNI(clientConn, sniPeekTimeout)
 	if err != nil {
 		return fmt.Errorf("peek sni: %w", err)
-	}
-
-	// Determine the upstream port: prefer the port in targetPort (from CONNECT
-	// target), fall back to 443 for the raw HTTPS listener which passes an
-	// empty host.
-	port := "443"
-	if targetPort != "" {
-		if _, p, splitErr := net.SplitHostPort(targetPort); splitErr == nil && p != "" {
-			port = p
-		}
 	}
 
 	// Run the pipeline with a host-only synthetic request.
@@ -111,6 +102,10 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn, targetPort string) erro
 	dialer := &net.Dialer{
 		Timeout:  sniUpstreamDial,
 		Resolver: p.resolver,
+	}
+	port := p.sniUpstreamPort
+	if port == "" {
+		port = defaultSNIUpstream
 	}
 	upstream, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(sni, port))
 	if err != nil {

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -142,16 +142,13 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn, targetPort string) erro
 // canceled (e.g. by Proxy.Shutdown), both connections are closed to unblock
 // any in-flight Reads.
 func proxyBidi(ctx context.Context, a, b net.Conn, logger *slog.Logger) {
-	done := make(chan struct{})
-	defer close(done)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			_ = a.Close()
-			_ = b.Close()
-		case <-done:
-		}
+		<-ctx.Done()
+		_ = a.Close()
+		_ = b.Close()
 	}()
 
 	var wg sync.WaitGroup

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -24,12 +24,6 @@ const (
 // the transform pipeline with a host-only synthetic request, and on accept
 // TCP-passthroughs the connection to the upstream server.
 func (p *Proxy) handleSNIPassthrough(clientConn net.Conn) {
-	defer func() {
-		if r := recover(); r != nil {
-			p.logger.Error("sni passthrough panic", slog.Any("panic", r))
-		}
-	}()
-
 	target := net.JoinHostPort("", "443")
 	if err := p.serveSNIPassthrough(clientConn, target); err != nil {
 		p.logger.Debug("sni passthrough error", slog.String("error", err.Error()))

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+const (
+	sniPeekTimeout  = 5 * time.Second
+	sniUpstreamDial = 30 * time.Second
+)
+
+// handleSNIPassthrough is the connection handler used by the HTTPS listener
+// when tls.mode is "sni-only". It peeks the SNI from the ClientHello, runs
+// the transform pipeline with a host-only synthetic request, and on accept
+// TCP-passthroughs the connection to the upstream server.
+func (p *Proxy) handleSNIPassthrough(clientConn net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.logger.Error("sni passthrough panic", slog.Any("panic", r))
+		}
+	}()
+
+	target := net.JoinHostPort("", "443")
+	if err := p.serveSNIPassthrough(clientConn, target); err != nil {
+		p.logger.Debug("sni passthrough error", slog.String("error", err.Error()))
+	}
+}
+
+// serveSNIPassthrough peeks SNI, runs the pipeline, and TCP-passthroughs the
+// connection if allowed. targetPort is "host:port" whose port is used as the
+// upstream port (host is filled in from the peeked SNI). Used by both the
+// HTTPS listener and the CONNECT/SOCKS5 tunnel TLS branch in sni-only mode.
+func (p *Proxy) serveSNIPassthrough(clientConn net.Conn, targetPort string) error {
+	defer clientConn.Close()
+
+	sni, peeked, err := peekSNI(clientConn, sniPeekTimeout)
+	if err != nil {
+		return fmt.Errorf("peek sni: %w", err)
+	}
+
+	// Determine the upstream port: prefer the port in targetPort (from CONNECT
+	// target), fall back to 443 for the raw HTTPS listener which passes an
+	// empty host.
+	port := "443"
+	if targetPort != "" {
+		if _, p, splitErr := net.SplitHostPort(targetPort); splitErr == nil && p != "" {
+			port = p
+		}
+	}
+
+	// Run the pipeline with a host-only synthetic request.
+	tctx := &transform.TransformContext{
+		Logger: p.logger,
+		SNI:    sni,
+		Mode:   transform.ModeSNIOnly,
+	}
+
+	result := &transform.PipelineResult{
+		Host:       sni,
+		RemoteAddr: clientConn.RemoteAddr().String(),
+		SNI:        sni,
+		Mode:       transform.ModeSNIOnly,
+	}
+	pl, finish := p.beginPipelineRun(result)
+	defer finish()
+
+	req := &http.Request{
+		Host:       sni,
+		URL:        &url.URL{Scheme: "https", Host: sni},
+		Header:     http.Header{},
+		RemoteAddr: clientConn.RemoteAddr().String(),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+	req.Body = transform.NewBufferedBody(http.NoBody, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rejectResp, pipelineErr := pl.ProcessRequest(ctx, tctx, req, &result.RequestTransforms)
+	if pipelineErr != nil {
+		result.Action = transform.ActionContinue
+		result.StatusCode = http.StatusBadGateway
+		result.Err = pipelineErr
+		return fmt.Errorf("pipeline error for %q: %w", sni, pipelineErr)
+	}
+	if rejectResp != nil {
+		result.Action = transform.ActionReject
+		result.StatusCode = rejectResp.StatusCode
+		p.logger.Info("sni passthrough rejected by transform",
+			slog.String("sni", sni),
+			slog.Int("status", rejectResp.StatusCode),
+		)
+		return nil
+	}
+
+	if sni == "" {
+		result.Action = transform.ActionReject
+		result.StatusCode = http.StatusBadRequest
+		result.Err = fmt.Errorf("client hello missing sni")
+		return fmt.Errorf("client hello missing sni")
+	}
+
+	// Dial upstream using the proxy's resolver so SNI → IP lookup goes via
+	// the configured upstream DNS (not the proxy's own intercepting server).
+	dialer := &net.Dialer{
+		Timeout:  sniUpstreamDial,
+		Resolver: p.resolver,
+	}
+	upstream, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(sni, port))
+	if err != nil {
+		result.Action = transform.ActionContinue
+		result.StatusCode = http.StatusBadGateway
+		result.Err = err
+		return fmt.Errorf("dial upstream %s: %w", sni, err)
+	}
+	defer upstream.Close()
+
+	// Replay the peeked ClientHello bytes to upstream.
+	if _, err := upstream.Write(peeked); err != nil {
+		result.Action = transform.ActionContinue
+		result.StatusCode = http.StatusBadGateway
+		result.Err = err
+		return fmt.Errorf("replay client hello to %s: %w", sni, err)
+	}
+
+	result.Action = transform.ActionContinue
+	result.StatusCode = http.StatusOK
+
+	// Proxy bidirectionally until either side closes.
+	proxyBidi(clientConn, upstream, p.logger)
+	return nil
+}
+
+// proxyBidi copies bytes between two connections in both directions, closing
+// write halves on EOF and logging copy errors at debug level.
+func proxyBidi(a, b net.Conn, logger *slog.Logger) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		if _, err := io.Copy(b, a); err != nil {
+			logger.Debug("sni passthrough a->b copy error", slog.String("error", err.Error()))
+		}
+		if tc, ok := b.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if _, err := io.Copy(a, b); err != nil {
+			logger.Debug("sni passthrough b->a copy error", slog.String("error", err.Error()))
+		}
+		if tc, ok := a.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -43,13 +43,7 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 		return fmt.Errorf("peek sni: %w", err)
 	}
 
-	// Run the pipeline with a host-only synthetic request.
-	tctx := &transform.TransformContext{
-		Logger: p.logger,
-		SNI:    sni,
-		Mode:   transform.ModeSNIOnly,
-	}
-
+	// Set up audit first so even empty-SNI rejections get logged.
 	result := &transform.PipelineResult{
 		Host:       sni,
 		RemoteAddr: clientConn.RemoteAddr().String(),
@@ -58,6 +52,19 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 	}
 	pl, finish := p.beginPipelineRun(result)
 	defer finish()
+
+	if sni == "" {
+		result.Action = transform.ActionReject
+		result.StatusCode = http.StatusBadRequest
+		result.Err = fmt.Errorf("client hello missing sni")
+		return result.Err
+	}
+
+	tctx := &transform.TransformContext{
+		Logger: p.logger,
+		SNI:    sni,
+		Mode:   transform.ModeSNIOnly,
+	}
 
 	req := &http.Request{
 		Host:       sni,
@@ -70,7 +77,7 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 	}
 	req.Body = transform.NewBufferedBody(http.NoBody, 0)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(p.shutdownCtx)
 	defer cancel()
 
 	rejectResp, pipelineErr := pl.ProcessRequest(ctx, tctx, req, &result.RequestTransforms)
@@ -88,13 +95,6 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 			slog.Int("status", rejectResp.StatusCode),
 		)
 		return nil
-	}
-
-	if sni == "" {
-		result.Action = transform.ActionReject
-		result.StatusCode = http.StatusBadRequest
-		result.Err = fmt.Errorf("client hello missing sni")
-		return fmt.Errorf("client hello missing sni")
 	}
 
 	// Dial upstream using the proxy's resolver so SNI → IP lookup goes via

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -98,10 +98,13 @@ func startEchoTLSServer(t *testing.T, cert tls.Certificate) string {
 
 // startSNIPassthroughProxy builds a Proxy in sni-only mode, listens on a
 // random port, and for each connection invokes serveSNIPassthrough with the
-// given upstream target. Returns the proxy listener addr and a slice that
-// tests can read to inspect emitted audit records (protected by mu).
+// upstream dial rerouted to the test echo server (via sniUpstreamPort).
+// Returns the proxy listener addr and a snapshot accessor for audit records.
 func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (listenAddr string, getResults func() []transform.PipelineResult) {
 	t.Helper()
+
+	_, upstreamPort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
@@ -131,6 +134,7 @@ func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (
 		Pipeline:  holder,
 		Logger:    logger,
 	})
+	p.sniUpstreamPort = upstreamPort
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -143,7 +147,7 @@ func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (
 				return
 			}
 			go func(c net.Conn) {
-				_ = p.serveSNIPassthrough(c, upstream)
+				_ = p.serveSNIPassthrough(c)
 			}(conn)
 		}
 	}()
@@ -278,6 +282,8 @@ func TestSNIPassthrough_MalformedClientHello(t *testing.T) {
 func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 	cert, pool := newLocalhostTLSCert(t)
 	upstream := startEchoTLSServer(t, cert)
+	_, upstreamPort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
@@ -295,6 +301,7 @@ func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 		Pipeline:  holder,
 		Logger:    logger,
 	})
+	p.sniUpstreamPort = upstreamPort
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -307,7 +314,7 @@ func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 			close(done)
 			return
 		}
-		_ = p.serveSNIPassthrough(conn, upstream)
+		_ = p.serveSNIPassthrough(conn)
 		close(done)
 	}()
 
@@ -357,6 +364,7 @@ func TestSNIPassthrough_CONNECTTunnel(t *testing.T) {
 		Pipeline:   holder,
 		Logger:     logger,
 	})
+	p.sniUpstreamPort = upstreamPort
 
 	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -410,4 +418,99 @@ func TestSNIPassthrough_CONNECTTunnel(t *testing.T) {
 	body, err := io.ReadAll(upResp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "echo /tunneled\n", string(body))
+}
+
+// TestSNIPassthrough_IgnoresCONNECTPort verifies that in sni-only mode a
+// client-supplied CONNECT port does not influence the upstream port the
+// proxy dials. This prevents a malicious client from pivoting an
+// allowlisted hostname onto a different port (e.g. SMTP).
+func TestSNIPassthrough_IgnoresCONNECTPort(t *testing.T) {
+	cert, pool := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+	_, upstreamPort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
+
+	// Start a second listener that we expect NEVER to be dialed. If the
+	// proxy respected the CONNECT port, it would try to connect here.
+	decoyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer decoyLn.Close()
+	_, decoyPort, err := net.SplitHostPort(decoyLn.Addr().String())
+	require.NoError(t, err)
+
+	decoyHit := make(chan struct{}, 1)
+	go func() {
+		conn, err := decoyLn.Accept()
+		if err == nil {
+			select {
+			case decoyHit <- struct{}{}:
+			default:
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
+		"localhost": {"127.0.0.1"},
+	}})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
+
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		HTTPSAddr:  "127.0.0.1:0",
+		TunnelAddr: "127.0.0.1:0",
+		TLSMode:    "sni-only",
+		Pipeline:   holder,
+		Logger:     logger,
+	})
+	p.sniUpstreamPort = upstreamPort // proxy should dial here, not decoyPort
+
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		_ = tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	// Client CONNECTs to localhost:decoyPort but the proxy should ignore
+	// that port and dial upstream on sniUpstreamPort.
+	conn, err := net.Dial("tcp", tunnelAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT localhost:%s HTTP/1.1\r\nHost: localhost:%s\r\n\r\n", decoyPort, decoyPort)
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    pool,
+	})
+	require.NoError(t, tlsConn.Handshake(), "handshake should succeed against the real upstream, not the decoy")
+
+	select {
+	case <-decoyHit:
+		t.Fatal("proxy dialed the CONNECT port instead of the fixed sni upstream port")
+	case <-time.After(300 * time.Millisecond):
+		// no connection to decoy, as expected.
+	}
 }

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -323,7 +323,7 @@ func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 		RootCAs:    pool,
 	})
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Handshake is complete and connection is idle — proxyBidi goroutines
 	// are blocked on reads in both directions. Calling Shutdown should

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -323,7 +323,7 @@ func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 		RootCAs:    pool,
 	})
 	require.NoError(t, err)
-	defer func() { _ = conn.Close() }()
+	defer conn.Close()
 
 	// Handshake is complete and connection is idle — proxyBidi goroutines
 	// are blocked on reads in both directions. Calling Shutdown should

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -27,11 +27,33 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
 
-// newLocalhostTLSCert returns a self-signed cert valid for "localhost" and
-// 127.0.0.1, plus a pool trusting it.
+// sniTestHosts covers every hostname used across the SNI passthrough tests.
+// The staticResolver maps each to 127.0.0.1 so the proxy's dial lands on our
+// local test upstream.
+var sniTestHosts = map[string][]string{
+	"localhost":       {"127.0.0.1"},
+	"blocked.example": {"127.0.0.1"},
+	"allowed.example": {"127.0.0.1"},
+}
+
+// startEchoTLSServer starts a TLS server on 127.0.0.1:0 that responds to any
+// request with "echo <path>\n". Returns the host:port address and a cert pool
+// trusting the server's self-signed leaf, whose SANs cover the hostnames in
+// sniTestHosts.
+func startEchoTLSServer(t *testing.T) (addr string, pool *x509.CertPool) {
+	t.Helper()
+	cert, pool := newLocalhostTLSCert(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "echo %s\n", r.URL.Path)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String(), pool
+}
+
 func newLocalhostTLSCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 	t.Helper()
-
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
@@ -52,46 +74,19 @@ func newLocalhostTLSCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 
 	pool := x509.NewCertPool()
 	pool.AddCert(parsed)
-
-	return tls.Certificate{
-		Certificate: [][]byte{certDER},
-		PrivateKey:  key,
-		Leaf:        parsed,
-	}, pool
+	return tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key, Leaf: parsed}, pool
 }
 
-// startEchoTLSServer starts a TLS server on 127.0.0.1:0 that responds to any
-// HTTP/1.1 request with "echo <path>\n". Returns the "host:port" address.
-func startEchoTLSServer(t *testing.T, cert tls.Certificate) string {
+// buildSNIProxy creates a Proxy in sni-only mode with an allowlist permitting
+// the given hostnames. Returns the proxy and an accessor for captured audit
+// records. Callers are responsible for starting listeners and setting
+// p.sniUpstreamPort if they want upstream dials to reach a test server.
+func buildSNIProxy(t *testing.T, allowed []string, withTunnel bool) (*Proxy, func() []transform.PipelineResult) {
 	t.Helper()
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintf(w, "echo %s\n", r.URL.Path)
-	}))
-	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
-	srv.StartTLS()
-	t.Cleanup(srv.Close)
-	return srv.Listener.Addr().String()
-}
-
-// startSNIPassthroughProxy builds a Proxy in sni-only mode, listens on a
-// random port, and for each connection invokes serveSNIPassthrough with the
-// upstream dial rerouted to the test echo server (via sniUpstreamPort).
-// Returns the proxy listener addr and a snapshot accessor for audit records.
-func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (listenAddr string, getResults func() []transform.PipelineResult) {
-	t.Helper()
-
-	_, upstreamPort, err := net.SplitHostPort(upstream)
-	require.NoError(t, err)
-
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	al, err := allowlist.New(allowed, nil, &staticResolver{hosts: map[string][]string{
-		"localhost":       {"127.0.0.1"},
-		"blocked.example": {"127.0.0.1"},
-		"allowed.example": {"127.0.0.1"},
-	}})
+	al, err := allowlist.New(allowed, nil, &staticResolver{hosts: sniTestHosts})
 	require.NoError(t, err)
-
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 
 	var mu sync.Mutex
@@ -102,34 +97,19 @@ func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (
 		results = append(results, *r)
 	})
 
-	holder := transform.NewPipelineHolder(pipeline)
-
-	p := New(Options{
+	opts := Options{
 		HTTPAddr:  "127.0.0.1:0",
 		HTTPSAddr: "127.0.0.1:0",
 		TLSMode:   "sni-only",
-		Pipeline:  holder,
+		Pipeline:  transform.NewPipelineHolder(pipeline),
 		Logger:    logger,
-	})
-	p.sniUpstreamPort = upstreamPort
+	}
+	if withTunnel {
+		opts.TunnelAddr = "127.0.0.1:0"
+	}
+	p := New(opts)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			go func(c net.Conn) {
-				_ = p.serveSNIPassthrough(c)
-			}(conn)
-		}
-	}()
-
-	return ln.Addr().String(), func() []transform.PipelineResult {
+	return p, func() []transform.PipelineResult {
 		mu.Lock()
 		defer mu.Unlock()
 		out := make([]transform.PipelineResult, len(results))
@@ -138,23 +118,97 @@ func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (
 	}
 }
 
-func TestSNIPassthrough_HappyPath(t *testing.T) {
-	cert, pool := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
+// startAcceptLoop listens on 127.0.0.1:0 and spawns handle(conn) for each
+// accepted connection. Returns the listener's address; the listener is closed
+// via t.Cleanup.
+func startAcceptLoop(t *testing.T, handle func(net.Conn)) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handle(conn)
+		}
+	}()
+	return ln.Addr().String()
+}
 
+// startTunnelListener wires up a tunnel accept loop for the given proxy on
+// 127.0.0.1:0 and returns the listener's address.
+func startTunnelListener(t *testing.T, p *Proxy) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	p.tunnelListener = ln
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		close(p.tunnelDone)
+	})
+	return ln.Addr().String()
+}
+
+// startSNIPassthroughProxy builds a sni-only proxy wired to dial upstream and
+// starts a local accept loop that drives serveSNIPassthrough. Returns the
+// proxy's listener address and an audit-records accessor.
+func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (string, func() []transform.PipelineResult) {
+	t.Helper()
+	_, upstreamPort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
+
+	p, getResults := buildSNIProxy(t, allowed, false)
+	p.sniUpstreamPort = upstreamPort
+
+	addr := startAcceptLoop(t, func(c net.Conn) { _ = p.serveSNIPassthrough(c) })
+	return addr, getResults
+}
+
+// connectAndHandshake opens a TCP connection to tunnelAddr, issues CONNECT to
+// connectTarget, and completes a TLS handshake with ServerName=sni verified
+// against pool. Returns the established TLS connection.
+func connectAndHandshake(t *testing.T, tunnelAddr, connectTarget, sni string, pool *x509.CertPool) *tls.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", tunnelAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", connectTarget, connectTarget)
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+
+	tlsConn := tls.Client(conn, &tls.Config{ServerName: sni, RootCAs: pool})
+	require.NoError(t, tlsConn.Handshake())
+	return tlsConn
+}
+
+func TestSNIPassthrough_HappyPath(t *testing.T) {
+	upstream, pool := startEchoTLSServer(t)
 	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
 
-	conn, err := tls.Dial("tcp", proxyAddr, &tls.Config{
-		ServerName: "localhost",
-		RootCAs:    pool,
-	})
+	conn, err := tls.Dial("tcp", proxyAddr, &tls.Config{ServerName: "localhost", RootCAs: pool})
 	require.NoError(t, err)
 
 	_, err = conn.Write([]byte("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"))
 	require.NoError(t, err)
 
-	br := bufio.NewReader(conn)
-	resp, err := http.ReadResponse(br, nil)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
@@ -166,9 +220,7 @@ func TestSNIPassthrough_HappyPath(t *testing.T) {
 	// Close the client conn so the proxy's bidi copy drains and emits audit.
 	_ = conn.Close()
 
-	require.Eventually(t, func() bool {
-		return len(getResults()) > 0
-	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(getResults()) > 0 }, 2*time.Second, 10*time.Millisecond)
 
 	results := getResults()
 	require.Len(t, results, 1)
@@ -181,26 +233,17 @@ func TestSNIPassthrough_HappyPath(t *testing.T) {
 }
 
 func TestSNIPassthrough_AllowlistDeny(t *testing.T) {
-	cert, _ := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
-
+	upstream, _ := startEchoTLSServer(t)
 	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"allowed.example"}, upstream)
 
 	conn, err := net.Dial("tcp", proxyAddr)
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Start a tls handshake to the proxy with an SNI not on the allowlist.
-	tlsConn := tls.Client(conn, &tls.Config{
-		ServerName:         "blocked.example",
-		InsecureSkipVerify: true,
-	})
-	handshakeErr := tlsConn.Handshake()
-	require.Error(t, handshakeErr, "handshake should fail because proxy closes conn")
+	tlsConn := tls.Client(conn, &tls.Config{ServerName: "blocked.example", InsecureSkipVerify: true})
+	require.Error(t, tlsConn.Handshake(), "handshake should fail because proxy closes conn")
 
-	require.Eventually(t, func() bool {
-		return len(getResults()) > 0
-	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(getResults()) > 0 }, 2*time.Second, 10*time.Millisecond)
 
 	results := getResults()
 	require.Len(t, results, 1)
@@ -210,24 +253,18 @@ func TestSNIPassthrough_AllowlistDeny(t *testing.T) {
 }
 
 func TestSNIPassthrough_NoSNI(t *testing.T) {
-	cert, _ := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
-
+	upstream, _ := startEchoTLSServer(t)
 	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
 
 	conn, err := net.Dial("tcp", proxyAddr)
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Client with no ServerName → ClientHello with no SNI extension.
-	tlsConn := tls.Client(conn, &tls.Config{
-		InsecureSkipVerify: true,
-	})
+	// Client with no ServerName sends a ClientHello without an SNI extension.
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
 	_ = tlsConn.Handshake() // will fail; proxy rejects empty SNI
 
-	require.Eventually(t, func() bool {
-		return len(getResults()) > 0
-	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return len(getResults()) > 0 }, 2*time.Second, 10*time.Millisecond)
 
 	results := getResults()
 	require.Len(t, results, 1)
@@ -236,75 +273,42 @@ func TestSNIPassthrough_NoSNI(t *testing.T) {
 }
 
 func TestSNIPassthrough_MalformedClientHello(t *testing.T) {
-	cert, _ := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
-
+	upstream, _ := startEchoTLSServer(t)
 	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
 
 	conn, err := net.Dial("tcp", proxyAddr)
 	require.NoError(t, err)
 	_, _ = conn.Write([]byte("definitely not a tls client hello"))
 
-	// Proxy should close. Give it a moment, then confirm no audit record
-	// claims success.
 	time.Sleep(200 * time.Millisecond)
 	_ = conn.Close()
 
-	results := getResults()
 	// Malformed input is rejected before the pipeline runs, so no audit
 	// record is emitted.
-	require.Len(t, results, 0)
+	require.Empty(t, getResults())
 }
 
 func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
-	cert, pool := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
+	upstream, pool := startEchoTLSServer(t)
 	_, upstreamPort, err := net.SplitHostPort(upstream)
 	require.NoError(t, err)
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-
-	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
-		"localhost": {"127.0.0.1"},
-	}})
-	require.NoError(t, err)
-	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
-	holder := transform.NewPipelineHolder(pipeline)
-
-	p := New(Options{
-		HTTPAddr:  "127.0.0.1:0",
-		HTTPSAddr: "127.0.0.1:0",
-		TLSMode:   "sni-only",
-		Pipeline:  holder,
-		Logger:    logger,
-	})
+	p, _ := buildSNIProxy(t, []string{"localhost"}, false)
 	p.sniUpstreamPort = upstreamPort
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-
 	done := make(chan struct{})
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			close(done)
-			return
-		}
-		_ = p.serveSNIPassthrough(conn)
+	addr := startAcceptLoop(t, func(c net.Conn) {
+		_ = p.serveSNIPassthrough(c)
 		close(done)
-	}()
-
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		ServerName: "localhost",
-		RootCAs:    pool,
 	})
+
+	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: "localhost", RootCAs: pool})
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// Handshake is complete and connection is idle — proxyBidi goroutines
-	// are blocked on reads in both directions. Calling Shutdown should
-	// cancel shutdownCtx and close both conns so serveSNIPassthrough returns.
+	// are blocked on reads in both directions. Shutdown should unblock them
+	// by closing both conns.
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	require.NoError(t, p.Shutdown(shutdownCtx))
@@ -317,98 +321,39 @@ func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
 }
 
 func TestSNIPassthrough_CONNECTTunnel(t *testing.T) {
-	// A full end-to-end test via the CONNECT tunnel path in sni-only mode.
-	cert, pool := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
-	upstreamHost, upstreamPort, err := net.SplitHostPort(upstream)
+	upstream, pool := startEchoTLSServer(t)
+	_, upstreamPort, err := net.SplitHostPort(upstream)
 	require.NoError(t, err)
-	require.Equal(t, "127.0.0.1", upstreamHost)
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-
-	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
-		"localhost": {"127.0.0.1"},
-	}})
-	require.NoError(t, err)
-	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
-	holder := transform.NewPipelineHolder(pipeline)
-
-	p := New(Options{
-		HTTPAddr:   "127.0.0.1:0",
-		HTTPSAddr:  "127.0.0.1:0",
-		TunnelAddr: "127.0.0.1:0",
-		TLSMode:    "sni-only",
-		Pipeline:   holder,
-		Logger:     logger,
-	})
+	p, _ := buildSNIProxy(t, []string{"localhost"}, true)
 	p.sniUpstreamPort = upstreamPort
+	tunnelAddr := startTunnelListener(t, p)
 
-	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	tunnelAddr := tunnelLn.Addr().String()
-	p.tunnelListener = tunnelLn
-	go func() {
-		for {
-			conn, err := tunnelLn.Accept()
-			if err != nil {
-				return
-			}
-			go p.handleTunnel(conn)
-		}
-	}()
-	t.Cleanup(func() {
-		_ = tunnelLn.Close()
-		close(p.tunnelDone)
-	})
-
-	// Connect to tunnel and send CONNECT for localhost:upstreamPort.
-	conn, err := net.Dial("tcp", tunnelAddr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	connectReq := fmt.Sprintf("CONNECT localhost:%s HTTP/1.1\r\nHost: localhost:%s\r\n\r\n", upstreamPort, upstreamPort)
-	_, err = conn.Write([]byte(connectReq))
-	require.NoError(t, err)
-
-	br := bufio.NewReader(conn)
-	resp, err := http.ReadResponse(br, nil)
-	require.NoError(t, err)
-	_ = resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
-
-	// Now do TLS over the tunnel, verifying it TCP-passthroughs rather than
-	// MITMs (cert chain must validate against the upstream's real cert).
-	tlsConn := tls.Client(conn, &tls.Config{
-		ServerName: "localhost",
-		RootCAs:    pool,
-	})
-	require.NoError(t, tlsConn.Handshake())
+	tlsConn := connectAndHandshake(t, tunnelAddr, "localhost:"+upstreamPort, "localhost", pool)
 
 	_, err = tlsConn.Write([]byte("GET /tunneled HTTP/1.1\r\nHost: localhost\r\n\r\n"))
 	require.NoError(t, err)
 
-	bufR := bufio.NewReader(tlsConn)
-	upResp, err := http.ReadResponse(bufR, nil)
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), nil)
 	require.NoError(t, err)
-	defer upResp.Body.Close()
-	require.Equal(t, 200, upResp.StatusCode)
-	body, err := io.ReadAll(upResp.Body)
+	defer resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "echo /tunneled\n", string(body))
 }
 
-// TestSNIPassthrough_IgnoresCONNECTPort verifies that in sni-only mode a
-// client-supplied CONNECT port does not influence the upstream port the
-// proxy dials. This prevents a malicious client from pivoting an
-// allowlisted hostname onto a different port (e.g. SMTP).
+// TestSNIPassthrough_IgnoresCONNECTPort verifies that a client-supplied
+// CONNECT port does not influence the upstream port the proxy dials. This
+// prevents a malicious client from pivoting an allowlisted hostname onto a
+// different port (e.g. SMTP).
 func TestSNIPassthrough_IgnoresCONNECTPort(t *testing.T) {
-	cert, pool := newLocalhostTLSCert(t)
-	upstream := startEchoTLSServer(t, cert)
+	upstream, pool := startEchoTLSServer(t)
 	_, upstreamPort, err := net.SplitHostPort(upstream)
 	require.NoError(t, err)
 
-	// Start a second listener that we expect NEVER to be dialed. If the
-	// proxy respected the CONNECT port, it would try to connect here.
+	// Start a second listener that we expect NEVER to be dialed.
 	decoyLn, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer decoyLn.Close()
@@ -427,62 +372,13 @@ func TestSNIPassthrough_IgnoresCONNECTPort(t *testing.T) {
 		}
 	}()
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
-		"localhost": {"127.0.0.1"},
-	}})
-	require.NoError(t, err)
-	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
-	holder := transform.NewPipelineHolder(pipeline)
-
-	p := New(Options{
-		HTTPAddr:   "127.0.0.1:0",
-		HTTPSAddr:  "127.0.0.1:0",
-		TunnelAddr: "127.0.0.1:0",
-		TLSMode:    "sni-only",
-		Pipeline:   holder,
-		Logger:     logger,
-	})
+	p, _ := buildSNIProxy(t, []string{"localhost"}, true)
 	p.sniUpstreamPort = upstreamPort // proxy should dial here, not decoyPort
-
-	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	tunnelAddr := tunnelLn.Addr().String()
-	p.tunnelListener = tunnelLn
-	go func() {
-		for {
-			conn, err := tunnelLn.Accept()
-			if err != nil {
-				return
-			}
-			go p.handleTunnel(conn)
-		}
-	}()
-	t.Cleanup(func() {
-		_ = tunnelLn.Close()
-		close(p.tunnelDone)
-	})
+	tunnelAddr := startTunnelListener(t, p)
 
 	// Client CONNECTs to localhost:decoyPort but the proxy should ignore
 	// that port and dial upstream on sniUpstreamPort.
-	conn, err := net.Dial("tcp", tunnelAddr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	_, err = fmt.Fprintf(conn, "CONNECT localhost:%s HTTP/1.1\r\nHost: localhost:%s\r\n\r\n", decoyPort, decoyPort)
-	require.NoError(t, err)
-
-	br := bufio.NewReader(conn)
-	resp, err := http.ReadResponse(br, nil)
-	require.NoError(t, err)
-	_ = resp.Body.Close()
-	require.Equal(t, 200, resp.StatusCode)
-
-	tlsConn := tls.Client(conn, &tls.Config{
-		ServerName: "localhost",
-		RootCAs:    pool,
-	})
-	require.NoError(t, tlsConn.Handshake(), "handshake should succeed against the real upstream, not the decoy")
+	_ = connectAndHandshake(t, tunnelAddr, "localhost:"+decoyPort, "localhost", pool)
 
 	select {
 	case <-decoyHit:

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
@@ -63,37 +64,13 @@ func newLocalhostTLSCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
 // HTTP/1.1 request with "echo <path>\n". Returns the "host:port" address.
 func startEchoTLSServer(t *testing.T, cert tls.Certificate) string {
 	t.Helper()
-
-	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
-		Certificates: []tls.Certificate{cert},
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ln.Close() })
-
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			go func(c net.Conn) {
-				defer c.Close()
-				br := bufio.NewReader(c)
-				req, err := http.ReadRequest(br)
-				if err != nil {
-					return
-				}
-				body := fmt.Sprintf("echo %s\n", req.URL.Path)
-				resp := fmt.Sprintf(
-					"HTTP/1.1 200 OK\r\nContent-Length: %d\r\nContent-Type: text/plain\r\n\r\n%s",
-					len(body), body,
-				)
-				_, _ = c.Write([]byte(resp))
-			}(conn)
-		}
-	}()
-
-	return ln.Addr().String()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "echo %s\n", r.URL.Path)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
 }
 
 // startSNIPassthroughProxy builds a Proxy in sni-only mode, listens on a

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -272,6 +273,63 @@ func TestSNIPassthrough_MalformedClientHello(t *testing.T) {
 	// Malformed input is rejected before the pipeline runs, so no audit
 	// record is emitted.
 	require.Len(t, results, 0)
+}
+
+func TestSNIPassthrough_ShutdownClosesInFlight(t *testing.T) {
+	cert, pool := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
+		"localhost": {"127.0.0.1"},
+	}})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
+
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		TLSMode:   "sni-only",
+		Pipeline:  holder,
+		Logger:    logger,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			close(done)
+			return
+		}
+		_ = p.serveSNIPassthrough(conn, upstream)
+		close(done)
+	}()
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    pool,
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Handshake is complete and connection is idle — proxyBidi goroutines
+	// are blocked on reads in both directions. Calling Shutdown should
+	// cancel shutdownCtx and close both conns so serveSNIPassthrough returns.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, p.Shutdown(shutdownCtx))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serveSNIPassthrough did not return after Shutdown")
+	}
 }
 
 func TestSNIPassthrough_CONNECTTunnel(t *testing.T) {

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -1,0 +1,355 @@
+package proxy
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
+)
+
+// newLocalhostTLSCert returns a self-signed cert valid for "localhost" and
+// 127.0.0.1, plus a pool trusting it.
+func newLocalhostTLSCert(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost", "blocked.example", "allowed.example"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	parsed, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(parsed)
+
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+		Leaf:        parsed,
+	}, pool
+}
+
+// startEchoTLSServer starts a TLS server on 127.0.0.1:0 that responds to any
+// HTTP/1.1 request with "echo <path>\n". Returns the "host:port" address.
+func startEchoTLSServer(t *testing.T, cert tls.Certificate) string {
+	t.Helper()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				body := fmt.Sprintf("echo %s\n", req.URL.Path)
+				resp := fmt.Sprintf(
+					"HTTP/1.1 200 OK\r\nContent-Length: %d\r\nContent-Type: text/plain\r\n\r\n%s",
+					len(body), body,
+				)
+				_, _ = c.Write([]byte(resp))
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+// startSNIPassthroughProxy builds a Proxy in sni-only mode, listens on a
+// random port, and for each connection invokes serveSNIPassthrough with the
+// given upstream target. Returns the proxy listener addr and a slice that
+// tests can read to inspect emitted audit records (protected by mu).
+func startSNIPassthroughProxy(t *testing.T, allowed []string, upstream string) (listenAddr string, getResults func() []transform.PipelineResult) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	al, err := allowlist.New(allowed, nil, &staticResolver{hosts: map[string][]string{
+		"localhost":       {"127.0.0.1"},
+		"blocked.example": {"127.0.0.1"},
+		"allowed.example": {"127.0.0.1"},
+	}})
+	require.NoError(t, err)
+
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	var mu sync.Mutex
+	var results []transform.PipelineResult
+	pipeline.SetAuditFunc(func(r *transform.PipelineResult) {
+		mu.Lock()
+		defer mu.Unlock()
+		results = append(results, *r)
+	})
+
+	holder := transform.NewPipelineHolder(pipeline)
+
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		TLSMode:   "sni-only",
+		Pipeline:  holder,
+		Logger:    logger,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				_ = p.serveSNIPassthrough(c, upstream)
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), func() []transform.PipelineResult {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]transform.PipelineResult, len(results))
+		copy(out, results)
+		return out
+	}
+}
+
+func TestSNIPassthrough_HappyPath(t *testing.T) {
+	cert, pool := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+
+	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
+
+	conn, err := tls.Dial("tcp", proxyAddr, &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    pool,
+	})
+	require.NoError(t, err)
+
+	_, err = conn.Write([]byte("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, "echo /hello\n", string(body))
+
+	// Close the client conn so the proxy's bidi copy drains and emits audit.
+	_ = conn.Close()
+
+	require.Eventually(t, func() bool {
+		return len(getResults()) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	results := getResults()
+	require.Len(t, results, 1)
+	require.Equal(t, transform.ModeSNIOnly, results[0].Mode)
+	require.Equal(t, "localhost", results[0].SNI)
+	require.Equal(t, "localhost", results[0].Host)
+	require.Equal(t, "", results[0].Method)
+	require.Equal(t, "", results[0].Path)
+	require.Equal(t, transform.ActionContinue, results[0].Action)
+}
+
+func TestSNIPassthrough_AllowlistDeny(t *testing.T) {
+	cert, _ := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+
+	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"allowed.example"}, upstream)
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Start a tls handshake to the proxy with an SNI not on the allowlist.
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         "blocked.example",
+		InsecureSkipVerify: true,
+	})
+	handshakeErr := tlsConn.Handshake()
+	require.Error(t, handshakeErr, "handshake should fail because proxy closes conn")
+
+	require.Eventually(t, func() bool {
+		return len(getResults()) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	results := getResults()
+	require.Len(t, results, 1)
+	require.Equal(t, transform.ModeSNIOnly, results[0].Mode)
+	require.Equal(t, "blocked.example", results[0].SNI)
+	require.Equal(t, transform.ActionReject, results[0].Action)
+}
+
+func TestSNIPassthrough_NoSNI(t *testing.T) {
+	cert, _ := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+
+	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Client with no ServerName → ClientHello with no SNI extension.
+	tlsConn := tls.Client(conn, &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	_ = tlsConn.Handshake() // will fail; proxy rejects empty SNI
+
+	require.Eventually(t, func() bool {
+		return len(getResults()) > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	results := getResults()
+	require.Len(t, results, 1)
+	require.Equal(t, "", results[0].SNI)
+	require.Equal(t, transform.ActionReject, results[0].Action)
+}
+
+func TestSNIPassthrough_MalformedClientHello(t *testing.T) {
+	cert, _ := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+
+	proxyAddr, getResults := startSNIPassthroughProxy(t, []string{"localhost"}, upstream)
+
+	conn, err := net.Dial("tcp", proxyAddr)
+	require.NoError(t, err)
+	_, _ = conn.Write([]byte("definitely not a tls client hello"))
+
+	// Proxy should close. Give it a moment, then confirm no audit record
+	// claims success.
+	time.Sleep(200 * time.Millisecond)
+	_ = conn.Close()
+
+	results := getResults()
+	// Malformed input is rejected before the pipeline runs, so no audit
+	// record is emitted.
+	require.Len(t, results, 0)
+}
+
+func TestSNIPassthrough_CONNECTTunnel(t *testing.T) {
+	// A full end-to-end test via the CONNECT tunnel path in sni-only mode.
+	cert, pool := newLocalhostTLSCert(t)
+	upstream := startEchoTLSServer(t, cert)
+	upstreamHost, upstreamPort, err := net.SplitHostPort(upstream)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1", upstreamHost)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	al, err := allowlist.New([]string{"localhost"}, nil, &staticResolver{hosts: map[string][]string{
+		"localhost": {"127.0.0.1"},
+	}})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
+
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		HTTPSAddr:  "127.0.0.1:0",
+		TunnelAddr: "127.0.0.1:0",
+		TLSMode:    "sni-only",
+		Pipeline:   holder,
+		Logger:     logger,
+	})
+
+	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tunnelAddr := tunnelLn.Addr().String()
+	p.tunnelListener = tunnelLn
+	go func() {
+		for {
+			conn, err := tunnelLn.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		_ = tunnelLn.Close()
+		close(p.tunnelDone)
+	})
+
+	// Connect to tunnel and send CONNECT for localhost:upstreamPort.
+	conn, err := net.Dial("tcp", tunnelAddr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	connectReq := fmt.Sprintf("CONNECT localhost:%s HTTP/1.1\r\nHost: localhost:%s\r\n\r\n", upstreamPort, upstreamPort)
+	_, err = conn.Write([]byte(connectReq))
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, 200, resp.StatusCode)
+
+	// Now do TLS over the tunnel, verifying it TCP-passthroughs rather than
+	// MITMs (cert chain must validate against the upstream's real cert).
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    pool,
+	})
+	require.NoError(t, tlsConn.Handshake())
+
+	_, err = tlsConn.Write([]byte("GET /tunneled HTTP/1.1\r\nHost: localhost\r\n\r\n"))
+	require.NoError(t, err)
+
+	bufR := bufio.NewReader(tlsConn)
+	upResp, err := http.ReadResponse(bufR, nil)
+	require.NoError(t, err)
+	defer upResp.Body.Close()
+	require.Equal(t, 200, upResp.StatusCode)
+	body, err := io.ReadAll(upResp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "echo /tunneled\n", string(body))
+}

--- a/internal/proxy/snipeek.go
+++ b/internal/proxy/snipeek.go
@@ -6,9 +6,16 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"time"
 )
+
+// maxClientHelloBytes caps how many bytes peekSNI will buffer from a client
+// before giving up. A well-formed TLS ClientHello fits comfortably; this
+// exists so a malicious client cannot exhaust memory by streaming a slow,
+// ever-growing handshake record.
+const maxClientHelloBytes = 16 * 1024
 
 // errSNIPeekDone is returned from GetConfigForClient to abort the TLS handshake
 // after the ClientHello has been parsed and the SNI captured.
@@ -60,13 +67,18 @@ func peekSNI(conn net.Conn, timeout time.Duration) (sni string, peeked []byte, e
 // recordingConn wraps a net.Conn so that all bytes read from it are also
 // buffered for later replay, and all writes are silently discarded. This lets
 // us drive crypto/tls far enough to parse the ClientHello without sending a
-// handshake response (or an abort alert) back to the peer.
+// handshake response (or an abort alert) back to the peer. Reads past
+// maxClientHelloBytes return io.ErrShortBuffer so a slow/malicious client
+// cannot grow the buffer without bound.
 type recordingConn struct {
 	net.Conn
 	buf bytes.Buffer
 }
 
 func (c *recordingConn) Read(p []byte) (int, error) {
+	if c.buf.Len() >= maxClientHelloBytes {
+		return 0, io.ErrShortBuffer
+	}
 	n, err := c.Conn.Read(p)
 	if n > 0 {
 		c.buf.Write(p[:n])
@@ -74,6 +86,8 @@ func (c *recordingConn) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// Write silently discards bytes so the crypto/tls server's abort alert never
+// reaches the client.
 func (c *recordingConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }

--- a/internal/proxy/snipeek.go
+++ b/internal/proxy/snipeek.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// errSNIPeekDone is returned from GetConfigForClient to abort the TLS handshake
+// after the ClientHello has been parsed and the SNI captured.
+var errSNIPeekDone = errors.New("sni peek complete")
+
+// peekSNI reads a TLS ClientHello from conn, parses it via crypto/tls, and
+// returns the SNI hostname plus the raw bytes consumed from conn so the caller
+// can replay them to an upstream server.
+//
+// The approach: wrap conn so all Reads are teed into a buffer, call tls.Server
+// with a GetConfigForClient callback that captures SNI and aborts the handshake,
+// and swallow writes (the abort triggers an alert that we don't want to send to
+// the client). Any post-handshake bytes remain in the underlying conn for the
+// caller to io.Copy normally.
+func peekSNI(conn net.Conn, timeout time.Duration) (sni string, peeked []byte, err error) {
+	deadline := time.Now().Add(timeout)
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		return "", nil, fmt.Errorf("set read deadline: %w", err)
+	}
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	rec := &recordingConn{Conn: conn}
+	var captured string
+	var called bool
+
+	tlsCfg := &tls.Config{
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			captured = hello.ServerName
+			called = true
+			return nil, errSNIPeekDone
+		},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	tlsConn := tls.Server(rec, tlsCfg)
+	handshakeErr := tlsConn.HandshakeContext(ctx)
+
+	if !called {
+		if handshakeErr == nil {
+			return "", nil, fmt.Errorf("tls handshake completed unexpectedly during sni peek")
+		}
+		return "", nil, fmt.Errorf("tls handshake failed before client hello parsed: %w", handshakeErr)
+	}
+	return captured, rec.buf.Bytes(), nil
+}
+
+// recordingConn wraps a net.Conn so that all bytes read from it are also
+// buffered for later replay, and all writes are silently discarded. This lets
+// us drive crypto/tls far enough to parse the ClientHello without sending a
+// handshake response (or an abort alert) back to the peer.
+type recordingConn struct {
+	net.Conn
+	buf bytes.Buffer
+}
+
+func (c *recordingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.buf.Write(p[:n])
+	}
+	return n, err
+}
+
+func (c *recordingConn) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/internal/proxy/snipeek_test.go
+++ b/internal/proxy/snipeek_test.go
@@ -1,0 +1,188 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// dialClientHello runs a real tls.Client handshake against the given conn.
+// The handshake will fail (peekSNI aborts) but the client will have sent a
+// valid ClientHello. Returns when the client handshake errors.
+func dialClientHello(t *testing.T, conn net.Conn, cfg *tls.Config) {
+	t.Helper()
+	go func() {
+		client := tls.Client(conn, cfg)
+		_ = client.Handshake()
+		_ = client.Close()
+	}()
+}
+
+func TestPeekSNI_WithSNI(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	dialClientHello(t, clientConn, &tls.Config{
+		ServerName:         "example.com",
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	})
+
+	sni, peeked, err := peekSNI(serverConn, 2*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "example.com", sni)
+	require.NotEmpty(t, peeked)
+	// First byte of a TLS handshake record is 0x16.
+	require.Equal(t, byte(0x16), peeked[0])
+}
+
+func TestPeekSNI_TLS13(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	dialClientHello(t, clientConn, &tls.Config{
+		ServerName:         "tls13.example.com",
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS13,
+		MaxVersion:         tls.VersionTLS13,
+	})
+
+	sni, peeked, err := peekSNI(serverConn, 2*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "tls13.example.com", sni)
+	require.NotEmpty(t, peeked)
+}
+
+func TestPeekSNI_NoSNI(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	// A tls.Client with no ServerName still sends a ClientHello, just without
+	// the SNI extension populated (ServerName field on ClientHelloInfo is "").
+	dialClientHello(t, clientConn, &tls.Config{
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	})
+
+	sni, peeked, err := peekSNI(serverConn, 2*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "", sni)
+	require.NotEmpty(t, peeked)
+}
+
+func TestPeekSNI_Malformed(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	// Write garbage that doesn't look like a TLS handshake.
+	go func() {
+		_, _ = clientConn.Write([]byte("HTTP/1.1 GET / garbage"))
+		_ = clientConn.Close()
+	}()
+
+	sni, peeked, err := peekSNI(serverConn, 500*time.Millisecond)
+	require.Error(t, err)
+	require.Equal(t, "", sni)
+	require.Empty(t, peeked)
+}
+
+func TestPeekSNI_Timeout(t *testing.T) {
+	_, serverConn := net.Pipe()
+	// No client writes anything; peekSNI should time out waiting.
+
+	start := time.Now()
+	_, _, err := peekSNI(serverConn, 200*time.Millisecond)
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second)
+}
+
+func TestPeekSNI_ReplayableBytes(t *testing.T) {
+	// Verify the peeked bytes can be used to re-drive a TLS parse on a fresh
+	// reader, confirming they form a complete ClientHello record.
+	clientConn, serverConn := net.Pipe()
+
+	dialClientHello(t, clientConn, &tls.Config{
+		ServerName:         "replay.example",
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS12,
+	})
+
+	_, peeked, err := peekSNI(serverConn, 2*time.Second)
+	require.NoError(t, err)
+
+	// First 5 bytes are the TLS record header: type(1) + version(2) + length(2).
+	require.Equal(t, byte(0x16), peeked[0]) // handshake
+	require.Equal(t, byte(0x03), peeked[1]) // TLS major
+	recordLen := int(peeked[3])<<8 | int(peeked[4])
+	require.GreaterOrEqual(t, len(peeked), 5+recordLen)
+
+	// Record starting at byte 5 is a handshake message. First byte of the
+	// handshake message is 0x01 (ClientHello).
+	require.Equal(t, byte(0x01), peeked[5])
+}
+
+func TestRecordingConn_DiscardsWrites(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	rec := &recordingConn{Conn: c2}
+
+	// Write to rec should return success without actually sending anything.
+	n, err := rec.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+
+	// Confirm nothing was sent by doing a non-blocking-ish read on c1 with
+	// a short deadline.
+	_ = c1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	buf := make([]byte, 16)
+	_, err = c1.Read(buf)
+	require.Error(t, err)
+}
+
+func TestRecordingConn_RecordsReads(t *testing.T) {
+	// Feed a bytes.Reader through recordingConn.
+	src := &readOnlyConn{r: bytes.NewReader([]byte("abcdef"))}
+	rec := &recordingConn{Conn: src}
+
+	buf := make([]byte, 3)
+	n, err := rec.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "abc", string(buf[:n]))
+
+	n, err = rec.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "def", string(buf[:n]))
+
+	require.Equal(t, "abcdef", rec.buf.String())
+}
+
+// readOnlyConn adapts an io.Reader to net.Conn for recordingConn tests.
+type readOnlyConn struct {
+	r io.Reader
+}
+
+func (c *readOnlyConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
+func (c *readOnlyConn) Write(p []byte) (int, error)        { return 0, io.ErrClosedPipe }
+func (c *readOnlyConn) Close() error                       { return nil }
+func (c *readOnlyConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *readOnlyConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *readOnlyConn) SetDeadline(t time.Time) error      { return nil }
+func (c *readOnlyConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *readOnlyConn) SetWriteDeadline(t time.Time) error { return nil }
+
+type dummyAddr struct{}
+
+func (dummyAddr) Network() string { return "dummy" }
+func (dummyAddr) String() string  { return "dummy" }
+
+// Sanity: ensure the package's errSNIPeekDone is the sentinel we expect.
+func TestErrSentinel(t *testing.T) {
+	require.True(t, strings.Contains(errSNIPeekDone.Error(), "sni peek"))
+}

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -242,7 +243,7 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 	req.Body = transform.NewBufferedBody(http.NoBody, 0)
 
 	mode := transform.ModeMITM
-	if p.tlsMode == "sni-only" {
+	if p.tlsMode == config.TLSModeSNIOnly {
 		mode = transform.ModeSNIOnly
 	}
 
@@ -320,7 +321,7 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 // peeks SNI and TCP-passthroughs to the SNI host on port 443 (the CONNECT
 // port is ignored to prevent port-pivot attacks).
 func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
-	if p.tlsMode == "sni-only" {
+	if p.tlsMode == config.TLSModeSNIOnly {
 		return p.serveSNIPassthrough(clientConn)
 	}
 

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -317,10 +317,11 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 
 // serveTunnelTLS handles the TLS branch of a tunnel connection. In MITM mode
 // it terminates TLS and serves HTTP via handleHTTP; in sni-only mode it
-// peeks SNI and TCP-passthroughs to the upstream named in target.
+// peeks SNI and TCP-passthroughs to the SNI host on port 443 (the CONNECT
+// port is ignored to prevent port-pivot attacks).
 func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
 	if p.tlsMode == "sni-only" {
-		return p.serveSNIPassthrough(clientConn, target)
+		return p.serveSNIPassthrough(clientConn)
 	}
 
 	tlsConn := tls.Server(clientConn, &tls.Config{

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -44,12 +44,6 @@ func (p *Proxy) listenTunnel() error {
 // handleTunnel peeks at the first byte to dispatch to CONNECT or SOCKS5.
 // This is the single logging point for tunnel connection errors.
 func (p *Proxy) handleTunnel(conn net.Conn) {
-	defer func() {
-		if r := recover(); r != nil {
-			p.logger.Error("tunnel panic", slog.Any("panic", r))
-		}
-	}()
-
 	br := bufio.NewReader(conn)
 	first, err := br.Peek(1)
 	if err != nil {

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
@@ -248,30 +247,29 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 	}
 	req.Body = transform.NewBufferedBody(http.NoBody, 0)
 
-	pl := p.pipeline.Load()
+	mode := transform.ModeMITM
+	if p.tlsMode == "sni-only" {
+		mode = transform.ModeSNIOnly
+	}
 
-	startedAt := time.Now()
 	tctx := &transform.TransformContext{
 		Logger: p.logger,
 		SNI:    host,
+		Mode:   mode,
 	}
 
-	var reqTraces []transform.TransformTrace
 	result := &transform.PipelineResult{
 		Host:       target,
 		Method:     http.MethodConnect,
 		Path:       "",
 		RemoteAddr: remoteAddr,
 		SNI:        host,
-		StartedAt:  startedAt,
+		Mode:       mode,
 	}
-	defer func() {
-		result.Duration = time.Since(startedAt)
-		result.RequestTransforms = reqTraces
-		pl.EmitAudit(result)
-	}()
+	pl, finish := p.beginPipelineRun(result)
+	defer finish()
 
-	rejectResp, err := pl.ProcessRequest(req.Context(), tctx, req, &reqTraces)
+	rejectResp, err := pl.ProcessRequest(req.Context(), tctx, req, &result.RequestTransforms)
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
@@ -323,9 +321,14 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 	return fmt.Errorf("unsupported protocol (first byte 0x%02x) for target %s", first[0], target)
 }
 
-// serveTunnelTLS performs TLS MITM on the client connection, then serves
-// HTTP requests through the normal handleHTTP handler.
+// serveTunnelTLS handles the TLS branch of a tunnel connection. In MITM mode
+// it terminates TLS and serves HTTP via handleHTTP; in sni-only mode it
+// peeks SNI and TCP-passthroughs to the upstream named in target.
 func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
+	if p.tlsMode == "sni-only" {
+		return p.serveSNIPassthrough(clientConn, target)
+	}
+
 	tlsConn := tls.Server(clientConn, &tls.Config{
 		GetCertificate: p.getCertificate,
 	})

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -29,7 +29,14 @@ func startTunnelProxy(t *testing.T, transforms []transform.Transformer) (*Proxy,
 
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
 	holder := transform.NewPipelineHolder(pipeline)
-	p := New("127.0.0.1:0", "127.0.0.1:0", "127.0.0.1:0", cache, holder, nil, testLogger())
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		HTTPSAddr:  "127.0.0.1:0",
+		TunnelAddr: "127.0.0.1:0",
+		CertCache:  cache,
+		Pipeline:   holder,
+		Logger:     testLogger(),
+	})
 
 	// Start tunnel listener
 	tunnelLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -30,6 +30,7 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 				slog.String("path", result.Path),
 				slog.String("remote_addr", result.RemoteAddr),
 				slog.String("sni", result.SNI),
+				slog.String("mode", result.Mode.String()),
 				slog.String("action", action),
 				slog.Int("status_code", result.StatusCode),
 				slog.Float64("duration_ms", float64(result.Duration.Microseconds())/1000.0),

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -46,6 +46,7 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 			log.String("path", result.Path),
 			log.String("remote_addr", result.RemoteAddr),
 			log.String("sni", result.SNI),
+			log.String("mode", result.Mode.String()),
 			log.String("action", action),
 			log.Int("status_code", result.StatusCode),
 			log.Float64("duration_ms", float64(result.Duration.Microseconds())/1000.0),

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -22,11 +22,38 @@ const (
 	ActionReject
 )
 
+// Mode identifies how the proxy obtained the request being transformed.
+type Mode int
+
+const (
+	// ModeMITM means the request was parsed from a terminated TLS connection
+	// (or plaintext HTTP) and has full method, path, headers, and body.
+	ModeMITM Mode = iota
+
+	// ModeSNIOnly means the request is a synthetic host-only stand-in built
+	// from a peeked TLS ClientHello SNI. Method, path, headers, and body are
+	// all empty; transforms that depend on them cannot function.
+	ModeSNIOnly
+)
+
+// String returns the canonical string form of the mode.
+func (m Mode) String() string {
+	switch m {
+	case ModeMITM:
+		return "mitm"
+	case ModeSNIOnly:
+		return "sni-only"
+	default:
+		return "unknown"
+	}
+}
+
 // TransformContext carries metadata about the connection and request.
 type TransformContext struct {
 	SNI        string
 	ClientCert *x509.Certificate
 	Logger     *slog.Logger
+	Mode       Mode
 
 	// annotations is written by transforms via Annotate and read by the pipeline
 	// to build TransformTrace. Not exported — transforms use the Annotate method.
@@ -56,9 +83,10 @@ type PipelineResult struct {
 	Path       string
 	RemoteAddr string
 	SNI        string
+	Mode       Mode
 
-	StartedAt  time.Time
-	Duration   time.Duration
+	StartedAt time.Time
+	Duration  time.Duration
 
 	Action     TransformAction
 	StatusCode int

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -30,6 +30,14 @@ proxy:
 
 # TLS / MITM configuration
 tls:
+  # mode: "mitm" (default) or "sni-only".
+  # In sni-only mode, the proxy peeks at the TLS ClientHello SNI and
+  # TCP-passthroughs to the upstream without terminating TLS. No CA cert is
+  # needed on clients, but the pipeline only sees the hostname (method,
+  # path, headers, and body are empty), so host-only allowlist rules are the
+  # only thing that can match. Body-inspecting transforms like secrets and
+  # grpc still run, but have nothing to act on.
+  mode: "mitm"
   ca_cert: "/etc/iron-proxy/ca.crt"
   ca_key: "/etc/iron-proxy/ca.key"
   cert_cache_size: 1000


### PR DESCRIPTION
Adds a new `tls.mode` config option with `"mitm"` (default) and `"sni-only"` values. In sni-only mode the HTTPS listener peeks the ClientHello SNI and TCP-passthroughs to the upstream without terminating TLS, so clients don't need to trust a CA. The transform pipeline still runs with a host-only synthetic request (method, path, headers, and body are empty), so allowlist rules can match on hostname.

The CONNECT/SOCKS5 tunnel's TLS branch also switches to passthrough in sni-only mode.