### PR TITLE
fix: emit transform annotations as nested otel values

### DIFF
--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/otel/log"
@@ -141,14 +142,45 @@ func transformTracesValue(traces []TransformTrace) log.Value {
 	return log.SliceValue(vals...)
 }
 
-// annotationsValue converts an arbitrary map[string]any into an OTEL log Value.
-// Since annotations can contain nested structures (e.g. swapped secret lists),
-// we JSON-encode the entire map as a string for maximum compatibility with
-// OTEL backends.
+// annotationsValue converts an arbitrary map[string]any into an OTEL log Value,
+// preserving nested structure. Annotation values may be arbitrary Go types
+// (structs, slices, maps), so we round-trip through JSON to normalize everything
+// into primitives, maps, and slices before building the log.Value tree.
 func annotationsValue(annotations map[string]any) log.Value {
 	data, err := json.Marshal(annotations)
 	if err != nil {
 		return log.StringValue("{}")
 	}
-	return log.StringValue(string(data))
+	var normalized any
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return log.StringValue("{}")
+	}
+	return toLogValue(normalized)
+}
+
+func toLogValue(v any) log.Value {
+	switch x := v.(type) {
+	case nil:
+		return log.Value{}
+	case bool:
+		return log.BoolValue(x)
+	case string:
+		return log.StringValue(x)
+	case float64:
+		return log.Float64Value(x)
+	case []any:
+		vals := make([]log.Value, len(x))
+		for i, item := range x {
+			vals[i] = toLogValue(item)
+		}
+		return log.SliceValue(vals...)
+	case map[string]any:
+		kvs := make([]log.KeyValue, 0, len(x))
+		for k, val := range x {
+			kvs = append(kvs, log.KeyValue{Key: k, Value: toLogValue(val)})
+		}
+		return log.MapValue(kvs...)
+	default:
+		return log.StringValue(fmt.Sprintf("%v", x))
+	}
 }

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -103,7 +103,24 @@ func TestOTELAuditFunc_AllowedRequest(t *testing.T) {
 	// Second transform: secrets with annotations
 	t1 := mapFromValue(transformSlice[1])
 	assert.Equal(t, "secrets", t1["name"].AsString())
-	assert.Contains(t, t1["annotations"].AsString(), "OPENAI_API_KEY")
+
+	// annotations should be a nested map, not a JSON string.
+	annotations := t1["annotations"]
+	require.Equal(t, log.KindMap, annotations.Kind())
+	annMap := mapFromValue(annotations)
+
+	swapped := annMap["swapped"]
+	require.Equal(t, log.KindSlice, swapped.Kind())
+	swappedSlice := swapped.AsSlice()
+	require.Len(t, swappedSlice, 1)
+
+	entry := mapFromValue(swappedSlice[0])
+	assert.Equal(t, "OPENAI_API_KEY", entry["secret"].AsString())
+	locations := entry["locations"]
+	require.Equal(t, log.KindSlice, locations.Kind())
+	locSlice := locations.AsSlice()
+	require.Len(t, locSlice, 1)
+	assert.Equal(t, "header:Authorization", locSlice[0].AsString())
 }
 
 func TestOTELAuditFunc_RejectedRequest(t *testing.T) {


### PR DESCRIPTION
Transform annotations were JSON-encoded into a string before being attached to OTEL audit log records, which caused them to render as stringified JSON instead of nested structured data. This converts annotations into a proper `log.MapValue`/`log.SliceValue` tree, matching the slog-based audit logger and the OTEL log data model's native support for nested `AnyValue`.