### PR TITLE
feat: auto-enable OTLP export in managed mode

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -98,9 +98,17 @@ func main() {
 	// and (in managed mode) the config poller.
 	errc := make(chan error, 4)
 	var holder *transform.PipelineHolder
+	var otelCfg iotel.ExportConfig
 
 	if managed {
-		holder = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
+		var ingestToken string
+		holder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
+		if ingestToken != "" {
+			otelCfg.DefaultEndpoint = "https://ingest.iron.sh"
+			otelCfg.DefaultHeaders = map[string]string{
+				"Authorization": "Bearer " + ingestToken,
+			}
+		}
 	} else {
 		holder = initStandalone(cfg, bodyLimits, logger)
 	}
@@ -114,8 +122,8 @@ func main() {
 	// Set up audit function.
 	auditFunc := transform.AuditFunc(transform.NewAuditLogger(logger))
 	var otelShutdown func(context.Context) error
-	if iotel.Enabled() {
-		otelProvider, otelErr := iotel.NewLoggerProvider(ctx)
+	if otelCfg.Enabled() {
+		otelProvider, otelErr := iotel.NewLoggerProvider(ctx, otelCfg)
 		if otelErr != nil {
 			logger.Error("initializing OTEL log provider", slog.String("error", otelErr.Error()))
 			os.Exit(1)
@@ -231,8 +239,9 @@ func main() {
 
 // initManaged registers with the control plane, performs an initial sync, builds
 // the initial pipeline, and starts the config poller. The poller runs until ctx
-// is canceled and sends fatal errors on errc.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) *transform.PipelineHolder {
+// is canceled and sends fatal errors on errc. Returns the pipeline holder and
+// the ingest token from the initial sync (empty if the sync failed).
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	tags := cfg.Tags
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
@@ -280,10 +289,12 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 	}
 
 	configHash := ""
+	ingestToken := ""
 	var initialRules json.RawMessage
 	if syncResp != nil {
 		configHash = syncResp.ConfigHash
 		initialRules = syncResp.Rules
+		ingestToken = syncResp.IngestToken
 		if len(syncResp.Rules) > 0 {
 			logger.Info("received initial config from control plane",
 				slog.String("config_hash", syncResp.ConfigHash),
@@ -325,7 +336,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder
+	return holder, ingestToken
 }
 
 // initStandalone builds the pipeline from the YAML config's transforms.

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -20,9 +20,10 @@ type Credential struct {
 
 // SyncResponse is the parsed response from the sync endpoint.
 type SyncResponse struct {
-	ConfigHash string          `json:"config_hash"`
-	Rules      json.RawMessage `json:"rules"`
-	Secrets    json.RawMessage `json:"secrets"`
+	ConfigHash  string          `json:"config_hash"`
+	Rules       json.RawMessage `json:"rules"`
+	Secrets     json.RawMessage `json:"secrets"`
+	IngestToken string          `json:"ingest_token"`
 }
 
 // Client talks to the iron.sh control plane REST API.

--- a/internal/controlplane/client_test.go
+++ b/internal/controlplane/client_test.go
@@ -146,9 +146,10 @@ func TestSyncSuccess(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(SyncResponse{
-			ConfigHash: "sha256:def",
-			Rules:      json.RawMessage(`[{"name":"allowlist"}]`),
-			Secrets:    json.RawMessage(`{"API_KEY":"secret"}`),
+			ConfigHash:  "sha256:def",
+			Rules:       json.RawMessage(`[{"name":"allowlist"}]`),
+			Secrets:     json.RawMessage(`{"API_KEY":"secret"}`),
+			IngestToken: "ingest_token_abc",
 		})
 	}))
 	defer server.Close()
@@ -164,6 +165,7 @@ func TestSyncSuccess(t *testing.T) {
 	require.Equal(t, "sha256:def", resp.ConfigHash)
 	require.NotNil(t, resp.Rules)
 	require.NotNil(t, resp.Secrets)
+	require.Equal(t, "ingest_token_abc", resp.IngestToken)
 }
 
 func TestSyncUnchanged(t *testing.T) {

--- a/internal/otel/provider.go
+++ b/internal/otel/provider.go
@@ -6,6 +6,9 @@
 //   - OTEL_EXPORTER_OTLP_HEADERS: comma-separated key=value pairs for auth
 //   - OTEL_RESOURCE_ATTRIBUTES: comma-separated key=value resource attributes
 //   - OTEL_SERVICE_NAME: service name (defaults to "iron-proxy")
+//
+// Callers may also provide an [ExportConfig] with defaults (used in managed
+// mode). Environment variables always take precedence over these defaults.
 package otel
 
 import (
@@ -21,11 +24,22 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 )
 
-// NewLoggerProvider creates an OTEL LoggerProvider configured via environment
-// variables. The caller must call Shutdown on the returned provider during
-// graceful shutdown. Both exporters read their config (endpoint, headers, TLS,
-// etc.) from standard OTEL_EXPORTER_OTLP_* env vars automatically.
-func NewLoggerProvider(ctx context.Context) (*sdklog.LoggerProvider, error) {
+// ExportConfig provides default OTLP export settings for fields not set via
+// OTEL_EXPORTER_OTLP_* environment variables.
+type ExportConfig struct {
+	DefaultEndpoint string
+	DefaultHeaders  map[string]string
+}
+
+// Enabled reports whether OTLP export should be initialized.
+func (c ExportConfig) Enabled() bool {
+	return c.DefaultEndpoint != "" || endpointFromEnv()
+}
+
+// NewLoggerProvider creates an OTEL LoggerProvider. Endpoint and headers from
+// cfg are used only when the corresponding OTEL_EXPORTER_OTLP_* env vars are
+// unset, so env vars always win.
+func NewLoggerProvider(ctx context.Context, cfg ExportConfig) (*sdklog.LoggerProvider, error) {
 	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 	if protocol == "" {
 		protocol = "http/protobuf"
@@ -35,9 +49,9 @@ func NewLoggerProvider(ctx context.Context) (*sdklog.LoggerProvider, error) {
 	var err error
 	switch protocol {
 	case "http/protobuf":
-		exporter, err = otlploghttp.New(ctx)
+		exporter, err = otlploghttp.New(ctx, httpOptions(cfg)...)
 	case "grpc":
-		exporter, err = otlploggrpc.New(ctx)
+		exporter, err = otlploggrpc.New(ctx, grpcOptions(cfg)...)
 	default:
 		return nil, fmt.Errorf("unsupported OTEL_EXPORTER_OTLP_PROTOCOL: %q (expected \"http/protobuf\" or \"grpc\")", protocol)
 	}
@@ -69,9 +83,34 @@ func NewLoggerProvider(ctx context.Context) (*sdklog.LoggerProvider, error) {
 	return provider, nil
 }
 
-// Enabled returns true if OTEL_EXPORTER_OTLP_ENDPOINT is set, indicating
-// that the user wants to export telemetry.
-func Enabled() bool {
-	return os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != ""
+func httpOptions(cfg ExportConfig) []otlploghttp.Option {
+	var opts []otlploghttp.Option
+	if cfg.DefaultEndpoint != "" && !endpointFromEnv() {
+		opts = append(opts, otlploghttp.WithEndpointURL(cfg.DefaultEndpoint))
+	}
+	if len(cfg.DefaultHeaders) > 0 && !headersFromEnv() {
+		opts = append(opts, otlploghttp.WithHeaders(cfg.DefaultHeaders))
+	}
+	return opts
 }
 
+func grpcOptions(cfg ExportConfig) []otlploggrpc.Option {
+	var opts []otlploggrpc.Option
+	if cfg.DefaultEndpoint != "" && !endpointFromEnv() {
+		opts = append(opts, otlploggrpc.WithEndpointURL(cfg.DefaultEndpoint))
+	}
+	if len(cfg.DefaultHeaders) > 0 && !headersFromEnv() {
+		opts = append(opts, otlploggrpc.WithHeaders(cfg.DefaultHeaders))
+	}
+	return opts
+}
+
+func endpointFromEnv() bool {
+	return os.Getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != ""
+}
+
+func headersFromEnv() bool {
+	return os.Getenv("OTEL_EXPORTER_OTLP_LOGS_HEADERS") != "" ||
+		os.Getenv("OTEL_EXPORTER_OTLP_HEADERS") != ""
+}

--- a/internal/otel/provider_test.go
+++ b/internal/otel/provider_test.go
@@ -1,0 +1,75 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportConfigEnabled(t *testing.T) {
+	t.Run("disabled when no endpoint", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+		require.False(t, ExportConfig{}.Enabled())
+	})
+
+	t.Run("enabled via default endpoint", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+		cfg := ExportConfig{DefaultEndpoint: "https://ingest.iron.sh"}
+		require.True(t, cfg.Enabled())
+	})
+
+	t.Run("enabled via env endpoint", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com")
+		require.True(t, ExportConfig{}.Enabled())
+	})
+
+	t.Run("enabled via logs-specific env endpoint", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+		t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "https://example.com")
+		require.True(t, ExportConfig{}.Enabled())
+	})
+}
+
+func TestHTTPOptionsUsesDefaultsWhenEnvUnset(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "")
+
+	cfg := ExportConfig{
+		DefaultEndpoint: "https://ingest.iron.sh",
+		DefaultHeaders:  map[string]string{"Authorization": "Bearer t"},
+	}
+	// Both defaults should produce options.
+	require.Len(t, httpOptions(cfg), 2)
+	require.Len(t, grpcOptions(cfg), 2)
+}
+
+func TestHTTPOptionsOmittedWhenEnvSet(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://env-endpoint.example")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "X-Token=from-env")
+
+	cfg := ExportConfig{
+		DefaultEndpoint: "https://ingest.iron.sh",
+		DefaultHeaders:  map[string]string{"Authorization": "Bearer t"},
+	}
+	// Env takes precedence; no options should be generated so the SDK reads env.
+	require.Empty(t, httpOptions(cfg))
+	require.Empty(t, grpcOptions(cfg))
+}
+
+func TestHTTPOptionsMixedPrecedence(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://env-endpoint.example")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "")
+
+	cfg := ExportConfig{
+		DefaultEndpoint: "https://ingest.iron.sh",
+		DefaultHeaders:  map[string]string{"Authorization": "Bearer t"},
+	}
+	// Endpoint comes from env; headers use the default.
+	require.Len(t, httpOptions(cfg), 1)
+	require.Len(t, grpcOptions(cfg), 1)
+}


### PR DESCRIPTION
In managed mode, OTLP export is automatically enabled with endpoint `https://ingest.iron.sh` and `Authorization: Bearer <ingest_token>` using the token returned by the sync endpoint. Standard `OTEL_EXPORTER_OTLP_*` env vars override these defaults via exporter options, without touching the process environment.