### PR TITLE
feat: add version subcommand

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -43,6 +43,9 @@ func main() {
 		case "init":
 			runInit(os.Args[2:])
 			return
+		case "version", "--version", "-v":
+			fmt.Println(version)
+			return
 		}
 	}
 


### PR DESCRIPTION
Adds a `version` subcommand that prints the proxy's version (the `version` var populated via `-ldflags` at build time). Also accepts `--version` and `-v` for convention.