### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in iron-proxy, please
+report it privately. Do **not** open a public GitHub issue, discussion, or pull
+request.
+
+Email **security@iron.sh** with a description of the issue, steps to
+reproduce, and the version or commit SHA you tested against.
+
+You can encrypt your report using the PGP key at
+[`public-key.asc`](public-key.asc) in this repository.
+
+Please give us a reasonable window to ship a fix before any public disclosure.


### PR DESCRIPTION
Adds a SECURITY.md pointing vulnerability reports to security@iron.sh with a PGP key reference for encrypted reports.