### PR TITLE
feat: forward CONNECT headers and rejection responses to transforms

### DIFF
--- a/gen/transform/v1/transform.pb.go
+++ b/gen/transform/v1/transform.pb.go
@@ -76,6 +76,7 @@ type TransformContext struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Sni           string                 `protobuf:"bytes,1,opt,name=sni,proto3" json:"sni,omitempty"`
 	ClientCertDer []byte                 `protobuf:"bytes,2,opt,name=client_cert_der,json=clientCertDer,proto3" json:"client_cert_der,omitempty"`
+	Tunnel        *TunnelInfo            `protobuf:"bytes,3,opt,name=tunnel,proto3" json:"tunnel,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -124,6 +125,65 @@ func (x *TransformContext) GetClientCertDer() []byte {
 	return nil
 }
 
+func (x *TransformContext) GetTunnel() *TunnelInfo {
+	if x != nil {
+		return x.Tunnel
+	}
+	return nil
+}
+
+type TunnelInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Target        string                 `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
+	Annotations   map[string]string      `protobuf:"bytes,2,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TunnelInfo) Reset() {
+	*x = TunnelInfo{}
+	mi := &file_transform_v1_transform_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TunnelInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TunnelInfo) ProtoMessage() {}
+
+func (x *TunnelInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_transform_v1_transform_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TunnelInfo.ProtoReflect.Descriptor instead.
+func (*TunnelInfo) Descriptor() ([]byte, []int) {
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *TunnelInfo) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *TunnelInfo) GetAnnotations() map[string]string {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
 type HttpRequest struct {
 	state         protoimpl.MessageState   `protogen:"open.v1"`
 	Method        string                   `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
@@ -138,7 +198,7 @@ type HttpRequest struct {
 
 func (x *HttpRequest) Reset() {
 	*x = HttpRequest{}
-	mi := &file_transform_v1_transform_proto_msgTypes[1]
+	mi := &file_transform_v1_transform_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -150,7 +210,7 @@ func (x *HttpRequest) String() string {
 func (*HttpRequest) ProtoMessage() {}
 
 func (x *HttpRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[1]
+	mi := &file_transform_v1_transform_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -163,7 +223,7 @@ func (x *HttpRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HttpRequest.ProtoReflect.Descriptor instead.
 func (*HttpRequest) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{1}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *HttpRequest) GetMethod() string {
@@ -217,7 +277,7 @@ type HeaderValues struct {
 
 func (x *HeaderValues) Reset() {
 	*x = HeaderValues{}
-	mi := &file_transform_v1_transform_proto_msgTypes[2]
+	mi := &file_transform_v1_transform_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -229,7 +289,7 @@ func (x *HeaderValues) String() string {
 func (*HeaderValues) ProtoMessage() {}
 
 func (x *HeaderValues) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[2]
+	mi := &file_transform_v1_transform_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -242,7 +302,7 @@ func (x *HeaderValues) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeaderValues.ProtoReflect.Descriptor instead.
 func (*HeaderValues) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{2}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *HeaderValues) GetValues() []string {
@@ -263,7 +323,7 @@ type HttpResponse struct {
 
 func (x *HttpResponse) Reset() {
 	*x = HttpResponse{}
-	mi := &file_transform_v1_transform_proto_msgTypes[3]
+	mi := &file_transform_v1_transform_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -275,7 +335,7 @@ func (x *HttpResponse) String() string {
 func (*HttpResponse) ProtoMessage() {}
 
 func (x *HttpResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[3]
+	mi := &file_transform_v1_transform_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -288,7 +348,7 @@ func (x *HttpResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HttpResponse.ProtoReflect.Descriptor instead.
 func (*HttpResponse) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{3}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *HttpResponse) GetStatusCode() int32 {
@@ -322,7 +382,7 @@ type TransformRequestRequest struct {
 
 func (x *TransformRequestRequest) Reset() {
 	*x = TransformRequestRequest{}
-	mi := &file_transform_v1_transform_proto_msgTypes[4]
+	mi := &file_transform_v1_transform_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -334,7 +394,7 @@ func (x *TransformRequestRequest) String() string {
 func (*TransformRequestRequest) ProtoMessage() {}
 
 func (x *TransformRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[4]
+	mi := &file_transform_v1_transform_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -347,7 +407,7 @@ func (x *TransformRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransformRequestRequest.ProtoReflect.Descriptor instead.
 func (*TransformRequestRequest) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{4}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TransformRequestRequest) GetContext() *TransformContext {
@@ -380,7 +440,7 @@ type TransformRequestResponse struct {
 
 func (x *TransformRequestResponse) Reset() {
 	*x = TransformRequestResponse{}
-	mi := &file_transform_v1_transform_proto_msgTypes[5]
+	mi := &file_transform_v1_transform_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -392,7 +452,7 @@ func (x *TransformRequestResponse) String() string {
 func (*TransformRequestResponse) ProtoMessage() {}
 
 func (x *TransformRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[5]
+	mi := &file_transform_v1_transform_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -405,7 +465,7 @@ func (x *TransformRequestResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransformRequestResponse.ProtoReflect.Descriptor instead.
 func (*TransformRequestResponse) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{5}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *TransformRequestResponse) GetAction() TransformAction {
@@ -447,7 +507,7 @@ type TransformResponseRequest struct {
 
 func (x *TransformResponseRequest) Reset() {
 	*x = TransformResponseRequest{}
-	mi := &file_transform_v1_transform_proto_msgTypes[6]
+	mi := &file_transform_v1_transform_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -459,7 +519,7 @@ func (x *TransformResponseRequest) String() string {
 func (*TransformResponseRequest) ProtoMessage() {}
 
 func (x *TransformResponseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[6]
+	mi := &file_transform_v1_transform_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -472,7 +532,7 @@ func (x *TransformResponseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransformResponseRequest.ProtoReflect.Descriptor instead.
 func (*TransformResponseRequest) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{6}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *TransformResponseRequest) GetContext() *TransformContext {
@@ -509,7 +569,7 @@ type TransformResponseResponse struct {
 
 func (x *TransformResponseResponse) Reset() {
 	*x = TransformResponseResponse{}
-	mi := &file_transform_v1_transform_proto_msgTypes[7]
+	mi := &file_transform_v1_transform_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -521,7 +581,7 @@ func (x *TransformResponseResponse) String() string {
 func (*TransformResponseResponse) ProtoMessage() {}
 
 func (x *TransformResponseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transform_v1_transform_proto_msgTypes[7]
+	mi := &file_transform_v1_transform_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -534,7 +594,7 @@ func (x *TransformResponseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransformResponseResponse.ProtoReflect.Descriptor instead.
 func (*TransformResponseResponse) Descriptor() ([]byte, []int) {
-	return file_transform_v1_transform_proto_rawDescGZIP(), []int{7}
+	return file_transform_v1_transform_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *TransformResponseResponse) GetAction() TransformAction {
@@ -562,10 +622,18 @@ var File_transform_v1_transform_proto protoreflect.FileDescriptor
 
 const file_transform_v1_transform_proto_rawDesc = "" +
 	"\n" +
-	"\x1ctransform/v1/transform.proto\x12\ftransform.v1\"L\n" +
+	"\x1ctransform/v1/transform.proto\x12\ftransform.v1\"~\n" +
 	"\x10TransformContext\x12\x10\n" +
 	"\x03sni\x18\x01 \x01(\tR\x03sni\x12&\n" +
-	"\x0fclient_cert_der\x18\x02 \x01(\fR\rclientCertDer\"\x9a\x02\n" +
+	"\x0fclient_cert_der\x18\x02 \x01(\fR\rclientCertDer\x120\n" +
+	"\x06tunnel\x18\x03 \x01(\v2\x18.transform.v1.TunnelInfoR\x06tunnel\"\xb1\x01\n" +
+	"\n" +
+	"TunnelInfo\x12\x16\n" +
+	"\x06target\x18\x01 \x01(\tR\x06target\x12K\n" +
+	"\vannotations\x18\x02 \x03(\v2).transform.v1.TunnelInfo.AnnotationsEntryR\vannotations\x1a>\n" +
+	"\x10AnnotationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9a\x02\n" +
 	"\vHttpRequest\x12\x16\n" +
 	"\x06method\x18\x01 \x01(\tR\x06method\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x12@\n" +
@@ -630,48 +698,52 @@ func file_transform_v1_transform_proto_rawDescGZIP() []byte {
 }
 
 var file_transform_v1_transform_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_transform_v1_transform_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_transform_v1_transform_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_transform_v1_transform_proto_goTypes = []any{
 	(TransformAction)(0),              // 0: transform.v1.TransformAction
 	(*TransformContext)(nil),          // 1: transform.v1.TransformContext
-	(*HttpRequest)(nil),               // 2: transform.v1.HttpRequest
-	(*HeaderValues)(nil),              // 3: transform.v1.HeaderValues
-	(*HttpResponse)(nil),              // 4: transform.v1.HttpResponse
-	(*TransformRequestRequest)(nil),   // 5: transform.v1.TransformRequestRequest
-	(*TransformRequestResponse)(nil),  // 6: transform.v1.TransformRequestResponse
-	(*TransformResponseRequest)(nil),  // 7: transform.v1.TransformResponseRequest
-	(*TransformResponseResponse)(nil), // 8: transform.v1.TransformResponseResponse
-	nil,                               // 9: transform.v1.HttpRequest.HeadersEntry
-	nil,                               // 10: transform.v1.HttpResponse.HeadersEntry
-	nil,                               // 11: transform.v1.TransformRequestResponse.AnnotationsEntry
-	nil,                               // 12: transform.v1.TransformResponseResponse.AnnotationsEntry
+	(*TunnelInfo)(nil),                // 2: transform.v1.TunnelInfo
+	(*HttpRequest)(nil),               // 3: transform.v1.HttpRequest
+	(*HeaderValues)(nil),              // 4: transform.v1.HeaderValues
+	(*HttpResponse)(nil),              // 5: transform.v1.HttpResponse
+	(*TransformRequestRequest)(nil),   // 6: transform.v1.TransformRequestRequest
+	(*TransformRequestResponse)(nil),  // 7: transform.v1.TransformRequestResponse
+	(*TransformResponseRequest)(nil),  // 8: transform.v1.TransformResponseRequest
+	(*TransformResponseResponse)(nil), // 9: transform.v1.TransformResponseResponse
+	nil,                               // 10: transform.v1.TunnelInfo.AnnotationsEntry
+	nil,                               // 11: transform.v1.HttpRequest.HeadersEntry
+	nil,                               // 12: transform.v1.HttpResponse.HeadersEntry
+	nil,                               // 13: transform.v1.TransformRequestResponse.AnnotationsEntry
+	nil,                               // 14: transform.v1.TransformResponseResponse.AnnotationsEntry
 }
 var file_transform_v1_transform_proto_depIdxs = []int32{
-	9,  // 0: transform.v1.HttpRequest.headers:type_name -> transform.v1.HttpRequest.HeadersEntry
-	10, // 1: transform.v1.HttpResponse.headers:type_name -> transform.v1.HttpResponse.HeadersEntry
-	1,  // 2: transform.v1.TransformRequestRequest.context:type_name -> transform.v1.TransformContext
-	2,  // 3: transform.v1.TransformRequestRequest.request:type_name -> transform.v1.HttpRequest
-	0,  // 4: transform.v1.TransformRequestResponse.action:type_name -> transform.v1.TransformAction
-	4,  // 5: transform.v1.TransformRequestResponse.response:type_name -> transform.v1.HttpResponse
-	2,  // 6: transform.v1.TransformRequestResponse.modified_request:type_name -> transform.v1.HttpRequest
-	11, // 7: transform.v1.TransformRequestResponse.annotations:type_name -> transform.v1.TransformRequestResponse.AnnotationsEntry
-	1,  // 8: transform.v1.TransformResponseRequest.context:type_name -> transform.v1.TransformContext
-	2,  // 9: transform.v1.TransformResponseRequest.request:type_name -> transform.v1.HttpRequest
-	4,  // 10: transform.v1.TransformResponseRequest.response:type_name -> transform.v1.HttpResponse
-	0,  // 11: transform.v1.TransformResponseResponse.action:type_name -> transform.v1.TransformAction
-	4,  // 12: transform.v1.TransformResponseResponse.modified_response:type_name -> transform.v1.HttpResponse
-	12, // 13: transform.v1.TransformResponseResponse.annotations:type_name -> transform.v1.TransformResponseResponse.AnnotationsEntry
-	3,  // 14: transform.v1.HttpRequest.HeadersEntry.value:type_name -> transform.v1.HeaderValues
-	3,  // 15: transform.v1.HttpResponse.HeadersEntry.value:type_name -> transform.v1.HeaderValues
-	5,  // 16: transform.v1.TransformService.TransformRequest:input_type -> transform.v1.TransformRequestRequest
-	7,  // 17: transform.v1.TransformService.TransformResponse:input_type -> transform.v1.TransformResponseRequest
-	6,  // 18: transform.v1.TransformService.TransformRequest:output_type -> transform.v1.TransformRequestResponse
-	8,  // 19: transform.v1.TransformService.TransformResponse:output_type -> transform.v1.TransformResponseResponse
-	18, // [18:20] is the sub-list for method output_type
-	16, // [16:18] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	2,  // 0: transform.v1.TransformContext.tunnel:type_name -> transform.v1.TunnelInfo
+	10, // 1: transform.v1.TunnelInfo.annotations:type_name -> transform.v1.TunnelInfo.AnnotationsEntry
+	11, // 2: transform.v1.HttpRequest.headers:type_name -> transform.v1.HttpRequest.HeadersEntry
+	12, // 3: transform.v1.HttpResponse.headers:type_name -> transform.v1.HttpResponse.HeadersEntry
+	1,  // 4: transform.v1.TransformRequestRequest.context:type_name -> transform.v1.TransformContext
+	3,  // 5: transform.v1.TransformRequestRequest.request:type_name -> transform.v1.HttpRequest
+	0,  // 6: transform.v1.TransformRequestResponse.action:type_name -> transform.v1.TransformAction
+	5,  // 7: transform.v1.TransformRequestResponse.response:type_name -> transform.v1.HttpResponse
+	3,  // 8: transform.v1.TransformRequestResponse.modified_request:type_name -> transform.v1.HttpRequest
+	13, // 9: transform.v1.TransformRequestResponse.annotations:type_name -> transform.v1.TransformRequestResponse.AnnotationsEntry
+	1,  // 10: transform.v1.TransformResponseRequest.context:type_name -> transform.v1.TransformContext
+	3,  // 11: transform.v1.TransformResponseRequest.request:type_name -> transform.v1.HttpRequest
+	5,  // 12: transform.v1.TransformResponseRequest.response:type_name -> transform.v1.HttpResponse
+	0,  // 13: transform.v1.TransformResponseResponse.action:type_name -> transform.v1.TransformAction
+	5,  // 14: transform.v1.TransformResponseResponse.modified_response:type_name -> transform.v1.HttpResponse
+	14, // 15: transform.v1.TransformResponseResponse.annotations:type_name -> transform.v1.TransformResponseResponse.AnnotationsEntry
+	4,  // 16: transform.v1.HttpRequest.HeadersEntry.value:type_name -> transform.v1.HeaderValues
+	4,  // 17: transform.v1.HttpResponse.HeadersEntry.value:type_name -> transform.v1.HeaderValues
+	6,  // 18: transform.v1.TransformService.TransformRequest:input_type -> transform.v1.TransformRequestRequest
+	8,  // 19: transform.v1.TransformService.TransformResponse:input_type -> transform.v1.TransformResponseRequest
+	7,  // 20: transform.v1.TransformService.TransformRequest:output_type -> transform.v1.TransformRequestResponse
+	9,  // 21: transform.v1.TransformService.TransformResponse:output_type -> transform.v1.TransformResponseResponse
+	20, // [20:22] is the sub-list for method output_type
+	18, // [18:20] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_transform_v1_transform_proto_init() }
@@ -685,7 +757,7 @@ func file_transform_v1_transform_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transform_v1_transform_proto_rawDesc), len(file_transform_v1_transform_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -274,6 +274,9 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.TLS != nil {
 		tctx.SNI = r.TLS.ServerName
 	}
+	if tunnelInfo, ok := r.Context().Value(tunnelInfoKey).(*transform.TunnelInfo); ok {
+		tctx.Tunnel = tunnelInfo
+	}
 
 	result := &transform.PipelineResult{
 		Host:       r.Host,
@@ -282,6 +285,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		RemoteAddr: r.RemoteAddr,
 		SNI:        tctx.SNI,
 		Mode:       transform.ModeMITM,
+		Tunnel:     tctx.Tunnel,
 	}
 	pl, finish := p.beginPipelineRun(result)
 	defer finish()

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -18,6 +18,12 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
+// tunnelInfoKey is the context key for tunnel metadata propagated to inner
+// HTTP requests within the same tunnel.
+type tunnelInfoKeyType struct{}
+
+var tunnelInfoKey = tunnelInfoKeyType{}
+
 // listenTunnel starts the CONNECT/SOCKS5 tunnel listener.
 func (p *Proxy) listenTunnel() error {
 	ln, err := net.Listen("tcp", p.tunnelAddr)
@@ -90,9 +96,20 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) error {
 
 	p.logger.Debug("tunnel CONNECT", slog.String("target", host))
 
-	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), host) {
-		if _, err := fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\n"); err != nil {
-			return fmt.Errorf("write 403: %w", err)
+	ok, rejectResp, tunnelInfo := p.tunnelTransformCheck(conn.RemoteAddr().String(), host, req.Header)
+	if !ok {
+		if rejectResp == nil {
+			rejectResp = &http.Response{
+				StatusCode: http.StatusForbidden,
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				Header:     http.Header{},
+				Body:       http.NoBody,
+			}
+		}
+		if err := rejectResp.Write(conn); err != nil {
+			return fmt.Errorf("write rejection: %w", err)
 		}
 		return nil
 	}
@@ -102,7 +119,7 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) error {
 		return fmt.Errorf("write 200: %w", err)
 	}
 
-	return p.serveTunnel(conn, host)
+	return p.serveTunnel(conn, host, tunnelInfo)
 }
 
 // handleSOCKS5 handles SOCKS5 tunnel requests.
@@ -202,7 +219,8 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) error {
 
 	p.logger.Debug("tunnel SOCKS5 CONNECT", slog.String("target", target))
 
-	if !p.tunnelTransformCheck(conn.RemoteAddr().String(), target) {
+	ok, _, tunnelInfo := p.tunnelTransformCheck(conn.RemoteAddr().String(), target, nil)
+	if !ok {
 		if err := p.socks5Reply(conn, 0x02); err != nil {
 			return fmt.Errorf("write connection-not-allowed: %w", err)
 		}
@@ -215,7 +233,7 @@ func (p *Proxy) handleSOCKS5(conn net.Conn, br *bufio.Reader) error {
 		return fmt.Errorf("write success reply: %w", err)
 	}
 
-	return p.serveTunnel(conn, target)
+	return p.serveTunnel(conn, target, tunnelInfo)
 }
 
 // socks5Reply sends a SOCKS5 reply with the given status code.
@@ -226,15 +244,23 @@ func (p *Proxy) socks5Reply(conn net.Conn, status byte) error {
 }
 
 // tunnelTransformCheck runs a synthetic CONNECT request through the transform
-// pipeline to decide whether the tunnel should be allowed.
-func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
+// pipeline to decide whether the tunnel should be allowed. When connectHeaders
+// is non-nil the headers from the original CONNECT request (e.g.
+// Proxy-Authorization) are forwarded to transforms so they can make
+// authentication and policy decisions at the tunnel level.
+func (p *Proxy) tunnelTransformCheck(remoteAddr, target string, connectHeaders http.Header) (bool, *http.Response, *transform.TunnelInfo) {
 	host, _, _ := net.SplitHostPort(target)
+
+	hdr := http.Header{}
+	if connectHeaders != nil {
+		hdr = connectHeaders.Clone()
+	}
 
 	req := &http.Request{
 		Method:     http.MethodConnect,
 		Host:       target,
 		URL:        &url.URL{Host: target},
-		Header:     http.Header{},
+		Header:     hdr,
 		RemoteAddr: remoteAddr,
 		Proto:      "HTTP/1.1",
 		ProtoMajor: 1,
@@ -273,7 +299,7 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 			slog.String("target", target),
 			slog.String("error", err.Error()),
 		)
-		return false
+		return false, nil, nil
 	}
 	if rejectResp != nil {
 		result.Action = transform.ActionReject
@@ -282,18 +308,29 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string) bool {
 			slog.String("target", target),
 			slog.Int("status", rejectResp.StatusCode),
 		)
-		return false
+		return false, rejectResp, nil
+	}
+
+	// Collect annotations from all CONNECT transforms.
+	annotations := make(map[string]any)
+	for _, tr := range result.RequestTransforms {
+		for k, v := range tr.Annotations {
+			annotations[k] = v
+		}
 	}
 
 	result.Action = transform.ActionContinue
 	result.StatusCode = http.StatusOK
-	return true
+	return true, nil, &transform.TunnelInfo{
+		Target:      target,
+		Annotations: annotations,
+	}
 }
 
 // serveTunnel peeks at the client's first byte after the CONNECT/SOCKS5
 // handshake to detect TLS (0x16) vs plain HTTP. TLS connections get MITM'd;
 // plain HTTP is served directly through handleHTTP. Anything else is rejected.
-func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
+func (p *Proxy) serveTunnel(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	br := bufio.NewReader(clientConn)
 	first, err := br.Peek(1)
 	if err != nil {
@@ -305,12 +342,12 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 
 	if first[0] == 0x16 {
 		// TLS ClientHello: MITM
-		return p.serveTunnelTLS(peekedConn, target)
+		return p.serveTunnelTLS(peekedConn, target, tunnelInfo)
 	}
 
 	if isHTTPMethodByte(first[0]) {
 		// Plain HTTP request
-		return p.serveTunnelHTTP(peekedConn, target)
+		return p.serveTunnelHTTP(peekedConn, target, tunnelInfo)
 	}
 
 	return fmt.Errorf("unsupported protocol (first byte 0x%02x) for target %s", first[0], target)
@@ -320,7 +357,7 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string) error {
 // it terminates TLS and serves HTTP via handleHTTP; in sni-only mode it
 // peeks SNI and TCP-passthroughs to the SNI host on port 443 (the CONNECT
 // port is ignored to prevent port-pivot attacks).
-func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
+func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	if p.tlsMode == config.TLSModeSNIOnly {
 		return p.serveSNIPassthrough(clientConn)
 	}
@@ -336,20 +373,45 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string) error {
 
 	ln := newOneConnListener(tlsConn)
 	srv := &http.Server{
-		Handler: http.HandlerFunc(p.handleHTTP),
+		Handler: p.withTunnelInfo(tunnelInfo),
 	}
 	return srv.Serve(ln)
 }
 
 // serveTunnelHTTP serves plain HTTP requests through the normal handleHTTP handler.
-func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string) error {
+func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	defer clientConn.Close()
 
 	ln := newOneConnListener(clientConn)
 	srv := &http.Server{
-		Handler: http.HandlerFunc(p.handleHTTP),
+		Handler: p.withTunnelInfo(tunnelInfo),
 	}
 	return srv.Serve(ln)
+}
+
+// withTunnelInfo wraps handleHTTP to inject CONNECT metadata into the request
+// context so inner requests can read tunnel identity and policy annotations.
+func (p *Proxy) withTunnelInfo(tunnelInfo *transform.TunnelInfo) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if tunnelInfo != nil {
+			r = r.WithContext(context.WithValue(r.Context(), tunnelInfoKey, cloneTunnelInfo(tunnelInfo)))
+		}
+		p.handleHTTP(w, r)
+	})
+}
+
+func cloneTunnelInfo(info *transform.TunnelInfo) *transform.TunnelInfo {
+	if info == nil {
+		return nil
+	}
+	clone := &transform.TunnelInfo{
+		Target:      info.Target,
+		Annotations: make(map[string]any, len(info.Annotations)),
+	}
+	for k, v := range info.Annotations {
+		clone.Annotations[k] = v
+	}
+	return clone
 }
 
 // isHTTPMethodByte returns true if b could be the first byte of an HTTP method.

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -350,6 +350,82 @@ func TestTunnel_TransformReject(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
+func TestTunnel_CONNECTHeadersAndRejectResponse(t *testing.T) {
+	auth := &connectHeaderAuthTransform{}
+
+	_, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{auth})
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusProxyAuthRequired, resp.StatusCode)
+	require.Equal(t, `Basic realm="proxy"`, resp.Header.Get("Proxy-Authenticate"))
+	require.Equal(t, "example.com:443", auth.lastTarget)
+
+	conn2, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	_, err = fmt.Fprintf(conn2, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Basic ok\r\n\r\n")
+	require.NoError(t, err)
+
+	resp2, err := http.ReadResponse(bufio.NewReader(conn2), nil)
+	require.NoError(t, err)
+	_ = resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+func TestTunnelInfoPropagatesToInnerTransforms(t *testing.T) {
+	seen := make(chan *transform.TunnelInfo, 1)
+	tunnelInfoTransform := &tunnelInfoTransform{seen: seen}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	_, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{tunnelInfoTransform})
+	target := upstream.Listener.Addr().String()
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	require.NoError(t, err)
+
+	resp2, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	select {
+	case info := <-seen:
+		require.Equal(t, target, info.Target)
+		require.Equal(t, "alice", info.Annotations["user_id"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("inner transform did not receive tunnel info")
+	}
+}
+
 func TestTunnel_SOCKS5_TransformReject(t *testing.T) {
 	rejecter := &rejectTransform{}
 
@@ -387,5 +463,60 @@ func (r *rejectTransform) TransformRequest(_ context.Context, _ *transform.Trans
 }
 
 func (r *rejectTransform) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+type connectHeaderAuthTransform struct {
+	lastTarget string
+}
+
+func (c *connectHeaderAuthTransform) Name() string { return "connect-auth" }
+
+func (c *connectHeaderAuthTransform) TransformRequest(_ context.Context, _ *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if req.Method != http.MethodConnect {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+	c.lastTarget = req.Host
+	if req.Header.Get("Proxy-Authorization") == "Basic ok" {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+	return &transform.TransformResult{
+		Action: transform.ActionReject,
+		Response: &http.Response{
+			StatusCode: http.StatusProxyAuthRequired,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     http.Header{"Proxy-Authenticate": []string{`Basic realm="proxy"`}},
+			Body:       http.NoBody,
+		},
+	}, nil
+}
+
+func (c *connectHeaderAuthTransform) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+type tunnelInfoTransform struct {
+	seen chan<- *transform.TunnelInfo
+}
+
+func (t *tunnelInfoTransform) Name() string { return "tunnel-info" }
+
+func (t *tunnelInfoTransform) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if req.Method == http.MethodConnect {
+		tctx.Annotate("user_id", "alice")
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+	if tctx.Tunnel != nil {
+		select {
+		case t.seen <- tctx.Tunnel:
+		default:
+		}
+	}
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (t *tunnelInfoTransform) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -36,6 +36,12 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 				slog.Float64("duration_ms", float64(result.Duration.Microseconds())/1000.0),
 			),
 		}
+		if result.Tunnel != nil {
+			attrs = append(attrs, slog.Group("tunnel",
+				slog.String("target", result.Tunnel.Target),
+				slog.Any("annotations", result.Tunnel.Annotations),
+			))
+		}
 
 		// Add rejected_by for reject actions
 		if result.Action == ActionReject {

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -85,6 +85,31 @@ func TestAudit_RejectedRequest(t *testing.T) {
 	require.Equal(t, float64(403), audit["status_code"])
 }
 
+func TestAudit_TunnelInfo(t *testing.T) {
+	result := &PipelineResult{
+		Host:       "example.com",
+		Method:     "GET",
+		Path:       "/",
+		RemoteAddr: "10.16.0.5:43213",
+		SNI:        "example.com",
+		StartedAt:  time.Now(),
+		Duration:   time.Millisecond,
+		Action:     ActionContinue,
+		StatusCode: 200,
+		Tunnel: &TunnelInfo{
+			Target:      "example.com:443",
+			Annotations: map[string]any{"user_id": "alice"},
+		},
+	}
+
+	parsed, _ := captureAuditLog(result)
+
+	tunnel := parsed["tunnel"].(map[string]any)
+	require.Equal(t, "example.com:443", tunnel["target"])
+	annotations := tunnel["annotations"].(map[string]any)
+	require.Equal(t, "alice", annotations["user_id"])
+}
+
 func TestAudit_ErroredRequest(t *testing.T) {
 	result := &PipelineResult{
 		Host:       "api.openai.com",

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -221,7 +221,26 @@ func transformContextToProto(tctx *transform.TransformContext) *transformv1.Tran
 	if tctx.ClientCert != nil {
 		pb.ClientCertDer = tctx.ClientCert.Raw
 	}
+	if tctx.Tunnel != nil {
+		pb.Tunnel = &transformv1.TunnelInfo{
+			Target:      tctx.Tunnel.Target,
+			Annotations: stringAnnotations(tctx.Tunnel.Annotations),
+		}
+	}
 	return pb
+}
+
+func stringAnnotations(annotations map[string]any) map[string]string {
+	if len(annotations) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
 }
 
 func httpRequestToProto(req *http.Request, sendBody bool) (*transformv1.HttpRequest, error) {

--- a/internal/transform/grpc/grpc_test.go
+++ b/internal/transform/grpc/grpc_test.go
@@ -111,6 +111,31 @@ func TestTransformRequest_Continue(t *testing.T) {
 	require.Equal(t, "hello", srv.lastReqProto.GetRequest().GetHeaders()["X-Test"].GetValues()[0])
 }
 
+func TestTransformRequest_TunnelInfoInContext(t *testing.T) {
+	srv := &fakeServer{reqAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE}
+	addr := startFakeServer(t, srv)
+
+	gt := newTestTransform(t, "test", addr, false, false)
+	req, _ := http.NewRequest("GET", "https://example.com/foo", nil)
+	tctx := &transform.TransformContext{
+		Tunnel: &transform.TunnelInfo{
+			Target: "example.com:443",
+			Annotations: map[string]any{
+				"user_id": "alice",
+				"count":   3,
+			},
+		},
+	}
+
+	result, err := gt.TransformRequest(context.Background(), tctx, req)
+
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, result.Action)
+	require.Equal(t, "example.com:443", srv.lastReqProto.GetContext().GetTunnel().GetTarget())
+	require.Equal(t, "alice", srv.lastReqProto.GetContext().GetTunnel().GetAnnotations()["user_id"])
+	require.NotContains(t, srv.lastReqProto.GetContext().GetTunnel().GetAnnotations(), "count")
+}
+
 func TestTransformRequest_Reject(t *testing.T) {
 	srv := &fakeServer{
 		reqAction: transformv1.TransformAction_TRANSFORM_ACTION_REJECT,

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -54,10 +54,21 @@ type TransformContext struct {
 	ClientCert *x509.Certificate
 	Logger     *slog.Logger
 	Mode       Mode
+	Tunnel     *TunnelInfo
 
 	// annotations is written by transforms via Annotate and read by the pipeline
 	// to build TransformTrace. Not exported — transforms use the Annotate method.
 	annotations map[string]any
+}
+
+// TunnelInfo carries metadata from the CONNECT/SOCKS5 tunnel that established
+// an inner request.
+type TunnelInfo struct {
+	// Target is the host:port from the CONNECT request or SOCKS5 target.
+	Target string
+
+	// Annotations are merged from CONNECT-time request transforms.
+	Annotations map[string]any
 }
 
 // Annotate attaches audit metadata to the current transform's trace.
@@ -90,6 +101,8 @@ type PipelineResult struct {
 
 	Action     TransformAction
 	StatusCode int
+
+	Tunnel *TunnelInfo
 
 	RequestTransforms  []TransformTrace
 	ResponseTransforms []TransformTrace

--- a/proto/transform/v1/transform.proto
+++ b/proto/transform/v1/transform.proto
@@ -22,6 +22,12 @@ enum TransformAction {
 message TransformContext {
   string sni = 1;
   bytes client_cert_der = 2;
+  TunnelInfo tunnel = 3;
+}
+
+message TunnelInfo {
+  string target = 1;
+  map<string, string> annotations = 2;
 }
 
 // --- Request transform ---


### PR DESCRIPTION
## Problem

The tunnel handler strips information in both directions:

1. **Client → Transform:** CONNECT request headers (e.g., `Proxy-Authorization`) are discarded. `tunnelTransformCheck` creates a synthetic request with `Header: http.Header{}`. Transforms cannot authenticate tunnel connections.

2. **Transform → Client:** Rejection responses (status code + headers) are discarded. The handler hardcodes `403 Forbidden` regardless of what the transform returned. Clients cannot receive auth challenges (e.g., `407 + Proxy-Authenticate: Basic`).

## Changes

### Commit 1: Forward CONNECT headers to transforms

`tunnelTransformCheck` now accepts `connectHeaders http.Header`. The CONNECT handler passes `req.Header`; SOCKS5 passes `nil`. Transforms see the original CONNECT headers.

### Commit 2: Forward rejection responses to clients

`tunnelTransformCheck` now returns `(bool, *http.Response)`. When a transform rejects, the handler sends the transform's status code and headers instead of hardcoded 403. Falls back to 403 if no response is provided.

## Use case

A gRPC transform that verifies JWTs for proxy authentication:

1. Client sends `CONNECT host:443` with `Proxy-Authorization: Basic base64(user:jwt)` (commit 1 makes this visible to the transform)
2. Transform verifies JWT → allow with annotation, or reject with `407 + Proxy-Authenticate: Basic` (commit 2 makes this visible to the client)
3. Clients like Chromium retry with credentials after receiving the 407 challenge

## Testing

All existing tests pass (`go test ./internal/proxy/`). Backward compatible — callers that don't use CONNECT headers or custom rejection responses are unaffected. SOCKS5 passes `nil` headers and discards the response (same behavior as before).

Replaces #71 and #72. Removed accidentally committed binaries and JWT transform from #71.