### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,32 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
       - name: Run tests
         run: go test -v -race -count=1 ./...
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()
 
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
@@ -54,59 +54,59 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()
 
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
       - name: go vet
         run: go vet ./...
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
           install-mode: binary
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()
 
   tidy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
 
-      - uses: actions/setup-go@v6.4.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
 
@@ -115,5 +115,5 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ironsh/iron-proxy-action@v0.1.3
+      - uses: ironsh/iron-proxy-action@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         with:
           egress-rules: egress-rules.yaml
           disable-docker: false
@@ -51,5 +51,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ironsh/iron-proxy-action/summary@v0.1.3
+      - uses: ironsh/iron-proxy-action/summary@67ae2cdb5cc549c5cb94e76235953f4a9fcb183c # v0.1.3
         if: always()


### PR DESCRIPTION
Pins all third-party GitHub Actions in `ci.yml` and `release.yml` to full commit SHAs (with the version as a trailing comment) instead of mutable tags. This protects against tag-retargeting attacks on upstream actions.