### PR TITLE
feat: allow "*" as a wildcard host in allowlist matcher

### DIFF
--- a/internal/dns/server_test.go
+++ b/internal/dns/server_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ironsh/iron-proxy/internal/config"
-	"github.com/ironsh/iron-proxy/internal/hostmatch"
 )
 
 // mockResolver implements Resolver for testing.
@@ -251,23 +250,3 @@ func TestStaticRecord_WrongQtypeReturnsEmpty(t *testing.T) {
 	require.Empty(t, resp.Answer)
 }
 
-func TestMatchGlob(t *testing.T) {
-	tests := []struct {
-		pattern string
-		name    string
-		want    bool
-	}{
-		{"*.example.com", "foo.example.com", true},
-		{"*.example.com", "bar.baz.example.com", true},
-		{"*.example.com", "example.com", true},
-		{"*.example.com", "notexample.com", false},
-		{"exact.example.com", "exact.example.com", true},
-		{"exact.example.com", "other.example.com", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s/%s", tt.pattern, tt.name), func(t *testing.T) {
-			require.Equal(t, tt.want, hostmatch.MatchGlob(tt.pattern, tt.name))
-		})
-	}
-}

--- a/internal/hostmatch/hostmatch.go
+++ b/internal/hostmatch/hostmatch.go
@@ -70,8 +70,12 @@ func (m *Matcher) Matches(ctx context.Context, host string) bool {
 }
 
 // MatchGlob matches a domain against a glob pattern.
-// "*.example.com" matches any subdomain depth and "example.com" itself.
+// "*" matches any host. "*.example.com" matches any subdomain depth and
+// "example.com" itself.
 func MatchGlob(pattern, name string) bool {
+	if pattern == "*" {
+		return true
+	}
 	if strings.HasPrefix(pattern, "*.") {
 		suffix := pattern[1:] // ".example.com"
 		return strings.HasSuffix(name, suffix) || name == pattern[2:]

--- a/internal/hostmatch/hostmatch_test.go
+++ b/internal/hostmatch/hostmatch_test.go
@@ -1,0 +1,32 @@
+package hostmatch
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		{"*.example.com", "foo.example.com", true},
+		{"*.example.com", "bar.baz.example.com", true},
+		{"*.example.com", "example.com", true},
+		{"*.example.com", "notexample.com", false},
+		{"exact.example.com", "exact.example.com", true},
+		{"exact.example.com", "other.example.com", false},
+		{"*", "anything.example.com", true},
+		{"*", "1.2.3.4", true},
+		{"*", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%s", tt.pattern, tt.name), func(t *testing.T) {
+			require.Equal(t, tt.want, MatchGlob(tt.pattern, tt.name))
+		})
+	}
+}


### PR DESCRIPTION
Adds a short-circuit in `hostmatch.MatchGlob` so a `"*"` pattern matches any host, letting operators write a single catch-all entry in the allowlist. Also moves `TestMatchGlob` out of the dns package into `hostmatch`, where the function lives.