### PR TITLE
feat: wire secrets into managed-mode sync pipeline

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -294,12 +294,13 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	configHash := ""
 	ingestToken := ""
-	var initialRules json.RawMessage
+	var initialRules, initialSecrets json.RawMessage
 	if syncResp != nil {
 		configHash = syncResp.ConfigHash
 		initialRules = syncResp.Rules
+		initialSecrets = syncResp.Secrets
 		ingestToken = syncResp.IngestToken
-		if len(syncResp.Rules) > 0 {
+		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 {
 			logger.Info("received initial config from control plane",
 				slog.String("config_hash", syncResp.ConfigHash),
 			)
@@ -307,7 +308,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 	}
 
 	// Build initial pipeline from sync response.
-	initialTransforms, err := config.TransformsFromSync(initialRules)
+	initialTransforms, err := config.TransformsFromSync(initialRules, initialSecrets)
 	if err != nil {
 		logger.Error("parsing initial config", slog.String("error", err.Error()))
 		os.Exit(1)
@@ -322,7 +323,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	// Start config poller.
 	poller := controlplane.NewPoller(client, configHash, func(rules json.RawMessage, secrets json.RawMessage) error {
-		newTransforms, err := config.TransformsFromSync(rules)
+		newTransforms, err := config.TransformsFromSync(rules, secrets)
 		if err != nil {
 			return fmt.Errorf("parsing config update: %w", err)
 		}

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -7,21 +7,33 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TransformsFromSync builds a []Transform from the control plane's rules JSON
-// payload. The rules payload is a JSON array of rule objects that gets wrapped
-// into {"rules": [...]} to match the allowlist transform's expected config
-// shape. If rules is nil or JSON null, an empty slice is returned.
-func TransformsFromSync(rules json.RawMessage) ([]Transform, error) {
+// TransformsFromSync builds a []Transform from the control plane's sync
+// payload. Each payload field is a JSON array that gets wrapped to match the
+// corresponding transform's config shape: rules → {"rules": [...]} for the
+// allowlist transform, secrets → {"secrets": [...]} for the secrets transform.
+// Pipeline order is allowlist first, then secrets. Fields that are nil or JSON
+// null are skipped.
+func TransformsFromSync(rules, secrets json.RawMessage) ([]Transform, error) {
 	var transforms []Transform
 
 	if isNonNullJSON(rules) {
-		wrapped := map[string]json.RawMessage{"rules": rules}
-		node, err := yamlNodeFromJSON(wrapped)
+		node, err := yamlNodeFromJSON(map[string]json.RawMessage{"rules": rules})
 		if err != nil {
 			return nil, fmt.Errorf("parsing rules: %w", err)
 		}
 		transforms = append(transforms, Transform{
 			Name:   "allowlist",
+			Config: node,
+		})
+	}
+
+	if isNonNullJSON(secrets) {
+		node, err := yamlNodeFromJSON(map[string]json.RawMessage{"secrets": secrets})
+		if err != nil {
+			return nil, fmt.Errorf("parsing secrets: %w", err)
+		}
+		transforms = append(transforms, Transform{
+			Name:   "secrets",
 			Config: node,
 		})
 	}

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -10,33 +10,38 @@ import (
 func TestTransformsFromSync_RulesPresent(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)
 
-	transforms, err := TransformsFromSync(rules)
+	transforms, err := TransformsFromSync(rules, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 	require.Equal(t, "allowlist", transforms[0].Name)
 }
 
 func TestTransformsFromSync_Nil(t *testing.T) {
-	transforms, err := TransformsFromSync(nil)
+	transforms, err := TransformsFromSync(nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, transforms)
 }
 
 func TestTransformsFromSync_NullJSON(t *testing.T) {
-	transforms, err := TransformsFromSync(json.RawMessage("null"))
+	transforms, err := TransformsFromSync(json.RawMessage("null"), json.RawMessage("null"))
 	require.NoError(t, err)
 	require.Empty(t, transforms)
 }
 
-func TestTransformsFromSync_InvalidJSON(t *testing.T) {
-	_, err := TransformsFromSync(json.RawMessage(`{bad json`))
+func TestTransformsFromSync_InvalidRules(t *testing.T) {
+	_, err := TransformsFromSync(json.RawMessage(`{bad json`), nil)
 	require.ErrorContains(t, err, "parsing rules")
+}
+
+func TestTransformsFromSync_InvalidSecrets(t *testing.T) {
+	_, err := TransformsFromSync(nil, json.RawMessage(`{bad json`))
+	require.ErrorContains(t, err, "parsing secrets")
 }
 
 func TestTransformsFromSync_RoundTrip(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"*.example.com","methods":["GET","POST"],"paths":["/api/*"]},{"host":"api.test.io","methods":["*"],"paths":["*"]}]`)
 
-	transforms, err := TransformsFromSync(rules)
+	transforms, err := TransformsFromSync(rules, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 
@@ -58,7 +63,7 @@ func TestTransformsFromSync_RoundTrip(t *testing.T) {
 func TestTransformsFromSync_EmptyRules(t *testing.T) {
 	rules := json.RawMessage(`[]`)
 
-	transforms, err := TransformsFromSync(rules)
+	transforms, err := TransformsFromSync(rules, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 
@@ -69,4 +74,54 @@ func TestTransformsFromSync_EmptyRules(t *testing.T) {
 	}
 	require.NoError(t, transforms[0].Config.Decode(&decoded))
 	require.Empty(t, decoded.Rules)
+}
+
+func TestTransformsFromSync_SecretsPresent(t *testing.T) {
+	secrets := json.RawMessage(`[{"source":{"type":"env","var":"OPENAI_API_KEY"},"inject":{"header":"Authorization","formatter":"Bearer {{ .Value }}"},"rules":[{"host":"api.openai.com"}]}]`)
+
+	transforms, err := TransformsFromSync(nil, secrets)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "secrets", transforms[0].Name)
+
+	var decoded struct {
+		Secrets []struct {
+			Source struct {
+				Type string `yaml:"type"`
+				Var  string `yaml:"var"`
+			} `yaml:"source"`
+			Inject struct {
+				Header    string `yaml:"header"`
+				Formatter string `yaml:"formatter"`
+			} `yaml:"inject"`
+			Rules []struct {
+				Host string `yaml:"host"`
+			} `yaml:"rules"`
+		} `yaml:"secrets"`
+	}
+	require.NoError(t, transforms[0].Config.Decode(&decoded))
+	require.Len(t, decoded.Secrets, 1)
+	require.Equal(t, "env", decoded.Secrets[0].Source.Type)
+	require.Equal(t, "OPENAI_API_KEY", decoded.Secrets[0].Source.Var)
+	require.Equal(t, "Authorization", decoded.Secrets[0].Inject.Header)
+	require.Equal(t, "Bearer {{ .Value }}", decoded.Secrets[0].Inject.Formatter)
+	require.Equal(t, "api.openai.com", decoded.Secrets[0].Rules[0].Host)
+}
+
+func TestTransformsFromSync_RulesAndSecretsOrder(t *testing.T) {
+	rules := json.RawMessage(`[{"host":"example.com"}]`)
+	secrets := json.RawMessage(`[{"source":{"type":"env","var":"X"},"inject":{"header":"Authorization"},"rules":[{"host":"example.com"}]}]`)
+
+	transforms, err := TransformsFromSync(rules, secrets)
+	require.NoError(t, err)
+	require.Len(t, transforms, 2)
+	require.Equal(t, "allowlist", transforms[0].Name)
+	require.Equal(t, "secrets", transforms[1].Name)
+}
+
+func TestTransformsFromSync_EmptySecrets(t *testing.T) {
+	transforms, err := TransformsFromSync(nil, json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "secrets", transforms[0].Name)
 }


### PR DESCRIPTION
The sync endpoint now exposes secrets in addition to rules, with a shape that matches the secrets transform's config YAML. This change extends `TransformsFromSync` to accept the secrets payload and appends a `secrets` transform after the `allowlist` transform in the managed-mode pipeline. Both the initial sync and the poller callback now pass the secrets payload through.