### PR TITLE
fix: validate pipeline before swap on managed sync

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -323,17 +323,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	// Start config poller.
 	poller := controlplane.NewPoller(client, configHash, func(rules json.RawMessage, secrets json.RawMessage) error {
-		newTransforms, err := config.TransformsFromSync(rules, secrets)
-		if err != nil {
-			return fmt.Errorf("parsing config update: %w", err)
-		}
-		newPipeline, err := buildPipeline(newTransforms, bodyLimits, logger)
-		if err != nil {
-			return fmt.Errorf("building updated pipeline: %w", err)
-		}
-		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
-		holder.Store(newPipeline)
-		logger.Info("pipeline reloaded", slog.String("transforms", newPipeline.Names()))
+		applyPipelineSync(holder, bodyLimits, logger, rules, secrets)
 		return nil
 	}, logger)
 
@@ -373,6 +363,26 @@ func ensureStateStoreDir(stateStore string) error {
 		return fmt.Errorf("creating state store directory: %w", err)
 	}
 	return nil
+}
+
+// applyPipelineSync builds a new pipeline from a sync payload and atomically
+// swaps it in. If parsing or pipeline construction fails, the existing pipeline
+// is preserved and an error is logged: an invalid push from the control plane
+// must not take down the proxy.
+func applyPipelineSync(holder *transform.PipelineHolder, bodyLimits transform.BodyLimits, logger *slog.Logger, rules, secrets json.RawMessage) {
+	newTransforms, err := config.TransformsFromSync(rules, secrets)
+	if err != nil {
+		logger.Error("rejecting invalid pipeline config from sync, keeping current pipeline", slog.String("error", err.Error()))
+		return
+	}
+	newPipeline, err := buildPipeline(newTransforms, bodyLimits, logger)
+	if err != nil {
+		logger.Error("rejecting invalid pipeline config from sync, keeping current pipeline", slog.String("error", err.Error()))
+		return
+	}
+	newPipeline.SetAuditFunc(holder.Load().AuditFunc())
+	holder.Store(newPipeline)
+	logger.Info("pipeline reloaded", slog.String("transforms", newPipeline.Names()))
 }
 
 // buildPipeline creates a transform.Pipeline from config transforms.

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+
+	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
+	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+func TestApplyPipelineSync_ValidConfig_Swaps(t *testing.T) {
+	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	holder := transform.NewPipelineHolder(original)
+
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+
+	require.NotSame(t, original, holder.Load(), "pipeline should have been swapped")
+	require.Equal(t, "allowlist", holder.Load().Names())
+	require.Contains(t, logBuf.String(), "pipeline reloaded")
+}
+
+func TestApplyPipelineSync_InvalidJSON_KeepsExistingPipeline(t *testing.T) {
+	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	holder := transform.NewPipelineHolder(original)
+
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, json.RawMessage(`{not json`), nil)
+
+	require.Same(t, original, holder.Load(), "pipeline must not be swapped on invalid config")
+	require.Contains(t, logBuf.String(), "rejecting invalid pipeline config")
+	require.Contains(t, logBuf.String(), "level=ERROR")
+}
+
+func TestApplyPipelineSync_InvalidRule_KeepsExistingPipeline(t *testing.T) {
+	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	holder := transform.NewPipelineHolder(original)
+
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	// host and cidr are mutually exclusive — rule construction fails.
+	rules := json.RawMessage(`[{"host":"example.com","cidr":"10.0.0.0/8"}]`)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+
+	require.Same(t, original, holder.Load(), "pipeline must not be swapped when transform construction fails")
+	require.Contains(t, logBuf.String(), "rejecting invalid pipeline config")
+	require.Contains(t, logBuf.String(), "level=ERROR")
+}
+
+func TestApplyPipelineSync_PreservesAuditFunc(t *testing.T) {
+	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	called := false
+	original.SetAuditFunc(func(*transform.PipelineResult) { called = true })
+	holder := transform.NewPipelineHolder(original)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	rules := json.RawMessage(`[{"host":"example.com"}]`)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+
+	holder.Load().EmitAudit(nil)
+	require.True(t, called, "audit func should be carried over to the new pipeline")
+}


### PR DESCRIPTION
The managed-mode poller previously returned build errors up to the poller, which logged them generically. An invalid control-plane push could in principle slip through if anything in the future stored the new pipeline before construction completed.

Extract the update logic into `applyPipelineSync` so the build (which acts as the validation step via each transform's factory) clearly precedes the atomic `holder.Store`. On parse or build failure, the existing pipeline is preserved and an explicit error is logged: a bad push can no longer take down the proxy.