### PR TITLE
refactor: rename bootstrap token to enrollment token

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -27,7 +27,7 @@ func runInit(args []string) {
 	tunnelPort := fs.String("tunnel-port", defaultTunnelPort, "port for the CONNECT/SOCKS5 tunnel listener")
 	proxyIP := fs.String("proxy-ip", "127.0.0.1", "IP address the DNS server returns for proxied domains")
 	allow := fs.String("allow", defaultAllowList, "comma-separated domains for the initial allowlist")
-	bootstrapToken := fs.String("bootstrap-token", "", "bootstrap token for control plane registration (managed mode)")
+	enrollmentToken := fs.String("enrollment-token", "", "enrollment token for control plane registration (managed mode)")
 	tags := fs.String("tags", "", "comma-separated tags for control plane registration (managed mode)")
 	noStart := fs.Bool("no-start", false, "generate config and unit file but don't start the service")
 	force := fs.Bool("force", false, "overwrite existing config and CA")
@@ -81,7 +81,7 @@ func runInit(args []string) {
 	}
 
 	// 2. Write default config.
-	managedMode := *bootstrapToken != ""
+	managedMode := *enrollmentToken != ""
 	tagList := splitCommaList(*tags)
 	var configYAML string
 	if managedMode {
@@ -100,7 +100,7 @@ func runInit(args []string) {
 
 	hasSystemd := hasSystemd()
 	if hasSystemd {
-		unitContent := generateSystemdUnit(execPath, configPath, *bootstrapToken)
+		unitContent := generateSystemdUnit(execPath, configPath, *enrollmentToken)
 		unitPath := "/etc/systemd/system/iron-proxy.service"
 		if err := os.WriteFile(unitPath, []byte(unitContent), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "error writing systemd unit: %v\n", err)
@@ -142,7 +142,7 @@ func runInit(args []string) {
 			return
 		}
 
-		pid, err := startBackground(execPath, configPath, *bootstrapToken)
+		pid, err := startBackground(execPath, configPath, *enrollmentToken)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error starting iron-proxy: %v\n", err)
 			os.Exit(1)
@@ -232,10 +232,10 @@ func formatTags(tags []string) string {
 	return s
 }
 
-func generateSystemdUnit(execPath, configPath, bootstrapToken string) string {
+func generateSystemdUnit(execPath, configPath, enrollmentToken string) string {
 	var envLine string
-	if bootstrapToken != "" {
-		envLine = fmt.Sprintf("Environment=IRON_BOOTSTRAP_TOKEN=%s\n", bootstrapToken)
+	if enrollmentToken != "" {
+		envLine = fmt.Sprintf("Environment=IRON_ENROLLMENT_TOKEN=%s\n", enrollmentToken)
 	}
 
 	return fmt.Sprintf(`[Unit]
@@ -320,7 +320,7 @@ func printLogTail() {
 	}
 }
 
-func startBackground(execPath, configPath, bootstrapToken string) (int, error) {
+func startBackground(execPath, configPath, enrollmentToken string) (int, error) {
 	logFile, err := os.OpenFile(defaultLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return 0, fmt.Errorf("opening log file: %w", err)
@@ -331,8 +331,8 @@ func startBackground(execPath, configPath, bootstrapToken string) (int, error) {
 	cmd.Stderr = logFile
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
-	if bootstrapToken != "" {
-		cmd.Env = append(os.Environ(), "IRON_BOOTSTRAP_TOKEN="+bootstrapToken)
+	if enrollmentToken != "" {
+		cmd.Env = append(os.Environ(), "IRON_ENROLLMENT_TOKEN="+enrollmentToken)
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	configPath := flag.String("config", "", "path to iron-proxy YAML config file")
-	bootstrapTokenFlag := flag.String("bootstrap-token", "", "bootstrap token for control plane registration")
+	enrollmentTokenFlag := flag.String("enrollment-token", "", "enrollment token for control plane registration")
 	flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -71,12 +71,12 @@ func main() {
 	}
 
 	// CLI flag takes precedence over environment variable.
-	bootstrapToken := *bootstrapTokenFlag
-	if bootstrapToken == "" {
-		bootstrapToken = os.Getenv("IRON_BOOTSTRAP_TOKEN")
+	enrollmentToken := *enrollmentTokenFlag
+	if enrollmentToken == "" {
+		enrollmentToken = os.Getenv("IRON_ENROLLMENT_TOKEN")
 	}
 
-	// Managed mode is determined by the presence of a bootstrap token or
+	// Managed mode is determined by the presence of an enrollment token or
 	// an existing credential from a prior registration.
 	stateStore, err := stateStorePath()
 	if err != nil {
@@ -88,7 +88,7 @@ func main() {
 		logger.Error("loading credential", slog.String("error", credErr.Error()))
 		os.Exit(1)
 	}
-	managed := bootstrapToken != "" || cred != nil
+	managed := enrollmentToken != "" || cred != nil
 
 	// Both modes produce a pipeline holder. Managed mode populates the
 	// initial transforms from the control plane and starts a poller that
@@ -106,7 +106,7 @@ func main() {
 
 	if managed {
 		var ingestToken string
-		holder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, stateStore, bootstrapToken, cred, logger)
+		holder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, stateStore, enrollmentToken, cred, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -245,7 +245,7 @@ func main() {
 // the initial pipeline, and starts the config poller. The poller runs until ctx
 // is canceled and sends fatal errors on errc. Returns the pipeline holder and
 // the ingest token from the initial sync (empty if the sync failed).
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, bootstrapToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, enrollmentToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	tags := cfg.Tags
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
@@ -256,7 +256,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 	if cred == nil {
 		logger.Info("registering with control plane")
 		var regErr error
-		cred, regErr = client.Register(ctx, bootstrapToken, controlplane.RegisterMetadata{
+		cred, regErr = client.Register(ctx, enrollmentToken, controlplane.RegisterMetadata{
 			Tags:    tags,
 			Version: version,
 		})

--- a/internal/controlplane/auth_test.go
+++ b/internal/controlplane/auth_test.go
@@ -32,7 +32,7 @@ func TestComputeSignature(t *testing.T) {
 			timestamp: "1744310400",
 			method:    "POST",
 			path:      "/v1/register",
-			body:      []byte(`{"bootstrap_token":"irbs_test"}`),
+			body:      []byte(`{"enrollment_token":"irbs_test"}`),
 		},
 		{
 			name:      "get request",

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -68,11 +68,11 @@ func (c *Client) GetCredential() *Credential {
 }
 
 type registerRequest struct {
-	BootstrapToken string   `json:"bootstrap_token"`
-	Tags           []string `json:"tags"`
-	Hostname       string   `json:"hostname"`
-	Version        string   `json:"version"`
-	Platform       string   `json:"platform"`
+	EnrollmentToken string   `json:"enrollment_token"`
+	Tags            []string `json:"tags"`
+	Hostname        string   `json:"hostname"`
+	Version         string   `json:"version"`
+	Platform        string   `json:"platform"`
 }
 
 type registerResponse struct {
@@ -80,7 +80,7 @@ type registerResponse struct {
 	Secret  string `json:"secret"`
 }
 
-// Register exchanges a bootstrap token for a persistent credential.
+// Register exchanges an enrollment token for a persistent credential.
 // Retries up to 5 times with exponential backoff on transient errors.
 func (c *Client) Register(ctx context.Context, token string, meta RegisterMetadata) (*Credential, error) {
 	return WithRetry(ctx, 5, func() (*Credential, error) {
@@ -92,11 +92,11 @@ func (c *Client) register(ctx context.Context, token string, meta RegisterMetada
 	hostname, _ := os.Hostname()
 
 	body := registerRequest{
-		BootstrapToken: token,
-		Tags:           meta.Tags,
-		Hostname:       hostname,
-		Version:        meta.Version,
-		Platform:       detectPlatform(),
+		EnrollmentToken: token,
+		Tags:            meta.Tags,
+		Hostname:        hostname,
+		Version:         meta.Version,
+		Platform:        detectPlatform(),
 	}
 	if body.Tags == nil {
 		body.Tags = []string{}
@@ -107,7 +107,7 @@ func (c *Client) register(ctx context.Context, token string, meta RegisterMetada
 		return nil, fmt.Errorf("marshaling register request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/proxies/register", bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/proxies/enroll", bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("building register request: %w", err)
 	}

--- a/internal/controlplane/client_test.go
+++ b/internal/controlplane/client_test.go
@@ -28,13 +28,13 @@ func apiError(code, message string) map[string]any {
 func TestRegisterSuccess(t *testing.T) {
 	secret := []byte{0xaa, 0xbb, 0xcc, 0xdd}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/proxies/register", r.URL.Path)
+		require.Equal(t, "/v1/proxies/enroll", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
 		var body registerRequest
 		err := json.NewDecoder(r.Body).Decode(&body)
 		require.NoError(t, err)
-		require.Equal(t, "irbs_test123", body.BootstrapToken)
+		require.Equal(t, "irbs_test123", body.EnrollmentToken)
 		require.Equal(t, []string{"ci", "prod"}, body.Tags)
 		require.Equal(t, "1.0.0", body.Version)
 


### PR DESCRIPTION
Renames the bootstrap token concept to enrollment token across the proxy:

- env var: `IRON_BOOTSTRAP_TOKEN` → `IRON_ENROLLMENT_TOKEN`
- CLI flag: `-bootstrap-token` → `-enrollment-token`
- JSON wire field: `bootstrap_token` → `enrollment_token`
- registration route: `/v1/proxies/register` → `/v1/proxies/enroll`

Requires a coordinated update on the control plane to accept the new route and field name.