### PR TITLE
proxy: configurable upstream response-header timeout

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -174,14 +174,15 @@ func main() {
 
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
-		HTTPAddr:   cfg.Proxy.HTTPListen,
-		HTTPSAddr:  cfg.Proxy.HTTPSListen,
-		TunnelAddr: cfg.Proxy.TunnelListen,
-		TLSMode:    cfg.TLS.Mode,
-		CertCache:  certCache,
-		Pipeline:   holder,
-		Resolver:   resolver,
-		Logger:     logger,
+		HTTPAddr:                      cfg.Proxy.HTTPListen,
+		HTTPSAddr:                     cfg.Proxy.HTTPSListen,
+		TunnelAddr:                    cfg.Proxy.TunnelListen,
+		TLSMode:                       cfg.TLS.Mode,
+		CertCache:                     certCache,
+		Pipeline:                      holder,
+		Resolver:                      resolver,
+		Logger:                        logger,
+		UpstreamResponseHeaderTimeout: cfg.Proxy.UpstreamResponseHeaderTimeoutDuration(),
 	})
 
 	// Initialize metrics server.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -182,7 +182,7 @@ func main() {
 		Pipeline:                      holder,
 		Resolver:                      resolver,
 		Logger:                        logger,
-		UpstreamResponseHeaderTimeout: cfg.Proxy.UpstreamResponseHeaderTimeoutDuration(),
+		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 	})
 
 	// Initialize metrics server.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,32 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// DefaultUpstreamResponseHeaderTimeout is applied when the policy does not
-// set proxy.upstream_response_header_timeout. It matches the historical
-// hard-coded value so existing configurations behave unchanged.
+// DefaultUpstreamResponseHeaderTimeout is the default cap on how long the
+// proxy waits for upstream response headers before returning 502.
 const DefaultUpstreamResponseHeaderTimeout = 30 * time.Second
+
+// Duration is a time.Duration that decodes YAML strings using
+// time.ParseDuration ("30s", "5m", "2h"). The zero value indicates "unset"
+// so applyDefaults can fill in a default.
+type Duration time.Duration
+
+// UnmarshalYAML decodes a Go duration string into a Duration.
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+	if s == "" {
+		*d = 0
+		return nil
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(parsed)
+	return nil
+}
 
 // Config is the top-level configuration for iron-proxy.
 type Config struct {
@@ -53,23 +75,7 @@ type Proxy struct {
 	// syntax: "30s" (default), "5m", "2h". Useful for upstream endpoints
 	// (e.g. LLM context compaction) that legitimately take longer than the
 	// 30-second default to begin replying.
-	UpstreamResponseHeaderTimeout string `yaml:"upstream_response_header_timeout"`
-}
-
-// UpstreamResponseHeaderTimeoutDuration returns the parsed duration for the
-// upstream response-header timeout, falling back to
-// DefaultUpstreamResponseHeaderTimeout when the field is empty. Validate
-// rejects invalid values up front, so this is safe to call on validated
-// configs.
-func (p Proxy) UpstreamResponseHeaderTimeoutDuration() time.Duration {
-	if p.UpstreamResponseHeaderTimeout == "" {
-		return DefaultUpstreamResponseHeaderTimeout
-	}
-	d, err := time.ParseDuration(p.UpstreamResponseHeaderTimeout)
-	if err != nil || d <= 0 {
-		return DefaultUpstreamResponseHeaderTimeout
-	}
-	return d
+	UpstreamResponseHeaderTimeout Duration `yaml:"upstream_response_header_timeout"`
 }
 
 // TLS configures certificate authority and cert caching for MITM.
@@ -173,6 +179,9 @@ func applyDefaults(cfg *Config) {
 		cfg.Proxy.MaxRequestBodyBytes = 1 << 20 // 1 MiB
 	}
 	// MaxResponseBodyBytes defaults to 0 (uncapped).
+	if cfg.Proxy.UpstreamResponseHeaderTimeout == 0 {
+		cfg.Proxy.UpstreamResponseHeaderTimeout = Duration(DefaultUpstreamResponseHeaderTimeout)
+	}
 	if cfg.TLS.Mode == "" {
 		cfg.TLS.Mode = TLSModeMITM
 	}
@@ -214,14 +223,8 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("log.level: %w", err)
 	}
 
-	if cfg.Proxy.UpstreamResponseHeaderTimeout != "" {
-		d, err := time.ParseDuration(cfg.Proxy.UpstreamResponseHeaderTimeout)
-		if err != nil {
-			return fmt.Errorf("proxy.upstream_response_header_timeout: %w", err)
-		}
-		if d <= 0 {
-			return fmt.Errorf("proxy.upstream_response_header_timeout must be positive; got %s", d)
-		}
+	if cfg.Proxy.UpstreamResponseHeaderTimeout <= 0 {
+		return fmt.Errorf("proxy.upstream_response_header_timeout must be positive; got %s", time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,15 @@ package config
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// DefaultUpstreamResponseHeaderTimeout is applied when the policy does not
+// set proxy.upstream_response_header_timeout. It matches the historical
+// hard-coded value so existing configurations behave unchanged.
+const DefaultUpstreamResponseHeaderTimeout = 30 * time.Second
 
 // Config is the top-level configuration for iron-proxy.
 type Config struct {
@@ -42,6 +48,28 @@ type Proxy struct {
 	TunnelListen         string `yaml:"tunnel_listen"`
 	MaxRequestBodyBytes  int64  `yaml:"max_request_body_bytes"`
 	MaxResponseBodyBytes int64  `yaml:"max_response_body_bytes"`
+	// UpstreamResponseHeaderTimeout caps how long the proxy waits for an
+	// upstream response's headers before returning 502. Accepts Go duration
+	// syntax: "30s" (default), "5m", "2h". Useful for upstream endpoints
+	// (e.g. LLM context compaction) that legitimately take longer than the
+	// 30-second default to begin replying.
+	UpstreamResponseHeaderTimeout string `yaml:"upstream_response_header_timeout"`
+}
+
+// UpstreamResponseHeaderTimeoutDuration returns the parsed duration for the
+// upstream response-header timeout, falling back to
+// DefaultUpstreamResponseHeaderTimeout when the field is empty. Validate
+// rejects invalid values up front, so this is safe to call on validated
+// configs.
+func (p Proxy) UpstreamResponseHeaderTimeoutDuration() time.Duration {
+	if p.UpstreamResponseHeaderTimeout == "" {
+		return DefaultUpstreamResponseHeaderTimeout
+	}
+	d, err := time.ParseDuration(p.UpstreamResponseHeaderTimeout)
+	if err != nil || d <= 0 {
+		return DefaultUpstreamResponseHeaderTimeout
+	}
+	return d
 }
 
 // TLS configures certificate authority and cert caching for MITM.
@@ -184,6 +212,16 @@ func Validate(cfg *Config) error {
 
 	if _, err := parseLogLevel(cfg.Log.Level); err != nil {
 		return fmt.Errorf("log.level: %w", err)
+	}
+
+	if cfg.Proxy.UpstreamResponseHeaderTimeout != "" {
+		d, err := time.ParseDuration(cfg.Proxy.UpstreamResponseHeaderTimeout)
+		if err != nil {
+			return fmt.Errorf("proxy.upstream_response_header_timeout: %w", err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("proxy.upstream_response_header_timeout must be positive; got %s", d)
+		}
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -311,8 +311,7 @@ tls:
 `
 		cfg, err := Load(strings.NewReader(yaml))
 		require.NoError(t, err)
-		require.Equal(t, "", cfg.Proxy.UpstreamResponseHeaderTimeout)
-		require.Equal(t, DefaultUpstreamResponseHeaderTimeout, cfg.Proxy.UpstreamResponseHeaderTimeoutDuration())
+		require.Equal(t, 30*time.Second, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
 	})
 
 	t.Run("valid duration accepted", func(t *testing.T) {
@@ -327,11 +326,10 @@ tls:
 `
 		cfg, err := Load(strings.NewReader(yaml))
 		require.NoError(t, err)
-		require.Equal(t, "5m", cfg.Proxy.UpstreamResponseHeaderTimeout)
-		require.Equal(t, 5*time.Minute, cfg.Proxy.UpstreamResponseHeaderTimeoutDuration())
+		require.Equal(t, 5*time.Minute, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
 	})
 
-	t.Run("invalid duration rejected at validate", func(t *testing.T) {
+	t.Run("invalid duration rejected at parse", func(t *testing.T) {
 		yaml := `
 dns:
   proxy_ip: "10.0.0.1"
@@ -343,15 +341,15 @@ tls:
 `
 		_, err := Load(strings.NewReader(yaml))
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "proxy.upstream_response_header_timeout")
+		require.Contains(t, err.Error(), "invalid duration")
 	})
 
-	t.Run("non-positive duration rejected at validate", func(t *testing.T) {
+	t.Run("negative duration rejected at validate", func(t *testing.T) {
 		yaml := `
 dns:
   proxy_ip: "10.0.0.1"
 proxy:
-  upstream_response_header_timeout: "0s"
+  upstream_response_header_timeout: "-5s"
 tls:
   ca_cert: "/tmp/ca.crt"
   ca_key: "/tmp/ca.key"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -297,4 +298,66 @@ tls:
 	require.Equal(t, "internal.example.com", cfg.DNS.Records[0].Name)
 	require.Equal(t, "A", cfg.DNS.Records[0].Type)
 	require.Equal(t, "10.0.0.5", cfg.DNS.Records[0].Value)
+}
+
+func TestLoad_UpstreamResponseHeaderTimeout(t *testing.T) {
+	t.Run("default applied when unset", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, "", cfg.Proxy.UpstreamResponseHeaderTimeout)
+		require.Equal(t, DefaultUpstreamResponseHeaderTimeout, cfg.Proxy.UpstreamResponseHeaderTimeoutDuration())
+	})
+
+	t.Run("valid duration accepted", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_response_header_timeout: "5m"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, "5m", cfg.Proxy.UpstreamResponseHeaderTimeout)
+		require.Equal(t, 5*time.Minute, cfg.Proxy.UpstreamResponseHeaderTimeoutDuration())
+	})
+
+	t.Run("invalid duration rejected at validate", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_response_header_timeout: "not-a-duration"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "proxy.upstream_response_header_timeout")
+	})
+
+	t.Run("non-positive duration rejected at validate", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_response_header_timeout: "0s"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be positive")
+	})
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // applyEnvOverrides layers IRON_* environment variables on top of an existing
@@ -84,6 +85,14 @@ func applyEnvOverrides(cfg *Config) error {
 			return fmt.Errorf("IRON_TLS_LEAF_CERT_EXPIRY_HOURS: %w", err)
 		}
 		cfg.TLS.LeafCertExpiryHours = n
+	}
+
+	if v := os.Getenv("IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT: %w", err)
+		}
+		cfg.Proxy.UpstreamResponseHeaderTimeout = Duration(d)
 	}
 
 	return nil

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -32,24 +33,26 @@ func TestLoadConfig_EnvOnly_Defaults(t *testing.T) {
 	require.Equal(t, ":9090", cfg.Metrics.Listen)
 	require.Equal(t, "info", cfg.Log.Level)
 	require.Empty(t, cfg.Transforms)
+	require.Equal(t, 30*time.Second, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
 }
 
 func TestLoadConfig_EnvOnly_AllOverrides(t *testing.T) {
 	setEnvs(t, map[string]string{
-		"IRON_DNS_LISTEN":                    ":5353",
-		"IRON_DNS_PROXY_IP":                  "10.0.0.1",
-		"IRON_DNS_UPSTREAM_RESOLVER":         "8.8.8.8:53",
-		"IRON_PROXY_HTTP_LISTEN":             ":8080",
-		"IRON_PROXY_HTTPS_LISTEN":            ":8443",
-		"IRON_PROXY_TUNNEL_LISTEN":           ":1080",
-		"IRON_PROXY_MAX_REQUEST_BODY_BYTES":  "2097152",
-		"IRON_PROXY_MAX_RESPONSE_BODY_BYTES": "4194304",
-		"IRON_TLS_CA_CERT":                   "/custom/ca.pem",
-		"IRON_TLS_CA_KEY":                    "/custom/ca-key.pem",
-		"IRON_TLS_CERT_CACHE_SIZE":           "500",
-		"IRON_TLS_LEAF_CERT_EXPIRY_HOURS":    "24",
-		"IRON_METRICS_LISTEN":                ":2112",
-		"IRON_LOG_LEVEL":                     "debug",
+		"IRON_DNS_LISTEN":                             ":5353",
+		"IRON_DNS_PROXY_IP":                           "10.0.0.1",
+		"IRON_DNS_UPSTREAM_RESOLVER":                  "8.8.8.8:53",
+		"IRON_PROXY_HTTP_LISTEN":                      ":8080",
+		"IRON_PROXY_HTTPS_LISTEN":                     ":8443",
+		"IRON_PROXY_TUNNEL_LISTEN":                    ":1080",
+		"IRON_PROXY_MAX_REQUEST_BODY_BYTES":           "2097152",
+		"IRON_PROXY_MAX_RESPONSE_BODY_BYTES":          "4194304",
+		"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT": "5m",
+		"IRON_TLS_CA_CERT":                            "/custom/ca.pem",
+		"IRON_TLS_CA_KEY":                             "/custom/ca-key.pem",
+		"IRON_TLS_CERT_CACHE_SIZE":                    "500",
+		"IRON_TLS_LEAF_CERT_EXPIRY_HOURS":             "24",
+		"IRON_METRICS_LISTEN":                         ":2112",
+		"IRON_LOG_LEVEL":                              "debug",
 	})
 
 	cfg, err := LoadConfig("")
@@ -69,6 +72,7 @@ func TestLoadConfig_EnvOnly_AllOverrides(t *testing.T) {
 	require.Equal(t, 24, cfg.TLS.LeafCertExpiryHours)
 	require.Equal(t, ":2112", cfg.Metrics.Listen)
 	require.Equal(t, "debug", cfg.Log.Level)
+	require.Equal(t, 5*time.Minute, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
 }
 
 func TestLoadConfig_EnvOnly_InvalidIntegers(t *testing.T) {
@@ -227,6 +231,39 @@ func TestApplyEnvOverrides_InvalidInteger(t *testing.T) {
 	require.Contains(t, err.Error(), "IRON_PROXY_MAX_REQUEST_BODY_BYTES")
 }
 
+func TestApplyEnvOverrides_UpstreamResponseHeaderTimeout(t *testing.T) {
+	t.Run("env override applied", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT": "2m",
+		})
+
+		var cfg Config
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.Equal(t, 2*time.Minute, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
+	})
+
+	t.Run("env override beats yaml value", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT": "10s",
+		})
+
+		cfg := Config{Proxy: Proxy{UpstreamResponseHeaderTimeout: Duration(time.Minute)}}
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.Equal(t, 10*time.Second, time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
+	})
+
+	t.Run("invalid duration rejected", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT": "not-a-duration",
+		})
+
+		var cfg Config
+		err := applyEnvOverrides(&cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT")
+	})
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
@@ -247,6 +284,7 @@ func setEnvs(t *testing.T, envs map[string]string) {
 		"IRON_PROXY_TUNNEL_LISTEN",
 		"IRON_PROXY_MAX_REQUEST_BODY_BYTES",
 		"IRON_PROXY_MAX_RESPONSE_BODY_BYTES",
+		"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT",
 		"IRON_TLS_CA_CERT",
 		"IRON_TLS_CA_KEY",
 		"IRON_TLS_CERT_CACHE_SIZE",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -65,7 +65,7 @@ type Options struct {
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
-	// config.DefaultUpstreamResponseHeaderTimeout (30s).
+	// config.DefaultUpstreamResponseHeaderTimeout.
 	UpstreamResponseHeaderTimeout time.Duration
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -63,6 +63,10 @@ type Options struct {
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
 	Logger     *slog.Logger
+	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
+	// ResponseHeaderTimeout. Zero falls back to
+	// config.DefaultUpstreamResponseHeaderTimeout (30s).
+	UpstreamResponseHeaderTimeout time.Duration
 }
 
 // New creates a new Proxy. In TLSModeMITM, certCache must be non-nil. In
@@ -79,7 +83,7 @@ func New(opts Options) *Proxy {
 		tunnelDone:     make(chan struct{}),
 		certCache:      opts.CertCache,
 		pipeline:       opts.Pipeline,
-		transport:      buildTransport(opts.Resolver),
+		transport:      buildTransport(opts.Resolver, opts.UpstreamResponseHeaderTimeout),
 		resolver:       opts.Resolver,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
@@ -533,11 +537,16 @@ func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 // buildTransport creates the HTTP transport used for upstream requests.
 // If resolver is non-nil, the transport's dialer uses it instead of the OS
 // default — this prevents resolution loops when iron-proxy owns the system DNS.
-func buildTransport(resolver *net.Resolver) *http.Transport {
+// responseHeaderTimeout overrides the default 30-second
+// ResponseHeaderTimeout when greater than zero; pass 0 to keep the default.
+func buildTransport(resolver *net.Resolver, responseHeaderTimeout time.Duration) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Resolver:  resolver,
+	}
+	if responseHeaderTimeout <= 0 {
+		responseHeaderTimeout = config.DefaultUpstreamResponseHeaderTimeout
 	}
 	return &http.Transport{
 		TLSClientConfig: &tls.Config{
@@ -547,7 +556,7 @@ func buildTransport(resolver *net.Resolver) *http.Transport {
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 }
 

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -27,6 +27,11 @@ proxy:
   # Global body buffer limits for transforms.
   max_request_body_bytes: 1048576   # default: 1 MiB
   # max_response_body_bytes: 0      # default: 0 (uncapped)
+  # Cap on how long the proxy waits for upstream response headers before
+  # returning 502. Accepts Go duration syntax: "30s" (default), "5m", "2h".
+  # Bump this for upstream endpoints that legitimately take longer than 30s
+  # to begin replying (e.g. LLM context-compaction endpoints).
+  # upstream_response_header_timeout: "5m"
 
 # TLS / MITM configuration
 tls:


### PR DESCRIPTION
## Summary

The HTTP transport's `ResponseHeaderTimeout` is currently hard-coded to 30 seconds in `internal/proxy/proxy.go`. Upstream endpoints that legitimately take longer than 30s to begin sending response headers — most notably large LLM context-compaction calls — trip the limit, and the proxy returns 502 even though the upstream is healthy and would have eventually responded.

This PR makes the timeout configurable from the policy YAML, defaulting to the existing 30s so no current deployment changes behavior.

```yaml
proxy:
  upstream_response_header_timeout: "5m"   # optional; default "30s"
```

## What changed

- `Proxy.UpstreamResponseHeaderTimeout` (string, accepts Go duration syntax) added to the config schema.
- `Validate` parses the value at startup and rejects invalid or non-positive durations.
- `Proxy.UpstreamResponseHeaderTimeoutDuration()` returns the parsed value with a fallback to `DefaultUpstreamResponseHeaderTimeout` (30s) — kept as an exported constant.
- `proxy.Options.UpstreamResponseHeaderTimeout` plumbs the duration through; `buildTransport` uses it when > 0.
- `iron-proxy.example.yaml` documents the new field.

## Test plan

- New `TestLoad_UpstreamResponseHeaderTimeout` cases:
  - default applied when unset
  - valid duration accepted (`5m` → `5 * time.Minute`)
  - invalid duration rejected at `Validate`
  - non-positive duration rejected at `Validate`
- `go test ./... -count=1 -timeout 180s -short` passes locally.

## Concrete motivation

In our setup, codex's `/backend-api/codex/responses/compact` endpoint takes longer than 30s to respond when compacting ~244K-token conversations. iron-proxy's audit log records 14+ consecutive 30021ms `net/http: timeout awaiting response headers` errors against that endpoint while every other chatgpt.com path returns 200 in the same window. Bumping the timeout to a few minutes lets the request through; the proxy still hard-fails on a real outage rather than hanging forever.

## Backwards compatibility

The field is optional. When absent, behavior is identical to the previous hard-coded 30s.

Author: @tsenart
Replaces https://github.com/ironsh/iron-proxy/pull/79
