### PR TITLE
ci: group AWS SDK updates in one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      aws-sdk-go:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
 
   - package-ecosystem: docker
     directory: /examples/docker-compose


### PR DESCRIPTION
Groups all github.com/aws/aws-sdk-go-v2* module updates into a single weekly dependabot PR instead of one per module.