### PR TITLE
secrets: scan request path for proxy token

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ values before forwarding upstream. You control where it looks:
 
 - **`match_headers`:** list of header names to scan. Empty list = all headers.
 - **`match_body`:** scan the request body (buffered up to `max_request_body_bytes`).
+- **`match_path`:** scan the URL path. Defaults to `false`; opt in for upstreams
+  like Telegram that embed the secret in the path (e.g.
+  `/bot<TOKEN>/sendMessage`). URL paths often appear in access logs on either
+  side of the proxy, so this is off by default.
 - **`require`:** when `true`, requests to a matching host that do **not** contain
   the proxy token are rejected with 403. This prevents a compromised workload
   from bypassing the secret-swap mechanism with alternative credentials. Default: `false`.

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -48,6 +48,7 @@ type replaceConfig struct {
 	ProxyValue   string   `yaml:"proxy_value"`
 	MatchHeaders []string `yaml:"match_headers,omitempty"`
 	MatchBody    bool     `yaml:"match_body,omitempty"`
+	MatchPath    bool     `yaml:"match_path,omitempty"`
 	Require      bool     `yaml:"require,omitempty"`
 }
 
@@ -68,6 +69,7 @@ type resolvedSecret struct {
 	proxyValue   string
 	matchHeaders []string // empty = all headers
 	matchBody    bool
+	matchPath    bool
 	require      bool
 
 	// inject mode fields
@@ -167,6 +169,7 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 				getValue:     result.GetValue,
 				matchHeaders: replace.MatchHeaders,
 				matchBody:    replace.MatchBody,
+				matchPath:    replace.MatchPath,
 				require:      replace.Require,
 				rules:        rules,
 			})
@@ -280,6 +283,12 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		var locations []string
 		locations = append(locations, s.swapHeaders(req, &sec, realValue)...)
 		locations = append(locations, s.swapQuery(req, &sec, realValue)...)
+
+		if sec.matchPath {
+			if loc := s.swapPath(req, &sec, realValue); loc != "" {
+				locations = append(locations, loc)
+			}
+		}
 
 		if sec.matchBody {
 			if loc := s.swapBody(req, &sec, realValue); loc != "" {
@@ -434,6 +443,18 @@ func (s *Secrets) swapQuery(req *http.Request, sec *resolvedSecret, realValue st
 		req.URL.RawQuery = params.Encode()
 	}
 	return locations
+}
+
+func (s *Secrets) swapPath(req *http.Request, sec *resolvedSecret, realValue string) string {
+	path := req.URL.Path
+	if path == "" || !strings.Contains(path, sec.proxyValue) {
+		return ""
+	}
+	req.URL.Path = strings.ReplaceAll(path, sec.proxyValue, realValue)
+	// RawPath is an optional encoded form; clear it so net/http re-derives
+	// the encoding from the new Path.
+	req.URL.RawPath = ""
+	return "path"
 }
 
 func (s *Secrets) swapBody(req *http.Request, sec *resolvedSecret, realValue string) string {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -1047,6 +1047,84 @@ func TestInject_ConfigErrors(t *testing.T) {
 	}
 }
 
+// --- Path mode tests ---
+
+func telegramReq(path string) *http.Request {
+	req := httptest.NewRequest("POST", "http://api.telegram.org"+path, nil)
+	req.Host = "api.telegram.org"
+	return req
+}
+
+func telegramReplaceEntry(opts ...func(*secretEntry)) secretEntry {
+	e := secretEntry{
+		Source: envSource("OPENAI_API_KEY"),
+		Replace: &replaceConfig{
+			ProxyValue:   "proxy-tg-token",
+			MatchHeaders: []string{}, // disable header scanning
+			MatchPath:    true,
+		},
+		Rules: []hostmatch.RuleConfig{{Host: "api.telegram.org"}},
+	}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func TestReplace_MatchPath(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{telegramReplaceEntry()})
+
+	req := telegramReq("/botproxy-tg-token/sendMessage")
+	doTransform(t, s, req)
+
+	require.Equal(t, "/botsk-real-openai-key/sendMessage", req.URL.Path)
+	require.Empty(t, req.URL.RawPath)
+}
+
+func TestReplace_MatchPath_NoMatchInPath(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{telegramReplaceEntry()})
+
+	req := telegramReq("/sendMessage")
+	doTransform(t, s, req)
+
+	require.Equal(t, "/sendMessage", req.URL.Path)
+}
+
+func TestReplace_MatchPath_RequireRejectsWhenAbsent(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{telegramReplaceEntry(func(e *secretEntry) {
+		e.Replace.Require = true
+	})})
+
+	req := telegramReq("/sendMessage")
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestReplace_MatchPath_ClearsRawPath(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{telegramReplaceEntry()})
+
+	req := telegramReq("/botproxy-tg-token/sendMessage")
+	// Simulate net/http populating an encoded RawPath alongside Path.
+	req.URL.RawPath = "/botproxy-tg-token/sendMessage"
+	doTransform(t, s, req)
+
+	require.Equal(t, "/botsk-real-openai-key/sendMessage", req.URL.Path)
+	require.Empty(t, req.URL.RawPath, "RawPath must be cleared so net/http re-encodes from Path")
+}
+
+func TestReplace_MatchPath_DefaultOff(t *testing.T) {
+	// Without match_path, a proxy_value embedded in the path must be left alone.
+	s := makeSecrets(t, []secretEntry{telegramReplaceEntry(func(e *secretEntry) {
+		e.Replace.MatchPath = false
+	})})
+
+	req := telegramReq("/botproxy-tg-token/sendMessage")
+	doTransform(t, s, req)
+
+	require.Equal(t, "/botproxy-tg-token/sendMessage", req.URL.Path)
+}
+
 func TestInject_ConcurrentSafety(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{injectEntry()})
 

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -125,6 +125,21 @@ transforms:
               methods: ["POST"]
               paths: ["/v1/messages", "/v1/complete"]
 
+        # Replace mode with URL path scanning. Use match_path when the client
+        # embeds the proxy token in the URL path (e.g. Telegram-style APIs).
+        # Defaults to false; opt in explicitly because paths often appear in
+        # access logs.
+        # - source:
+        #     type: env
+        #     var: TELEGRAM_BOT_TOKEN
+        #   replace:
+        #     proxy_value: "proxy-tg-token-123"
+        #     match_headers: []          # disable header scanning if path-only
+        #     match_path: true
+        #     require: true
+        #   rules:
+        #     - host: "api.telegram.org"
+
         # Replace mode with AWS Secrets Manager and background refresh:
         # - source:
         #     type: aws_sm


### PR DESCRIPTION
Adds `match_path` to the `secrets` transform's replace block. When true, the proxy scans `req.URL.Path` for `proxy_value` and swaps in the resolved secret (clearing `RawPath` so net/http re-encodes from the new `Path`). Defaults to `false` since URL paths often appear in access logs on either side of the proxy.

Enables routing through iron-proxy for upstreams that embed credentials in the path. Telegram is the canonical example: a client sends `/bot<proxy-token>/sendMessage`, the proxy swaps the token before forwarding upstream. Inject mode is intentionally not extended to paths: there is no key for the proxy to anchor on, so it would either duplicate the secret or replace the client's path entirely.