### PR TITLE
feat(proxy): deny upstream connections to configured CIDRs at dial time

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Single binary. Single YAML config.
 - **Default-deny egress.** Every outbound request is blocked unless the
   destination matches your allowlist. List your domains and CIDRs, everything
   else gets a 403.
+- **Upstream IP deny list.** Even when a host is allowed, the proxy refuses
+  to dial it if its resolved address falls inside a denied CIDR — closing
+  the SSRF/DNS-rebinding gap where an allowlisted hostname points at IMDS
+  or loopback. Cloud metadata endpoints (`169.254.169.254`) and loopback are
+  denied by default; override via `proxy.upstream_deny_cidrs`.
 - **Boundary-level secret injection.** Workloads send proxy tokens; iron-proxy
   replaces them with real secrets before the request leaves. If the sandbox is
   compromised, the attacker gets tokens that are useless outside the proxy.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/controlplane"
 	idns "github.com/ironsh/iron-proxy/internal/dns"
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/metrics"
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/proxy"
@@ -172,6 +173,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Build the upstream-dial deny guard. config.Validate has already
+	// confirmed the entries parse, so this should not fail.
+	guard, err := dnsguard.New(cfg.Proxy.UpstreamDenyCIDRs.Values)
+	if err != nil {
+		logger.Error("initializing upstream deny guard", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if len(cfg.Proxy.UpstreamDenyCIDRs.Values) > 0 {
+		logger.Info("upstream deny list active",
+			slog.Any("cidrs", cfg.Proxy.UpstreamDenyCIDRs.Values),
+		)
+	}
+
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
@@ -181,6 +195,7 @@ func main() {
 		CertCache:                     certCache,
 		Pipeline:                      holder,
 		Resolver:                      resolver,
+		Guard:                         guard,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 	})

--- a/integration_test/testdata/aws_sm.yaml
+++ b/integration_test/testdata/aws_sm.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/aws_ssm.yaml
+++ b/integration_test/testdata/aws_ssm.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/grpc_pipeline.yaml
+++ b/integration_test/testdata/grpc_pipeline.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/judge_body.yaml
+++ b/integration_test/testdata/judge_body.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/judge_openai_body.yaml
+++ b/integration_test/testdata/judge_openai_body.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/judge_openai_pipeline.yaml
+++ b/integration_test/testdata/judge_openai_pipeline.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/integration_test/testdata/judge_pipeline.yaml
+++ b/integration_test/testdata/judge_pipeline.yaml
@@ -6,6 +6,7 @@ proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
 
 tls:
   ca_cert: tmp/ca.crt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 )
 
 // DefaultUpstreamResponseHeaderTimeout is the default cap on how long the
@@ -76,6 +78,25 @@ type Proxy struct {
 	// (e.g. LLM context compaction) that legitimately take longer than the
 	// 30-second default to begin replying.
 	UpstreamResponseHeaderTimeout Duration `yaml:"upstream_response_header_timeout"`
+	// UpstreamDenyCIDRs lists CIDR ranges the proxy refuses to dial. Enforced
+	// at connect time against the resolved address. When unset, a secure
+	// default (IMDS + loopback) is applied; set to an empty list to disable.
+	UpstreamDenyCIDRs CIDRList `yaml:"upstream_deny_cidrs"`
+}
+
+// CIDRList is a list of CIDR strings whose presence in YAML is distinguishable
+// from absence: an explicit empty list opts out of any default population,
+// while an unset field signals "apply the default".
+type CIDRList struct {
+	Values []string
+	Set    bool
+}
+
+// UnmarshalYAML records that the field was present in the source document,
+// even when the value is an empty list.
+func (l *CIDRList) UnmarshalYAML(value *yaml.Node) error {
+	l.Set = true
+	return value.Decode(&l.Values)
 }
 
 // TLS configures certificate authority and cert caching for MITM.
@@ -182,6 +203,10 @@ func applyDefaults(cfg *Config) {
 	if cfg.Proxy.UpstreamResponseHeaderTimeout == 0 {
 		cfg.Proxy.UpstreamResponseHeaderTimeout = Duration(DefaultUpstreamResponseHeaderTimeout)
 	}
+	if !cfg.Proxy.UpstreamDenyCIDRs.Set {
+		cfg.Proxy.UpstreamDenyCIDRs.Values = append([]string(nil), dnsguard.DefaultDenyCIDRs...)
+		cfg.Proxy.UpstreamDenyCIDRs.Set = true
+	}
 	if cfg.TLS.Mode == "" {
 		cfg.TLS.Mode = TLSModeMITM
 	}
@@ -225,6 +250,10 @@ func Validate(cfg *Config) error {
 
 	if cfg.Proxy.UpstreamResponseHeaderTimeout <= 0 {
 		return fmt.Errorf("proxy.upstream_response_header_timeout must be positive; got %s", time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout))
+	}
+
+	if err := dnsguard.ValidateCIDRs(cfg.Proxy.UpstreamDenyCIDRs.Values); err != nil {
+		return fmt.Errorf("proxy.upstream_deny_cidrs: %w", err)
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 )
 
 func validYAML() string {
@@ -298,6 +300,80 @@ tls:
 	require.Equal(t, "internal.example.com", cfg.DNS.Records[0].Name)
 	require.Equal(t, "A", cfg.DNS.Records[0].Type)
 	require.Equal(t, "10.0.0.5", cfg.DNS.Records[0].Value)
+}
+
+func TestLoad_UpstreamDenyCIDRs(t *testing.T) {
+	t.Run("default applied when unset", func(t *testing.T) {
+		cfg, err := Load(strings.NewReader(validYAML()))
+		require.NoError(t, err)
+		require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+		require.Equal(t, dnsguard.DefaultDenyCIDRs, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("explicit empty list opts out", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_deny_cidrs: []
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+		require.Empty(t, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("explicit list replaces defaults", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_deny_cidrs:
+    - "169.254.169.254/32"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, []string{"169.254.169.254/32"}, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("bare IP rejected", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_deny_cidrs:
+    - "1.2.3.4"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "proxy.upstream_deny_cidrs")
+		require.Contains(t, err.Error(), "must be CIDR notation")
+	})
+
+	t.Run("malformed CIDR rejected", func(t *testing.T) {
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+proxy:
+  upstream_deny_cidrs:
+    - "not-an-ip/24"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "proxy.upstream_deny_cidrs")
+	})
 }
 
 func TestLoad_UpstreamResponseHeaderTimeout(t *testing.T) {

--- a/internal/dnsguard/dnsguard.go
+++ b/internal/dnsguard/dnsguard.go
@@ -1,0 +1,131 @@
+// Package dnsguard rejects upstream connections to denied IP ranges at dial
+// time. Enforcement runs in net.Dialer.Control after DNS resolution, so a
+// hostname that resolves to a denied IP — even via DNS rebinding — is caught
+// before the TCP connect.
+package dnsguard
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+	"syscall"
+)
+
+// DefaultDenyCIDRs is the secure-default list applied when the operator has
+// not configured upstream_deny_cidrs. It blocks cloud instance metadata
+// endpoints and loopback. RFC1918 is intentionally excluded — many legitimate
+// iron-proxy deployments target private corporate networks.
+var DefaultDenyCIDRs = []string{
+	"169.254.169.254/32",
+	"fd00:ec2::254/128",
+	"127.0.0.0/8",
+	"::1/128",
+}
+
+// DenyError reports a connection refused because the resolved address falls
+// inside a denied CIDR.
+type DenyError struct {
+	Address string
+	Prefix  netip.Prefix
+}
+
+func (e *DenyError) Error() string {
+	return fmt.Sprintf("denied by upstream_deny_cidrs: %s in %s", e.Address, e.Prefix)
+}
+
+// IsDenyError reports whether err (or any wrapped error) is a *DenyError.
+func IsDenyError(err error) bool {
+	var de *DenyError
+	return errors.As(err, &de)
+}
+
+// Guard holds the compiled deny prefixes and exposes hooks for the dialer.
+// The zero value is a valid empty guard whose DialControl is a no-op.
+type Guard struct {
+	prefixes []netip.Prefix
+}
+
+// New compiles a Guard from CIDR strings. CIDR notation is required: bare IPs
+// like "1.2.3.4" are rejected, forcing operators to be explicit about scope.
+// A nil or empty list yields an empty guard whose checks always pass.
+func New(cidrs []string) (*Guard, error) {
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for _, raw := range cidrs {
+		p, err := parsePrefix(raw)
+		if err != nil {
+			return nil, err
+		}
+		prefixes = append(prefixes, p)
+	}
+	return &Guard{prefixes: prefixes}, nil
+}
+
+// ValidateCIDRs reports whether every entry in cidrs is a valid CIDR string
+// in the form Guard expects (CIDR notation required; bare IPs rejected).
+// Use this when only validation is needed — e.g. config validation that runs
+// before a Guard is built.
+func ValidateCIDRs(cidrs []string) error {
+	for _, raw := range cidrs {
+		if _, err := parsePrefix(raw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parsePrefix(raw string) (netip.Prefix, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return netip.Prefix{}, fmt.Errorf("empty CIDR entry")
+	}
+	if !strings.Contains(s, "/") {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR %q: must be CIDR notation, e.g. 1.2.3.4/32 or ::1/128", raw)
+	}
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("invalid CIDR %q: %w", raw, err)
+	}
+	return p.Masked(), nil
+}
+
+// IsDenied reports whether ip falls inside any configured deny prefix.
+func (g *Guard) IsDenied(ip netip.Addr) bool {
+	if g == nil || len(g.prefixes) == 0 {
+		return false
+	}
+	ip = ip.Unmap()
+	for _, p := range g.prefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// DialControl is the net.Dialer.Control hook. Go invokes it after DNS
+// resolution with the literal "host:port" about to be connected to; host is
+// already an IP at this point, so name-based dials and IP-literal dials
+// (e.g. SOCKS5 IPv4 atyp) are both covered. Returning an error aborts the
+// connect.
+func (g *Guard) DialControl(_ string, address string, _ syscall.RawConn) error {
+	if g == nil || len(g.prefixes) == 0 {
+		return nil
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return nil
+	}
+	addr = addr.Unmap()
+	for _, p := range g.prefixes {
+		if p.Contains(addr) {
+			return &DenyError{Address: host, Prefix: p}
+		}
+	}
+	return nil
+}

--- a/internal/dnsguard/dnsguard_test.go
+++ b/internal/dnsguard/dnsguard_test.go
@@ -1,0 +1,149 @@
+package dnsguard
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_RejectsBareIPs(t *testing.T) {
+	tests := []string{
+		"1.2.3.4",
+		"169.254.169.254",
+		"::1",
+		"fd00:ec2::254",
+	}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			_, err := New([]string{in})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "must be CIDR notation")
+		})
+	}
+}
+
+func TestNew_RejectsMalformed(t *testing.T) {
+	tests := []string{
+		"not-an-ip/24",
+		"999.999.999.999/32",
+		"10.0.0.0/99",
+		"  ",
+	}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			_, err := New([]string{in})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNew_AcceptsValid(t *testing.T) {
+	g, err := New([]string{
+		"169.254.169.254/32",
+		"127.0.0.0/8",
+		"::1/128",
+		"fd00:ec2::254/128",
+		"10.0.0.0/8",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, g)
+}
+
+func TestNew_NilAndEmpty(t *testing.T) {
+	g, err := New(nil)
+	require.NoError(t, err)
+	require.False(t, g.IsDenied(netip.MustParseAddr("169.254.169.254")))
+
+	g, err = New([]string{})
+	require.NoError(t, err)
+	require.False(t, g.IsDenied(netip.MustParseAddr("127.0.0.1")))
+}
+
+func TestIsDenied(t *testing.T) {
+	g, err := New([]string{
+		"169.254.169.254/32",
+		"127.0.0.0/8",
+		"::1/128",
+	})
+	require.NoError(t, err)
+
+	denied := []string{
+		"169.254.169.254",
+		"127.0.0.1",
+		"127.255.255.254",
+		"::1",
+	}
+	for _, ip := range denied {
+		t.Run("denied/"+ip, func(t *testing.T) {
+			require.True(t, g.IsDenied(netip.MustParseAddr(ip)))
+		})
+	}
+
+	allowed := []string{
+		"169.254.169.253",
+		"169.254.170.0",
+		"128.0.0.0",
+		"8.8.8.8",
+		"::2",
+		"2001:db8::1",
+	}
+	for _, ip := range allowed {
+		t.Run("allowed/"+ip, func(t *testing.T) {
+			require.False(t, g.IsDenied(netip.MustParseAddr(ip)))
+		})
+	}
+}
+
+func TestIsDenied_4in6Mapped(t *testing.T) {
+	g, err := New([]string{"127.0.0.0/8"})
+	require.NoError(t, err)
+
+	mapped := netip.MustParseAddr("::ffff:127.0.0.1")
+	require.True(t, g.IsDenied(mapped))
+}
+
+func TestDialControl_DenyAndAllow(t *testing.T) {
+	g, err := New([]string{"127.0.0.0/8", "169.254.169.254/32"})
+	require.NoError(t, err)
+
+	t.Run("denied ipv4", func(t *testing.T) {
+		err := g.DialControl("tcp", "127.0.0.1:443", nil)
+		require.Error(t, err)
+		require.True(t, IsDenyError(err))
+	})
+
+	t.Run("denied imds", func(t *testing.T) {
+		err := g.DialControl("tcp", "169.254.169.254:80", nil)
+		require.Error(t, err)
+		var de *DenyError
+		require.ErrorAs(t, err, &de)
+		require.Equal(t, "169.254.169.254", de.Address)
+	})
+
+	t.Run("allowed ipv4", func(t *testing.T) {
+		require.NoError(t, g.DialControl("tcp", "8.8.8.8:443", nil))
+	})
+
+	t.Run("4-in-6 mapped denied", func(t *testing.T) {
+		err := g.DialControl("tcp", "[::ffff:127.0.0.1]:443", nil)
+		require.Error(t, err)
+		require.True(t, IsDenyError(err))
+	})
+
+	t.Run("malformed address allowed", func(t *testing.T) {
+		// Not our job to reject malformed addresses — Go's connect will fail.
+		require.NoError(t, g.DialControl("tcp", "not-an-address", nil))
+	})
+}
+
+func TestDialControl_EmptyGuardNoop(t *testing.T) {
+	g, err := New(nil)
+	require.NoError(t, err)
+	require.NoError(t, g.DialControl("tcp", "127.0.0.1:443", nil))
+}
+
+func TestDialControl_NilGuardNoop(t *testing.T) {
+	var g *Guard
+	require.NoError(t, g.DialControl("tcp", "127.0.0.1:443", nil))
+}

--- a/internal/proxy/dnsguard_test.go
+++ b/internal/proxy/dnsguard_test.go
@@ -1,0 +1,187 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
+)
+
+// TestUpstreamDenyGuard_HTTP confirms the HTTP/HTTPS transport's dialer
+// rejects upstream connections whose resolved address falls inside a denied
+// CIDR. The allowlist is permissive ("*"), so the only thing that can stop
+// the request is the dial-time guard.
+func TestUpstreamDenyGuard_HTTP(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "from upstream")
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+
+	build := func(t *testing.T, denyCIDRs []string) (proxyHTTPAddr string, audits func() []transform.PipelineResult) {
+		t.Helper()
+		al, err := allowlist.New([]string{"*"}, nil, &staticResolver{})
+		require.NoError(t, err)
+		pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+		var mu sync.Mutex
+		var results []transform.PipelineResult
+		pipeline.SetAuditFunc(func(r *transform.PipelineResult) {
+			mu.Lock()
+			results = append(results, *r)
+			mu.Unlock()
+		})
+
+		guard, err := dnsguard.New(denyCIDRs)
+		require.NoError(t, err)
+
+		p := New(Options{
+			HTTPAddr: "127.0.0.1:0",
+			Pipeline: transform.NewPipelineHolder(pipeline),
+			Guard:    guard,
+			Logger:   logger,
+		})
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		go func() { _ = p.httpServer.Serve(ln) }()
+		t.Cleanup(func() { _ = p.httpServer.Close() })
+
+		return ln.Addr().String(), func() []transform.PipelineResult {
+			mu.Lock()
+			defer mu.Unlock()
+			out := make([]transform.PipelineResult, len(results))
+			copy(out, results)
+			return out
+		}
+	}
+
+	t.Run("denied loopback returns 502", func(t *testing.T) {
+		proxyAddr, _ := build(t, []string{"127.0.0.0/8"})
+		client := &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: proxyAddr}),
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		resp, err := client.Get(upstream.URL + "/test")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	})
+
+	t.Run("empty deny list permits", func(t *testing.T) {
+		proxyAddr, _ := build(t, nil)
+		client := &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: proxyAddr}),
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		resp, err := client.Get(upstream.URL + "/test")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		require.Equal(t, "from upstream", string(body))
+	})
+
+	t.Run("guard records audit with err", func(t *testing.T) {
+		proxyAddr, audits := build(t, []string{"127.0.0.0/8"})
+		client := &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: proxyAddr}),
+			},
+			Timeout: 5 * time.Second,
+		}
+
+		resp, err := client.Get(upstream.URL + "/test")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		records := audits()
+		require.Len(t, records, 1)
+		require.NotNil(t, records[0].Err)
+		require.True(t, dnsguard.IsDenyError(records[0].Err))
+	})
+
+	// Sanity: confirm we actually hit the dial path. The upstream listener
+	// must be on loopback for the deny test to be meaningful.
+	require.Equal(t, "127.0.0.1", upstreamURL.Hostname())
+}
+
+// TestUpstreamDenyGuard_SNIPassthrough confirms the sni-only dial path also
+// honors the guard.
+func TestUpstreamDenyGuard_SNIPassthrough(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	upstreamAddr, _ := startEchoTLSServer(t)
+	_, upstreamPort, err := net.SplitHostPort(upstreamAddr)
+	require.NoError(t, err)
+
+	al, err := allowlist.New([]string{"*"}, nil, &staticResolver{hosts: sniTestHosts})
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	guard, err := dnsguard.New([]string{"127.0.0.0/8"})
+	require.NoError(t, err)
+
+	p := New(Options{
+		HTTPSAddr: "127.0.0.1:0",
+		TLSMode:   "sni-only",
+		Pipeline:  transform.NewPipelineHolder(pipeline),
+		Guard:     guard,
+		Logger:    logger,
+	})
+	p.sniUpstreamPort = upstreamPort
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleSNIPassthrough(conn)
+		}
+	}()
+
+	// Connect raw TCP, send a TLS ClientHello with SNI=localhost. The dialer
+	// will resolve localhost → 127.0.0.1 and the guard will refuse.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         "localhost",
+		InsecureSkipVerify: true,
+	})
+	defer tlsConn.Close()
+
+	// Handshake should fail because the proxy refuses to dial upstream and
+	// closes the connection.
+	require.Error(t, tlsConn.HandshakeContext(context.Background()))
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
 	"github.com/ironsh/iron-proxy/internal/config"
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -40,6 +41,7 @@ type Proxy struct {
 	pipeline       *transform.PipelineHolder
 	transport      *http.Transport
 	resolver       *net.Resolver
+	guard          *dnsguard.Guard
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -62,6 +64,7 @@ type Options struct {
 	CertCache  *certcache.Cache // required when TLSMode == config.TLSModeMITM
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
+	Guard      *dnsguard.Guard // nil is treated as an empty (no-op) guard
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -76,6 +79,10 @@ func New(opts Options) *Proxy {
 		opts.TLSMode = config.TLSModeMITM
 	}
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	guard := opts.Guard
+	if guard == nil {
+		guard, _ = dnsguard.New(nil)
+	}
 	p := &Proxy{
 		httpsAddr:      opts.HTTPSAddr,
 		tlsMode:        opts.TLSMode,
@@ -83,8 +90,9 @@ func New(opts Options) *Proxy {
 		tunnelDone:     make(chan struct{}),
 		certCache:      opts.CertCache,
 		pipeline:       opts.Pipeline,
-		transport:      buildTransport(opts.Resolver, opts.UpstreamResponseHeaderTimeout),
+		transport:      buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout),
 		resolver:       opts.Resolver,
+		guard:          guard,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -395,14 +403,19 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 		}
 	}
 
+	dialer := &net.Dialer{
+		Timeout:  30 * time.Second,
+		Resolver: p.resolver,
+		Control:  p.guard.DialControl,
+	}
 	if upstreamScheme == "wss" {
 		upstreamConn, err = tls.DialWithDialer(
-			&net.Dialer{Timeout: 30 * time.Second},
+			dialer,
 			"tcp", upstreamHost,
 			&tls.Config{MinVersion: tls.VersionTLS12},
 		)
 	} else {
-		upstreamConn, err = net.DialTimeout("tcp", upstreamHost, 30*time.Second)
+		upstreamConn, err = dialer.DialContext(r.Context(), "tcp", upstreamHost)
 	}
 	if err != nil {
 		p.logger.Error("websocket upstream dial failed",
@@ -537,13 +550,16 @@ func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 // buildTransport creates the HTTP transport used for upstream requests.
 // If resolver is non-nil, the transport's dialer uses it instead of the OS
 // default — this prevents resolution loops when iron-proxy owns the system DNS.
+// guard's DialControl is wired in so a hostname that resolves to a denied IP
+// is rejected before the TCP connect.
 // responseHeaderTimeout overrides the default 30-second
 // ResponseHeaderTimeout when greater than zero; pass 0 to keep the default.
-func buildTransport(resolver *net.Resolver, responseHeaderTimeout time.Duration) *http.Transport {
+func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeaderTimeout time.Duration) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Resolver:  resolver,
+		Control:   guard.DialControl,
 	}
 	if responseHeaderTimeout <= 0 {
 		responseHeaderTimeout = config.DefaultUpstreamResponseHeaderTimeout

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -99,9 +99,11 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 
 	// Dial upstream using the proxy's resolver so SNI → IP lookup goes via
 	// the configured upstream DNS (not the proxy's own intercepting server).
+	// The guard's DialControl rejects denied IPs after resolution.
 	dialer := &net.Dialer{
 		Timeout:  sniUpstreamDial,
 		Resolver: p.resolver,
+		Control:  p.guard.DialControl,
 	}
 	port := p.sniUpstreamPort
 	if port == "" {

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -32,6 +32,25 @@ proxy:
   # Bump this for upstream endpoints that legitimately take longer than 30s
   # to begin replying (e.g. LLM context-compaction endpoints).
   # upstream_response_header_timeout: "5m"
+  #
+  # CIDRs the proxy refuses to dial upstream. Enforced at TCP connect time
+  # against the resolved address — defeats DNS rebinding and TOCTOU between
+  # allowlist evaluation and the eventual connect. CIDR notation is required
+  # (bare IPs are rejected).
+  #
+  # When this key is omitted, a secure default is applied that blocks cloud
+  # instance metadata (IMDS) and loopback:
+  #   - 169.254.169.254/32   AWS / GCP / Azure IPv4 IMDS
+  #   - fd00:ec2::254/128    AWS IPv6 IMDS
+  #   - 127.0.0.0/8          IPv4 loopback
+  #   - ::1/128              IPv6 loopback
+  #
+  # Set an explicit list to override the defaults. Use an empty list
+  # (upstream_deny_cidrs: []) if you intentionally need to allow IMDS or
+  # loopback traffic to upstreams.
+  # upstream_deny_cidrs:
+  #   - "169.254.169.254/32"
+  #   - "127.0.0.0/8"
 
 # TLS / MITM configuration
 tls:


### PR DESCRIPTION
Adds `proxy.upstream_deny_cidrs`, enforced via `net.Dialer.Control` after DNS resolution so a hostname that resolves into a denied range (e.g. via DNS rebinding or a permissive allowlist) is refused before the TCP connect. Applies to the HTTP/HTTPS transport, SNI passthrough, and the WebSocket upgrade dial — the WebSocket path previously bypassed the proxy resolver entirely and is now consistent with the others. Defaults block IMDS (`169.254.169.254`, `fd00:ec2::254`) and loopback; set the key to `[]` to opt out, or supply your own list to override. CIDR notation is required at config validation time.