### PR TITLE
refactor(controlplane): remove tags from registration

### DIFF
--- a/cmd/iron-proxy/init.go
+++ b/cmd/iron-proxy/init.go
@@ -28,7 +28,6 @@ func runInit(args []string) {
 	proxyIP := fs.String("proxy-ip", "127.0.0.1", "IP address the DNS server returns for proxied domains")
 	allow := fs.String("allow", defaultAllowList, "comma-separated domains for the initial allowlist")
 	enrollmentToken := fs.String("enrollment-token", "", "enrollment token for control plane registration (managed mode)")
-	tags := fs.String("tags", "", "comma-separated tags for control plane registration (managed mode)")
 	noStart := fs.Bool("no-start", false, "generate config and unit file but don't start the service")
 	force := fs.Bool("force", false, "overwrite existing config and CA")
 	if err := fs.Parse(args); err != nil {
@@ -82,13 +81,12 @@ func runInit(args []string) {
 
 	// 2. Write default config.
 	managedMode := *enrollmentToken != ""
-	tagList := splitCommaList(*tags)
 	var configYAML string
 	if managedMode {
-		configYAML = generateManagedConfig(*configDir, *tunnelPort, *proxyIP, tagList)
+		configYAML = generateManagedConfig(*configDir, *tunnelPort, *proxyIP)
 	} else {
 		domains := splitCommaList(*allow)
-		configYAML = generateConfig(*configDir, *tunnelPort, *proxyIP, domains, tagList)
+		configYAML = generateConfig(*configDir, *tunnelPort, *proxyIP, domains)
 	}
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing config: %v\n", err)
@@ -172,7 +170,7 @@ func splitCommaList(s string) []string {
 
 // generateManagedConfig produces a YAML config for managed mode. It omits the
 // transforms section since transforms come from the control plane.
-func generateManagedConfig(configDir, tunnelPort, proxyIP string, tags []string) string {
+func generateManagedConfig(configDir, tunnelPort, proxyIP string) string {
 	return fmt.Sprintf(`proxy:
   http_listen: ":8080"
   https_listen: ":8443"
@@ -185,13 +183,13 @@ dns:
 tls:
   ca_cert: "%s/ca.crt"
   ca_key: "%s/ca.key"
-%s
+
 log:
   level: "info"
-`, tunnelPort, proxyIP, configDir, configDir, formatTags(tags))
+`, tunnelPort, proxyIP, configDir, configDir)
 }
 
-func generateConfig(configDir, tunnelPort, proxyIP string, domains []string, tags []string) string {
+func generateConfig(configDir, tunnelPort, proxyIP string, domains []string) string {
 	var domainLines string
 	for _, d := range domains {
 		domainLines += fmt.Sprintf("        - %q\n", d)
@@ -214,22 +212,10 @@ transforms:
   - name: allowlist
     config:
       domains:
-%s%s
+%s
 log:
   level: "info"
-`, tunnelPort, proxyIP, configDir, configDir, domainLines, formatTags(tags))
-}
-
-func formatTags(tags []string) string {
-	if len(tags) == 0 {
-		return ""
-	}
-	var s string
-	s += "\ntags:\n"
-	for _, t := range tags {
-		s += fmt.Sprintf("  - %q\n", t)
-	}
-	return s
+`, tunnelPort, proxyIP, configDir, configDir, domainLines)
 }
 
 func generateSystemdUnit(execPath, configPath, enrollmentToken string) string {

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	if managed {
 		var ingestToken string
-		holder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, stateStore, enrollmentToken, cred, logger)
+		holder, ingestToken = initManaged(ctx, bodyLimits, errc, stateStore, enrollmentToken, cred, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -261,9 +261,8 @@ func main() {
 // the initial pipeline, and starts the config poller. The poller runs until ctx
 // is canceled and sends fatal errors on errc. Returns the pipeline holder and
 // the ingest token from the initial sync (empty if the sync failed).
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, enrollmentToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
+func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, enrollmentToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
-	tags := cfg.Tags
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
 	client := controlplane.NewClient(cpURL, logger)
@@ -273,7 +272,6 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		logger.Info("registering with control plane")
 		var regErr error
 		cred, regErr = client.Register(ctx, enrollmentToken, controlplane.RegisterMetadata{
-			Tags:    tags,
 			Version: version,
 		})
 		if regErr != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,7 +46,6 @@ type Config struct {
 	Transforms []Transform `yaml:"transforms"`
 	Metrics    Metrics     `yaml:"metrics"`
 	Log        Log         `yaml:"log"`
-	Tags       []string    `yaml:"tags"`
 }
 
 // DNS configures the built-in DNS server.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -43,16 +42,6 @@ func applyEnvOverrides(cfg *Config) error {
 	}
 	if v := os.Getenv("IRON_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
-	}
-	if v := os.Getenv("IRON_TAGS"); v != "" {
-		tags := make([]string, 0)
-		for _, t := range strings.Split(v, ",") {
-			t = strings.TrimSpace(t)
-			if t != "" {
-				tags = append(tags, t)
-			}
-		}
-		cfg.Tags = tags
 	}
 
 	if v := os.Getenv("IRON_PROXY_MAX_REQUEST_BODY_BYTES"); v != "" {

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -36,7 +36,6 @@ type Client struct {
 
 // RegisterMetadata contains information sent during registration.
 type RegisterMetadata struct {
-	Tags    []string
 	Version string
 }
 
@@ -68,11 +67,10 @@ func (c *Client) GetCredential() *Credential {
 }
 
 type registerRequest struct {
-	EnrollmentToken string   `json:"enrollment_token"`
-	Tags            []string `json:"tags"`
-	Hostname        string   `json:"hostname"`
-	Version         string   `json:"version"`
-	Platform        string   `json:"platform"`
+	EnrollmentToken string `json:"enrollment_token"`
+	Hostname        string `json:"hostname"`
+	Version         string `json:"version"`
+	Platform        string `json:"platform"`
 }
 
 type registerResponse struct {
@@ -93,13 +91,9 @@ func (c *Client) register(ctx context.Context, token string, meta RegisterMetada
 
 	body := registerRequest{
 		EnrollmentToken: token,
-		Tags:            meta.Tags,
 		Hostname:        hostname,
 		Version:         meta.Version,
 		Platform:        detectPlatform(),
-	}
-	if body.Tags == nil {
-		body.Tags = []string{}
 	}
 
 	data, err := json.Marshal(body)

--- a/internal/controlplane/client_test.go
+++ b/internal/controlplane/client_test.go
@@ -35,7 +35,6 @@ func TestRegisterSuccess(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&body)
 		require.NoError(t, err)
 		require.Equal(t, "irbs_test123", body.EnrollmentToken)
-		require.Equal(t, []string{"ci", "prod"}, body.Tags)
 		require.Equal(t, "1.0.0", body.Version)
 
 		w.WriteHeader(http.StatusCreated)
@@ -48,7 +47,6 @@ func TestRegisterSuccess(t *testing.T) {
 
 	client := NewClient(server.URL, testLogger())
 	cred, err := client.Register(context.Background(), "irbs_test123", RegisterMetadata{
-		Tags:    []string{"ci", "prod"},
 		Version: "1.0.0",
 	})
 	require.NoError(t, err)
@@ -86,22 +84,6 @@ func TestRegisterExhaustedToken(t *testing.T) {
 	var apiErr *APIError
 	require.ErrorAs(t, err, &apiErr)
 	require.Equal(t, ErrTokenExhausted, apiErr.Code)
-}
-
-func TestRegisterLabelNotPermitted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_ = json.NewEncoder(w).Encode(apiError("tag_not_permitted", "tag 'admin' is not allowed"))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, testLogger())
-	_, err := client.Register(context.Background(), "irbs_test", RegisterMetadata{Tags: []string{"admin"}})
-
-	var apiErr *APIError
-	require.ErrorAs(t, err, &apiErr)
-	require.Equal(t, ErrTagNotPermitted, apiErr.Code)
-	require.Contains(t, apiErr.Detail, "admin")
 }
 
 func TestRegisterRateLimitedThenSuccess(t *testing.T) {

--- a/internal/controlplane/errors.go
+++ b/internal/controlplane/errors.go
@@ -7,13 +7,12 @@ import "fmt"
 type ErrorCode string
 
 const (
-	ErrInvalidToken    ErrorCode = "invalid_token"
-	ErrTokenExpired    ErrorCode = "token_expired"
-	ErrTokenExhausted  ErrorCode = "token_exhausted"
-	ErrTagNotPermitted ErrorCode = "tag_not_permitted"
-	ErrValidationFail  ErrorCode = "validation_failed"
-	ErrProxyRevoked    ErrorCode = "proxy_revoked"
-	ErrHMACFailure     ErrorCode = "hmac_failure"
+	ErrInvalidToken   ErrorCode = "invalid_token"
+	ErrTokenExpired   ErrorCode = "token_expired"
+	ErrTokenExhausted ErrorCode = "token_exhausted"
+	ErrValidationFail ErrorCode = "validation_failed"
+	ErrProxyRevoked   ErrorCode = "proxy_revoked"
+	ErrHMACFailure    ErrorCode = "hmac_failure"
 )
 
 // APIError is a typed error returned by the control plane API.


### PR DESCRIPTION
Drops the `iron-proxy init -tags` flag, the `IRON_TAGS` env override, the `Config.Tags` YAML field, and the `tags` field from the control plane register request payload (plus the `tag_not_permitted` error code that's no longer reachable).