### PR TITLE
feat(secrets): add 1Password secret source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
 
 archives:
   - formats: ["tar.gz"]

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ transforms:
 The sandbox never holds real credentials. Instead:
 
 1. Configure iron-proxy with the real secret source: environment variables,
-   AWS Secrets Manager, or AWS Systems Manager Parameter Store.
+   AWS Secrets Manager, AWS Systems Manager Parameter Store, or 1Password.
 2. Give the sandbox a proxy token (e.g., `proxy-openai-abc123`).
 3. Configure the `secrets` transform to map proxy tokens to those sources.
 
@@ -346,6 +346,10 @@ Secret sources:
   `region`, `with_decryption`, `json_key`, and `ttl` are supported.
   `with_decryption` defaults to `true`, which is the expected setting for
   `SecureString` parameters.
+- **`1password`:** resolves `secret_ref` (an `op://vault/item/[section/]field`
+  reference) using a 1Password service account token. The token is read from
+  `OP_SERVICE_ACCOUNT_TOKEN` by default; override with `token_env`. Optional
+  `ttl` is supported.
 
 ### Judge
 

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -24,6 +24,7 @@ import (
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/proxy"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/version"
 
 	// Register built-in transforms.
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
@@ -32,9 +33,6 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
-
-// version is set at build time via -ldflags.
-var version = "dev"
 
 func main() {
 	if len(os.Args) > 1 {
@@ -46,7 +44,7 @@ func main() {
 			runInit(os.Args[2:])
 			return
 		case "version", "--version", "-v":
-			fmt.Println(version)
+			fmt.Println(version.Version)
 			return
 		}
 	}
@@ -272,7 +270,7 @@ func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan
 		logger.Info("registering with control plane")
 		var regErr error
 		cred, regErr = client.Register(ctx, enrollmentToken, controlplane.RegisterMetadata{
-			Version: version,
+			Version: version.Version,
 		})
 		if regErr != nil {
 			logger.Error("registration failed", slog.String("error", regErr.Error()))

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ironsh/iron-proxy
 go 1.26.1
 
 require (
+	github.com/1password/onepassword-sdk-go v0.4.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
@@ -41,11 +42,17 @@ require (
 	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1 // indirect
+	github.com/extism/go-sdk v1.7.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
+	github.com/tetratelabs/wazero v1.11.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/1password/onepassword-sdk-go v0.4.0 h1:Nou39yuC6Q0om03irkh5UurfPdX3wx26qZZhQeC9TBU=
+github.com/1password/onepassword-sdk-go v0.4.0/go.mod h1:j/CbzhucTywjlYrd6SE6k0LcQaFZ2l8OLBsAsOYtvD0=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
@@ -44,11 +46,17 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1 h1:idfl8M8rPW93NehFw5H1qqH8yG158t5POr+LX9avbJY=
+github.com/dylibso/observe-sdk/go v0.0.0-20240828172851-9145d8ad07e1/go.mod h1:C8DzXehI4zAbrdlbtOByKX6pfivJTBiV9Jjqv56Yd9Q=
+github.com/extism/go-sdk v1.7.1 h1:lWJos6uY+tRFdlIHR+SJjwFDApY7OypS/2nMhiVQ9Sw=
+github.com/extism/go-sdk v1.7.1/go.mod h1:IT+Xdg5AZM9hVtpFUA+uZCJMge/hbvshl8bwzLtFyKA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -59,6 +67,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f h1:Fnl4pzx8SR7k7JuzyW8lEtSFH6EQ8xgcypgIn8pcGIE=
+github.com/ianlancetaylor/demangle v0.0.0-20251118225945-96ee0021ea0f/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -71,6 +81,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZjBaFj3HgFonKXUcwgJ4djLb6i42S3Q=
+github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
+github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
+github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/internal/transform/secrets/op_resolver.go
+++ b/internal/transform/secrets/op_resolver.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	onepassword "github.com/1password/onepassword-sdk-go"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/version"
+)
+
+// defaultOPTokenEnv is the conventional environment variable for 1Password
+// service account tokens, matching the SDK's own examples.
+const defaultOPTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
+
+// opClient is the subset of the 1Password SDK used by opResolver, narrowed for testability.
+type opClient interface {
+	Resolve(ctx context.Context, ref string) (string, error)
+}
+
+// opResolver reads secrets from 1Password using a service account token.
+type opResolver struct {
+	clientFor func(ctx context.Context, tokenEnv string) (opClient, error)
+	logger    *slog.Logger
+}
+
+type opConfig struct {
+	Type      string `yaml:"type"`
+	SecretRef string `yaml:"secret_ref"`
+	TokenEnv  string `yaml:"token_env,omitempty"`
+	TTL       string `yaml:"ttl,omitempty"`
+}
+
+func newOPResolver(logger *slog.Logger) *opResolver {
+	cache := &opClientCache{
+		clients: make(map[string]opClient),
+		getenv:  os.Getenv,
+		newClient: func(ctx context.Context, token string) (opClient, error) {
+			c, err := onepassword.NewClient(ctx,
+				onepassword.WithServiceAccountToken(token),
+				onepassword.WithIntegrationInfo("iron-proxy", version.Version),
+			)
+			if err != nil {
+				return nil, err
+			}
+			return opSDKClient{c: c}, nil
+		},
+	}
+	return &opResolver{clientFor: cache.get, logger: logger}
+}
+
+func (r *opResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+	var cfg opConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing 1password source config: %w", err)
+	}
+	if cfg.SecretRef == "" {
+		return ResolveResult{}, fmt.Errorf("1password source requires \"secret_ref\" field")
+	}
+	if !strings.HasPrefix(cfg.SecretRef, "op://") {
+		return ResolveResult{}, fmt.Errorf("1password secret_ref %q must start with \"op://\"", cfg.SecretRef)
+	}
+	if cfg.TokenEnv == "" {
+		cfg.TokenEnv = defaultOPTokenEnv
+	}
+
+	val, err := r.fetchSecret(ctx, cfg)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+
+	return resolveWithTTL(cfg.SecretRef, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+		return r.fetchSecret(ctx, cfg)
+	})
+}
+
+func (r *opResolver) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {
+	client, err := r.clientFor(ctx, cfg.TokenEnv)
+	if err != nil {
+		return "", fmt.Errorf("creating 1password client: %w", err)
+	}
+	val, err := client.Resolve(ctx, cfg.SecretRef)
+	if err != nil {
+		return "", fmt.Errorf("resolving 1password secret %q: %w", cfg.SecretRef, err)
+	}
+	if val == "" {
+		return "", fmt.Errorf("1password secret %q resolved to empty value", cfg.SecretRef)
+	}
+	return val, nil
+}
+
+// opClientCache caches one SDK client per token-env-name. The 1P SDK loads a
+// Wasm module on NewClient, so reusing the client across multiple secret
+// entries is significantly cheaper than creating one per entry.
+type opClientCache struct {
+	mu        sync.Mutex
+	clients   map[string]opClient
+	getenv    func(string) string
+	newClient func(ctx context.Context, token string) (opClient, error)
+}
+
+func (c *opClientCache) get(ctx context.Context, tokenEnv string) (opClient, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if client, ok := c.clients[tokenEnv]; ok {
+		return client, nil
+	}
+	token := c.getenv(tokenEnv)
+	if token == "" {
+		return nil, fmt.Errorf("env var %q is not set or empty", tokenEnv)
+	}
+	client, err := c.newClient(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	c.clients[tokenEnv] = client
+	return client, nil
+}
+
+// opSDKClient adapts the 1Password SDK *Client to the opClient interface.
+type opSDKClient struct{ c *onepassword.Client }
+
+func (a opSDKClient) Resolve(ctx context.Context, ref string) (string, error) {
+	return a.c.Secrets().Resolve(ctx, ref)
+}

--- a/internal/transform/secrets/op_resolver_test.go
+++ b/internal/transform/secrets/op_resolver_test.go
@@ -1,0 +1,234 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockOPClient is a configurable mock for the 1Password SDK client.
+type mockOPClient struct {
+	fn func(ctx context.Context, ref string) (string, error)
+}
+
+func (m *mockOPClient) Resolve(ctx context.Context, ref string) (string, error) {
+	return m.fn(ctx, ref)
+}
+
+// staticOPClient returns an opClient that always returns the given value/error.
+func staticOPClient(value string, err error) *mockOPClient {
+	return &mockOPClient{fn: func(_ context.Context, _ string) (string, error) {
+		return value, err
+	}}
+}
+
+func newTestOPResolver(client opClient) *opResolver {
+	return &opResolver{
+		clientFor: func(_ context.Context, _ string) (opClient, error) {
+			return client, nil
+		},
+		logger: slog.Default(),
+	}
+}
+
+func TestOPResolver_HappyPath_DefaultTokenEnv(t *testing.T) {
+	var gotEnv string
+	r := &opResolver{
+		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
+			gotEnv = tokenEnv
+			return staticOPClient("real-secret", nil), nil
+		},
+		logger: slog.Default(),
+	}
+
+	node := yamlNode(t, map[string]string{
+		"type":       "1password",
+		"secret_ref": "op://Engineering/OpenAI/credential",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "op://Engineering/OpenAI/credential", result.Name)
+	require.Equal(t, "OP_SERVICE_ACCOUNT_TOKEN", gotEnv)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "real-secret", val)
+}
+
+func TestOPResolver_HappyPath_CustomTokenEnv(t *testing.T) {
+	var gotEnv string
+	r := &opResolver{
+		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
+			gotEnv = tokenEnv
+			return staticOPClient("custom-token-secret", nil), nil
+		},
+		logger: slog.Default(),
+	}
+
+	node := yamlNode(t, map[string]string{
+		"type":       "1password",
+		"secret_ref": "op://Engineering/OpenAI/credential",
+		"token_env":  "CUSTOM_OP_TOKEN",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "CUSTOM_OP_TOKEN", gotEnv)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "custom-token-secret", val)
+}
+
+func TestOPResolver_TTLReturnsCachedValue(t *testing.T) {
+	r := newTestOPResolver(staticOPClient("value", nil))
+	node := yamlNode(t, map[string]string{
+		"type":       "1password",
+		"secret_ref": "op://Engineering/OpenAI/credential",
+		"ttl":        "15m",
+	})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+
+	val, err := result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}
+
+func TestOPResolver_PassesSecretRefToClient(t *testing.T) {
+	var gotRef string
+	client := &mockOPClient{fn: func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return "v", nil
+	}}
+	r := newTestOPResolver(client)
+	node := yamlNode(t, map[string]string{
+		"type":       "1password",
+		"secret_ref": "op://vault/item/section/field",
+	})
+	_, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, "op://vault/item/section/field", gotRef)
+}
+
+func TestOPResolver_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *mockOPClient
+		input  map[string]string
+		errMsg string
+	}{
+		{
+			name:   "missing secret_ref",
+			client: staticOPClient("", nil),
+			input:  map[string]string{"type": "1password"},
+			errMsg: "\"secret_ref\" field",
+		},
+		{
+			name:   "secret_ref without op:// prefix",
+			client: staticOPClient("", nil),
+			input:  map[string]string{"type": "1password", "secret_ref": "vault/item/field"},
+			errMsg: "must start with \"op://\"",
+		},
+		{
+			name:   "sdk error",
+			client: staticOPClient("", fmt.Errorf("vault not found")),
+			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
+			errMsg: "vault not found",
+		},
+		{
+			name:   "empty secret value",
+			client: staticOPClient("", nil),
+			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
+			errMsg: "empty value",
+		},
+		{
+			name:   "invalid ttl",
+			client: staticOPClient("v", nil),
+			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestOPResolver(tt.client)
+			node := yamlNode(t, tt.input)
+			_, err := r.Resolve(context.Background(), node)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// --- opClientCache tests ---
+
+func TestOPClientCache_ReadsTokenFromEnv(t *testing.T) {
+	var gotToken string
+	cache := &opClientCache{
+		clients: make(map[string]opClient),
+		getenv: func(key string) string {
+			if key == "MY_OP_TOKEN" {
+				return "ops_secret_value"
+			}
+			return ""
+		},
+		newClient: func(_ context.Context, token string) (opClient, error) {
+			gotToken = token
+			return staticOPClient("v", nil), nil
+		},
+	}
+
+	_, err := cache.get(context.Background(), "MY_OP_TOKEN")
+	require.NoError(t, err)
+	require.Equal(t, "ops_secret_value", gotToken)
+}
+
+func TestOPClientCache_ErrorOnMissingEnvVar(t *testing.T) {
+	cache := &opClientCache{
+		clients:   make(map[string]opClient),
+		getenv:    func(string) string { return "" },
+		newClient: func(_ context.Context, _ string) (opClient, error) { return nil, nil },
+	}
+
+	_, err := cache.get(context.Background(), "MISSING_OP_TOKEN")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not set or empty")
+}
+
+func TestOPClientCache_ReusesClientPerTokenEnv(t *testing.T) {
+	calls := 0
+	cache := &opClientCache{
+		clients: make(map[string]opClient),
+		getenv:  func(string) string { return "tok" },
+		newClient: func(_ context.Context, _ string) (opClient, error) {
+			calls++
+			return staticOPClient("v", nil), nil
+		},
+	}
+
+	_, err := cache.get(context.Background(), "ENV1")
+	require.NoError(t, err)
+	_, err = cache.get(context.Background(), "ENV1")
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "second get on the same token_env should reuse the cached client")
+
+	_, err = cache.get(context.Background(), "ENV2")
+	require.NoError(t, err)
+	require.Equal(t, 2, calls, "different token_env should create a new client")
+}
+
+func TestOPClientCache_PropagatesNewClientError(t *testing.T) {
+	cache := &opClientCache{
+		clients: make(map[string]opClient),
+		getenv:  func(string) string { return "tok" },
+		newClient: func(_ context.Context, _ string) (opClient, error) {
+			return nil, fmt.Errorf("sdk init failed")
+		},
+	}
+
+	_, err := cache.get(context.Background(), "ENV")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sdk init failed")
+}

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -100,9 +100,10 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
 	registry := resolverRegistry{
-		"env":     newEnvResolver(),
-		"aws_sm":  newAWSSMResolver(logger),
-		"aws_ssm": newAWSSSMResolver(logger),
+		"env":       newEnvResolver(),
+		"aws_sm":    newAWSSMResolver(logger),
+		"aws_ssm":   newAWSSSMResolver(logger),
+		"1password": newOPResolver(logger),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,6 @@
+// Package version exposes the iron-proxy build version.
+package version
+
+// Version is the iron-proxy build version. It is overridden at link time via
+// -ldflags "-X github.com/ironsh/iron-proxy/internal/version.Version=...".
+var Version = "dev"

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -186,6 +186,20 @@ transforms:
         #   rules:
         #     - host: "api.example.com"
 
+        # Replace mode with 1Password (service account token auth). The token
+        # is read from the OP_SERVICE_ACCOUNT_TOKEN env var by default; override
+        # with token_env. secret_ref uses 1Password's secret reference syntax.
+        # - source:
+        #     type: 1password
+        #     secret_ref: "op://Engineering/OpenAI/credential"
+        #     token_env: OP_SERVICE_ACCOUNT_TOKEN  # optional; this is the default
+        #     ttl: "15m"                            # optional, re-fetch interval; 0 = no refresh
+        #   replace:
+        #     proxy_value: "proxy-token-1p"
+        #     match_headers: ["Authorization"]
+        #   rules:
+        #     - host: "api.openai.com"
+
         # Legacy replace mode (top-level fields, still supported):
         # - source:
         #     type: env


### PR DESCRIPTION
Adds a `1password` resolver to the secrets transform, backed by the 1Password Go SDK with service-account-token auth (no CGO). Token is read from `OP_SERVICE_ACCOUNT_TOKEN` by default or a configurable `token_env`, and `secret_ref` uses the standard `op://vault/item/[section/]field` syntax. The existing TTL helper handles refresh and stale-on-error semantics, matching the AWS resolvers.

The build version is moved into a dedicated `internal/version` package so the resolver can pass it to `WithIntegrationInfo` directly. Goreleaser's `-X` ldflag target is updated to the new package path.