### PR TITLE
feat(management): add /reload management API

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/controlplane"
 	idns "github.com/ironsh/iron-proxy/internal/dns"
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/ironsh/iron-proxy/internal/management"
 	"github.com/ironsh/iron-proxy/internal/metrics"
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/proxy"
@@ -89,6 +90,17 @@ func main() {
 	}
 	managed := enrollmentToken != "" || cred != nil
 
+	if cfg.Management.Listen != "" {
+		if managed {
+			fmt.Fprintln(os.Stderr, "error: management.listen cannot be used with managed mode; the control plane is the source of truth")
+			os.Exit(1)
+		}
+		if *configPath == "" {
+			fmt.Fprintln(os.Stderr, "error: management.listen requires --config; /reload has no file to re-read")
+			os.Exit(1)
+		}
+	}
+
 	// Both modes produce a pipeline holder. Managed mode populates the
 	// initial transforms from the control plane and starts a poller that
 	// hot-reloads the pipeline.
@@ -99,7 +111,7 @@ func main() {
 
 	// errc collects fatal errors from all background goroutines: servers
 	// and (in managed mode) the config poller.
-	errc := make(chan error, 4)
+	errc := make(chan error, 5)
 	var holder *transform.PipelineHolder
 	var otelCfg iotel.ExportConfig
 
@@ -201,10 +213,24 @@ func main() {
 	// Initialize metrics server.
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)
 
+	// Initialize management server (standalone mode only; guarded above).
+	var mgmtServer *management.Server
+	if cfg.Management.Listen != "" {
+		mgmtServer = management.New(management.Options{
+			Addr:   cfg.Management.Listen,
+			APIKey: os.Getenv(cfg.Management.APIKeyEnv),
+			Reload: newReloadFunc(*configPath, holder, bodyLimits, logger),
+			Logger: logger,
+		})
+	}
+
 	// Start services.
 	go func() { errc <- fmt.Errorf("dns: %w", dnsServer.ListenAndServe()) }()
 	go func() { errc <- fmt.Errorf("proxy: %w", p.ListenAndServe()) }()
 	go func() { errc <- fmt.Errorf("metrics: %w", metricsServer.ListenAndServe()) }()
+	if mgmtServer != nil {
+		go func() { errc <- fmt.Errorf("management: %w", mgmtServer.ListenAndServe()) }()
+	}
 
 	startAttrs := []any{
 		slog.String("dns_listen", cfg.DNS.Listen),
@@ -250,6 +276,11 @@ func main() {
 	}
 	if err := metricsServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("metrics server shutdown error", slog.String("error", err.Error()))
+	}
+	if mgmtServer != nil {
+		if err := mgmtServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("management server shutdown error", slog.String("error", err.Error()))
+		}
 	}
 
 	logger.Info("iron-proxy stopped")
@@ -395,6 +426,30 @@ func applyPipelineSync(holder *transform.PipelineHolder, bodyLimits transform.Bo
 	newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 	holder.Store(newPipeline)
 	logger.Info("pipeline reloaded", slog.String("transforms", newPipeline.Names()))
+}
+
+// newReloadFunc returns a management.ReloadFunc that re-reads the YAML config
+// from configPath, rebuilds the pipeline, and atomically swaps it in. Parse,
+// validation, and pipeline-build errors are wrapped in *management.ValidationError
+// so the management server returns 422; the existing pipeline is preserved.
+func newReloadFunc(configPath string, holder *transform.PipelineHolder, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
+	return func() error {
+		newCfg, err := config.LoadConfig(configPath)
+		if err != nil {
+			return &management.ValidationError{Err: err}
+		}
+		if err := config.Validate(newCfg); err != nil {
+			return &management.ValidationError{Err: err}
+		}
+		newPipeline, err := buildPipeline(newCfg.Transforms, bodyLimits, logger)
+		if err != nil {
+			return &management.ValidationError{Err: err}
+		}
+		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
+		holder.Store(newPipeline)
+		logger.Info("pipeline reloaded via management API", slog.String("transforms", newPipeline.Names()))
+		return nil
+	}
 }
 
 // buildPipeline creates a transform.Pipeline from config transforms.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -96,7 +96,7 @@ func main() {
 			os.Exit(1)
 		}
 		if *configPath == "" {
-			fmt.Fprintln(os.Stderr, "error: management.listen requires --config; /reload has no file to re-read")
+			fmt.Fprintln(os.Stderr, "error: management.listen requires --config; /v1/reload has no file to re-read")
 			os.Exit(1)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -45,6 +46,7 @@ type Config struct {
 	TLS        TLS         `yaml:"tls"`
 	Transforms []Transform `yaml:"transforms"`
 	Metrics    Metrics     `yaml:"metrics"`
+	Management Management  `yaml:"management"`
 	Log        Log         `yaml:"log"`
 }
 
@@ -128,6 +130,16 @@ type Transform struct {
 // Metrics configures the OpenTelemetry/Prometheus metrics endpoint.
 type Metrics struct {
 	Listen string `yaml:"listen"`
+}
+
+// Management configures the optional operator-facing HTTP API.
+//
+// When Listen is empty (the default) the management server is disabled.
+// When Listen is set, requests are authenticated with a bearer token whose
+// value is read from the env var named in APIKeyEnv.
+type Management struct {
+	Listen    string `yaml:"listen"`
+	APIKeyEnv string `yaml:"api_key_env"`
 }
 
 // Log configures structured logging.
@@ -218,6 +230,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.Metrics.Listen == "" {
 		cfg.Metrics.Listen = ":9090"
 	}
+	if cfg.Management.Listen != "" && cfg.Management.APIKeyEnv == "" {
+		cfg.Management.APIKeyEnv = "IRON_MANAGEMENT_API_KEY"
+	}
 	if cfg.Log.Level == "" {
 		cfg.Log.Level = "info"
 	}
@@ -253,6 +268,15 @@ func Validate(cfg *Config) error {
 
 	if err := dnsguard.ValidateCIDRs(cfg.Proxy.UpstreamDenyCIDRs.Values); err != nil {
 		return fmt.Errorf("proxy.upstream_deny_cidrs: %w", err)
+	}
+
+	if cfg.Management.Listen != "" {
+		if cfg.Management.APIKeyEnv == "" {
+			return fmt.Errorf("management.api_key_env is required when management.listen is set")
+		}
+		if os.Getenv(cfg.Management.APIKeyEnv) == "" {
+			return fmt.Errorf("management.api_key_env %q is not set in the environment", cfg.Management.APIKeyEnv)
+		}
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -376,6 +376,67 @@ tls:
 	})
 }
 
+func TestLoad_Management(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg, err := Load(strings.NewReader(validYAML()))
+		require.NoError(t, err)
+		require.Equal(t, "", cfg.Management.Listen)
+		require.Equal(t, "", cfg.Management.APIKeyEnv)
+	})
+
+	t.Run("api_key_env defaults when listen set", func(t *testing.T) {
+		t.Setenv("IRON_MANAGEMENT_API_KEY", "secret")
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+management:
+  listen: "127.0.0.1:9092"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, "127.0.0.1:9092", cfg.Management.Listen)
+		require.Equal(t, "IRON_MANAGEMENT_API_KEY", cfg.Management.APIKeyEnv)
+	})
+
+	t.Run("api_key_env override honored", func(t *testing.T) {
+		t.Setenv("CUSTOM_KEY", "secret")
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+management:
+  listen: "127.0.0.1:9092"
+  api_key_env: "CUSTOM_KEY"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.Equal(t, "CUSTOM_KEY", cfg.Management.APIKeyEnv)
+	})
+
+	t.Run("missing env var rejected", func(t *testing.T) {
+		// Ensure the default env var is unset for this test.
+		t.Setenv("IRON_MANAGEMENT_API_KEY", "")
+		yaml := `
+dns:
+  proxy_ip: "10.0.0.1"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+management:
+  listen: "127.0.0.1:9092"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "IRON_MANAGEMENT_API_KEY")
+		require.Contains(t, err.Error(), "is not set")
+	})
+}
+
 func TestLoad_UpstreamResponseHeaderTimeout(t *testing.T) {
 	t.Run("default applied when unset", func(t *testing.T) {
 		yaml := `

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -26,6 +26,16 @@ func (e *ValidationError) Error() string { return e.Err.Error() }
 // Unwrap exposes the underlying error to errors.Is / errors.As.
 func (e *ValidationError) Unwrap() error { return e.Err }
 
+// errorResponse is the JSON body sent for any non-2xx response.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// statusResponse is the JSON body sent for successful operations.
+type statusResponse struct {
+	Status string `json:"status"`
+}
+
 // Options configures Server.
 type Options struct {
 	Addr   string
@@ -72,31 +82,31 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 	if !s.authorize(r) {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
 		return
 	}
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
 		return
 	}
 
 	err := s.reload()
 	if err == nil {
 		s.logger.Info("management reload succeeded")
-		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})
 		return
 	}
 
 	var vErr *ValidationError
 	if errors.As(err, &vErr) {
 		s.logger.Warn("management reload rejected invalid config", slog.String("error", vErr.Error()))
-		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": vErr.Error()})
+		writeJSON(w, http.StatusUnprocessableEntity, errorResponse{Error: vErr.Error()})
 		return
 	}
 
 	s.logger.Error("management reload failed", slog.String("error", err.Error()))
-	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+	writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal error"})
 }
 
 func (s *Server) authorize(r *http.Request) bool {

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -1,0 +1,117 @@
+// Package management provides iron-proxy's authenticated operator HTTP API.
+package management
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// ReloadFunc rebuilds the running pipeline from the on-disk config. Returning
+// a *ValidationError signals that the supplied config could not be parsed or
+// built into a pipeline; the server maps that to HTTP 422.
+type ReloadFunc func() error
+
+// ValidationError marks an error as the result of bad on-disk configuration
+// rather than an internal failure. Reload handlers translate this to a 422.
+type ValidationError struct{ Err error }
+
+// Error returns the wrapped error message.
+func (e *ValidationError) Error() string { return e.Err.Error() }
+
+// Unwrap exposes the underlying error to errors.Is / errors.As.
+func (e *ValidationError) Unwrap() error { return e.Err }
+
+// Options configures Server.
+type Options struct {
+	Addr   string
+	APIKey string
+	Reload ReloadFunc
+	Logger *slog.Logger
+}
+
+// Server serves the management API.
+type Server struct {
+	server *http.Server
+	apiKey string
+	reload ReloadFunc
+	logger *slog.Logger
+}
+
+// New creates a Server bound to opts.Addr. The caller starts it with
+// ListenAndServe and stops it with Shutdown.
+func New(opts Options) *Server {
+	mux := http.NewServeMux()
+	s := &Server{
+		apiKey: opts.APIKey,
+		reload: opts.Reload,
+		logger: opts.Logger,
+	}
+	mux.HandleFunc("/reload", s.handleReload)
+	s.server = &http.Server{
+		Addr:    opts.Addr,
+		Handler: mux,
+	}
+	return s
+}
+
+// ListenAndServe starts the server. It blocks until the server is shut down.
+func (s *Server) ListenAndServe() error {
+	s.logger.Info("management server starting", slog.String("addr", s.server.Addr))
+	return s.server.ListenAndServe()
+}
+
+// Shutdown gracefully stops the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}
+
+func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	err := s.reload()
+	if err == nil {
+		s.logger.Info("management reload succeeded")
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	var vErr *ValidationError
+	if errors.As(err, &vErr) {
+		s.logger.Warn("management reload rejected invalid config", slog.String("error", vErr.Error()))
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": vErr.Error()})
+		return
+	}
+
+	s.logger.Error("management reload failed", slog.String("error", err.Error()))
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+}
+
+func (s *Server) authorize(r *http.Request) bool {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return false
+	}
+	got := []byte(strings.TrimPrefix(h, prefix))
+	want := []byte(s.apiKey)
+	return subtle.ConstantTimeCompare(got, want) == 1
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -61,7 +61,7 @@ func New(opts Options) *Server {
 		reload: opts.Reload,
 		logger: opts.Logger,
 	}
-	mux.HandleFunc("/reload", s.handleReload)
+	mux.HandleFunc("/v1/reload", s.handleReload)
 	s.server = &http.Server{
 		Addr:    opts.Addr,
 		Handler: mux,

--- a/internal/management/server_test.go
+++ b/internal/management/server_test.go
@@ -43,20 +43,20 @@ func decodeError(t *testing.T, body io.Reader) string {
 
 func TestReload_MissingAuth(t *testing.T) {
 	s := newTestServer(t, "secret", func() error { return nil })
-	rec := do(t, s, http.MethodPost, "/reload", "")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 	require.Equal(t, "unauthorized", decodeError(t, rec.Body))
 }
 
 func TestReload_WrongAuth(t *testing.T) {
 	s := newTestServer(t, "secret", func() error { return nil })
-	rec := do(t, s, http.MethodPost, "/reload", "Bearer nope")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer nope")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestReload_NonBearerAuth(t *testing.T) {
 	s := newTestServer(t, "secret", func() error { return nil })
-	rec := do(t, s, http.MethodPost, "/reload", "Basic c2VjcmV0")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Basic c2VjcmV0")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
@@ -65,7 +65,7 @@ func TestReload_WrongMethod(t *testing.T) {
 		t.Fatal("reload should not run on GET")
 		return nil
 	})
-	rec := do(t, s, http.MethodGet, "/reload", "Bearer secret")
+	rec := do(t, s, http.MethodGet, "/v1/reload", "Bearer secret")
 	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 	require.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
 }
@@ -76,7 +76,7 @@ func TestReload_Success(t *testing.T) {
 		called++
 		return nil
 	})
-	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, 1, called)
 
@@ -89,7 +89,7 @@ func TestReload_ValidationError(t *testing.T) {
 	s := newTestServer(t, "secret", func() error {
 		return &ValidationError{Err: errors.New("bad transform: missing field")}
 	})
-	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 	msg := decodeError(t, rec.Body)
 	require.True(t, strings.Contains(msg, "bad transform"), "got %q", msg)
@@ -101,7 +101,7 @@ func TestReload_WrappedValidationError(t *testing.T) {
 		inner := &ValidationError{Err: errors.New("parse failure")}
 		return errors.Join(errors.New("wrapper"), inner)
 	})
-	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 }
 
@@ -109,7 +109,7 @@ func TestReload_InternalError(t *testing.T) {
 	s := newTestServer(t, "secret", func() error {
 		return errors.New("disk on fire")
 	})
-	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
 	// Internal errors are not echoed back to the client.
 	require.Equal(t, "internal error", decodeError(t, rec.Body))

--- a/internal/management/server_test.go
+++ b/internal/management/server_test.go
@@ -36,9 +36,9 @@ func do(t *testing.T, s *Server, method, path, auth string) *httptest.ResponseRe
 
 func decodeError(t *testing.T, body io.Reader) string {
 	t.Helper()
-	var resp map[string]string
+	var resp errorResponse
 	require.NoError(t, json.NewDecoder(body).Decode(&resp))
-	return resp["error"]
+	return resp.Error
 }
 
 func TestReload_MissingAuth(t *testing.T) {
@@ -80,9 +80,9 @@ func TestReload_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, 1, called)
 
-	var resp map[string]string
+	var resp statusResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	require.Equal(t, "ok", resp["status"])
+	require.Equal(t, "ok", resp.Status)
 }
 
 func TestReload_ValidationError(t *testing.T) {

--- a/internal/management/server_test.go
+++ b/internal/management/server_test.go
@@ -1,0 +1,122 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T, key string, reload ReloadFunc) *Server {
+	t.Helper()
+	return New(Options{
+		Addr:   "127.0.0.1:0",
+		APIKey: key,
+		Reload: reload,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+func do(t *testing.T, s *Server, method, path, auth string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	rec := httptest.NewRecorder()
+	s.server.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeError(t *testing.T, body io.Reader) string {
+	t.Helper()
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(body).Decode(&resp))
+	return resp["error"]
+}
+
+func TestReload_MissingAuth(t *testing.T) {
+	s := newTestServer(t, "secret", func() error { return nil })
+	rec := do(t, s, http.MethodPost, "/reload", "")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, "unauthorized", decodeError(t, rec.Body))
+}
+
+func TestReload_WrongAuth(t *testing.T) {
+	s := newTestServer(t, "secret", func() error { return nil })
+	rec := do(t, s, http.MethodPost, "/reload", "Bearer nope")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestReload_NonBearerAuth(t *testing.T) {
+	s := newTestServer(t, "secret", func() error { return nil })
+	rec := do(t, s, http.MethodPost, "/reload", "Basic c2VjcmV0")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestReload_WrongMethod(t *testing.T) {
+	s := newTestServer(t, "secret", func() error {
+		t.Fatal("reload should not run on GET")
+		return nil
+	})
+	rec := do(t, s, http.MethodGet, "/reload", "Bearer secret")
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}
+
+func TestReload_Success(t *testing.T) {
+	called := 0
+	s := newTestServer(t, "secret", func() error {
+		called++
+		return nil
+	})
+	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, called)
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Equal(t, "ok", resp["status"])
+}
+
+func TestReload_ValidationError(t *testing.T) {
+	s := newTestServer(t, "secret", func() error {
+		return &ValidationError{Err: errors.New("bad transform: missing field")}
+	})
+	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	msg := decodeError(t, rec.Body)
+	require.True(t, strings.Contains(msg, "bad transform"), "got %q", msg)
+}
+
+func TestReload_WrappedValidationError(t *testing.T) {
+	// A ValidationError wrapped further down the chain still maps to 422.
+	s := newTestServer(t, "secret", func() error {
+		inner := &ValidationError{Err: errors.New("parse failure")}
+		return errors.Join(errors.New("wrapper"), inner)
+	})
+	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestReload_InternalError(t *testing.T) {
+	s := newTestServer(t, "secret", func() error {
+		return errors.New("disk on fire")
+	})
+	rec := do(t, s, http.MethodPost, "/reload", "Bearer secret")
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	// Internal errors are not echoed back to the client.
+	require.Equal(t, "internal error", decodeError(t, rec.Body))
+}
+
+func TestUnknownPath(t *testing.T) {
+	s := newTestServer(t, "secret", func() error { return nil })
+	rec := do(t, s, http.MethodPost, "/anything-else", "Bearer secret")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -268,13 +268,14 @@ transforms:
         management, billing, or any repository the agent is not reviewing.
 
 # Optional management API. When `listen` is empty (default), the management
-# server is disabled. When set, the proxy serves an authenticated POST /reload
-# endpoint that re-reads this YAML file and atomically swaps in a freshly built
-# transform pipeline. A bad config is rejected with 422; the running pipeline
-# is preserved. Standalone mode only — incompatible with control-plane mode.
+# server is disabled. When set, the proxy serves an authenticated
+# POST /v1/reload endpoint that re-reads this YAML file and atomically swaps in
+# a freshly built transform pipeline. A bad config is rejected with 422; the
+# running pipeline is preserved. Standalone mode only — incompatible with
+# control-plane mode.
 # management:
 #   # Bind on loopback unless you front this with a private network or auth proxy:
-#   # /reload can rebuild the entire transform pipeline.
+#   # /v1/reload can rebuild the entire transform pipeline.
 #   listen: "127.0.0.1:9092"
 #   # Env var that holds the bearer token. Defaults to IRON_MANAGEMENT_API_KEY.
 #   api_key_env: "IRON_MANAGEMENT_API_KEY"

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -267,6 +267,18 @@ transforms:
         repository under review. Deny writes to user settings, organization
         management, billing, or any repository the agent is not reviewing.
 
+# Optional management API. When `listen` is empty (default), the management
+# server is disabled. When set, the proxy serves an authenticated POST /reload
+# endpoint that re-reads this YAML file and atomically swaps in a freshly built
+# transform pipeline. A bad config is rejected with 422; the running pipeline
+# is preserved. Standalone mode only — incompatible with control-plane mode.
+# management:
+#   # Bind on loopback unless you front this with a private network or auth proxy:
+#   # /reload can rebuild the entire transform pipeline.
+#   listen: "127.0.0.1:9092"
+#   # Env var that holds the bearer token. Defaults to IRON_MANAGEMENT_API_KEY.
+#   api_key_env: "IRON_MANAGEMENT_API_KEY"
+
 # Logging
 log:
   level: "info"  # debug, info, warn, error


### PR DESCRIPTION
Adds an opt-in `management` config stanza that, when set, runs a small HTTP server with a bearer-authenticated `POST /reload` endpoint. The handler re-reads the YAML config from disk, rebuilds the transform pipeline, and atomically swaps it in. Parse or build errors return 422 with the message and leave the running pipeline untouched. The API key is read from a configurable env var (default `IRON_MANAGEMENT_API_KEY`). Standalone mode only — refuses to start alongside control-plane mode.