### PR TITLE
test(management): add itest for /v1/reload

### DIFF
--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -19,18 +21,40 @@ import (
 type proxyInstance struct {
 	HTTPAddr string
 	cmd      *exec.Cmd
+
+	addrsMu sync.Mutex
+	addrs   map[string]string
+}
+
+// AddrFor blocks until a JSON log line with the given "starting" msg has been
+// observed and returns its addr field. Useful for services configured with
+// listen ":0" — the actual bound port is only known via the log.
+func (p *proxyInstance) AddrFor(t *testing.T, msg string) string {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		p.addrsMu.Lock()
+		addr, ok := p.addrs[msg]
+		p.addrsMu.Unlock()
+		if ok {
+			return addr
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for log line %q", msg)
+			return ""
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // startProxy compiles (if needed) and starts the iron-proxy binary with the
-// given config and environment. It parses the JSON log output to discover
-// the actual HTTP listen address (supports :0). The proxy is killed when the
-// test completes.
+// given config and environment. It scans the JSON log output to discover
+// listen addresses (supports :0). The proxy is killed when the test completes.
 func startProxy(t *testing.T, binary, cfgPath string, env []string) *proxyInstance {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Pipe stderr so we can read JSON log lines.
 	stderrR, stderrW := io.Pipe()
 
 	cmd := exec.CommandContext(ctx, binary, "-config", cfgPath)
@@ -46,55 +70,42 @@ func startProxy(t *testing.T, binary, cfgPath string, env []string) *proxyInstan
 		_ = stderrW.Close()
 	})
 
-	// Tee stderr to os.Stderr so all log lines are visible while we scan
-	// for the HTTP listen address.
-	tee := io.TeeReader(stderrR, os.Stderr)
-	httpAddr := parseHTTPAddr(t, tee)
-
-	// Continue draining stderr after we have the address.
-	go func() {
-		_, _ = io.Copy(os.Stderr, tee)
-	}()
-
-	return &proxyInstance{
-		HTTPAddr: httpAddr,
-		cmd:      cmd,
+	p := &proxyInstance{
+		cmd:   cmd,
+		addrs: make(map[string]string),
 	}
+
+	go scanLogs(stderrR, p)
+
+	p.HTTPAddr = p.AddrFor(t, "http proxy starting")
+	return p
 }
 
-// parseHTTPAddr reads JSON log lines from r until it finds the
-// "http proxy starting" message and returns the addr field.
-func parseHTTPAddr(t *testing.T, r io.Reader) string {
-	t.Helper()
-
+// scanLogs reads the proxy's stderr line-by-line, tees raw bytes to os.Stderr
+// for visibility, and records the addr field of every "X starting" log line
+// for later lookup via AddrFor.
+func scanLogs(r io.Reader, p *proxyInstance) {
 	type logLine struct {
 		Msg  string `json:"msg"`
 		Addr string `json:"addr"`
 	}
 
 	scanner := bufio.NewScanner(r)
-	deadline := time.After(10 * time.Second)
-	found := make(chan string, 1)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		_, _ = os.Stderr.Write(append(append([]byte{}, line...), '\n'))
 
-	go func() {
-		for scanner.Scan() {
-			var line logLine
-			if json.Unmarshal(scanner.Bytes(), &line) != nil {
-				continue
-			}
-			if line.Msg == "http proxy starting" && line.Addr != "" {
-				found <- line.Addr
-				return
-			}
+		var entry logLine
+		if json.Unmarshal(line, &entry) != nil {
+			continue
 		}
-	}()
-
-	select {
-	case addr := <-found:
-		return addr
-	case <-deadline:
-		t.Fatal("timed out waiting for proxy to log HTTP listen address")
-		return ""
+		if !strings.HasSuffix(entry.Msg, "starting") || entry.Addr == "" {
+			continue
+		}
+		p.addrsMu.Lock()
+		p.addrs[entry.Msg] = entry.Addr
+		p.addrsMu.Unlock()
 	}
 }
 

--- a/integration_test/management_reload_test.go
+++ b/integration_test/management_reload_test.go
@@ -1,0 +1,113 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestManagementReload boots the proxy with config A, verifies the secret
+// transform swaps in config A's value, then rewrites the config file to
+// config B (different allowlist + secret env var), POSTs /v1/reload, and
+// verifies subsequent requests now see config B's resolved secret.
+func TestManagementReload(t *testing.T) {
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+
+	const (
+		secretValueA = "reload-secret-value-a"
+		secretValueB = "reload-secret-value-b"
+		apiKey       = "reload-itest-api-key"
+	)
+
+	t.Setenv("IRON_RELOAD_ITEST_SECRET_A", secretValueA)
+	t.Setenv("IRON_RELOAD_ITEST_SECRET_B", secretValueB)
+	t.Setenv("IRON_RELOAD_ITEST_API_KEY", apiKey)
+
+	// Upstream: echoes back the secret header so we can verify the swap.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Reload-Secret", r.Header.Get("X-Reload-Secret"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamHost := upstream.Listener.Addr().String()
+
+	// Pre-bind a free port for the management server. The management
+	// server logs only its configured Addr (not the resolved listener
+	// address), so we cannot use :0.
+	mgmtAddr := "127.0.0.1:" + freePort(t)
+	data := struct{ MgmtAddr string }{MgmtAddr: mgmtAddr}
+
+	// Render config A; this writes <tmpDir>/config.yaml.
+	cfgPath := renderConfig(t, tmpDir, "reload_a.yaml", data)
+	proxy := startProxy(t, binary, cfgPath, nil)
+
+	waitForTCP(t, mgmtAddr)
+
+	t.Run("config_a_active", func(t *testing.T) {
+		got := doSecretRequest(t, proxy.HTTPAddr, upstreamHost)
+		require.Equal(t, secretValueA, got)
+	})
+
+	// Overwrite the config file in place with config B and reload.
+	_ = renderConfig(t, tmpDir, "reload_b.yaml", data)
+
+	t.Run("reload_to_config_b", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/v1/reload", mgmtAddr), nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "reload response: %s", body)
+	})
+
+	t.Run("config_b_active", func(t *testing.T) {
+		got := doSecretRequest(t, proxy.HTTPAddr, upstreamHost)
+		require.Equal(t, secretValueB, got)
+		require.NotEqual(t, secretValueA, got)
+	})
+}
+
+// doSecretRequest sends a request through the proxy with the proxy-token in
+// the X-Reload-Secret header and returns the value the upstream observed
+// (which the upstream echoes back as X-Got-Reload-Secret).
+func doSecretRequest(t *testing.T, proxyAddr, upstreamHost string) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", proxyAddr), nil)
+	require.NoError(t, err)
+	req.Host = upstreamHost
+	req.Header.Set("X-Reload-Secret", "proxy-reload-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return resp.Header.Get("X-Got-Reload-Secret")
+}
+
+// waitForTCP polls addr until a TCP connect succeeds. The management server
+// starts in its own goroutine after the proxy logs "http proxy starting", so
+// it may not be listening yet when startProxy returns.
+func waitForTCP(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "management server never accepted connections at %s", addr)
+}

--- a/integration_test/management_reload_test.go
+++ b/integration_test/management_reload_test.go
@@ -6,16 +6,19 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestManagementReload boots the proxy with config A, verifies the secret
-// transform swaps in config A's value, then rewrites the config file to
-// config B (different allowlist + secret env var), POSTs /v1/reload, and
-// verifies subsequent requests now see config B's resolved secret.
+// TestManagementReload boots the proxy with config A (allowlist + secret rule
+// matching host-a.test, secret resolved from env var ..._SECRET_A), verifies
+// requests for host-a.test are allowed and the secret is swapped while
+// host-b.test is rejected, then overwrites the config file with config B
+// (allowlist + secret rule for host-b.test, env var ..._SECRET_B), POSTs
+// /v1/reload, and verifies the allow/block and the swapped value have flipped.
 func TestManagementReload(t *testing.T) {
 	tmpDir := t.TempDir()
 	binary := proxyBinary(t)
@@ -36,23 +39,41 @@ func TestManagementReload(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer upstream.Close()
-	upstreamHost := upstream.Listener.Addr().String()
+	upstreamPort := upstream.Listener.Addr().(*net.TCPAddr).Port
 
-	// Pre-bind a free port for the management server. The management
-	// server logs only its configured Addr (not the resolved listener
-	// address), so we cannot use :0.
+	// Pre-allocate fixed ports for the management server (TCP) and the
+	// proxy's DNS server (UDP). The management server logs only its
+	// configured Addr (not the resolved listener), and the DNS port has
+	// to be known up front so we can point the proxy's upstream resolver
+	// back at itself in the YAML.
 	mgmtAddr := "127.0.0.1:" + freePort(t)
-	data := struct{ MgmtAddr string }{MgmtAddr: mgmtAddr}
+	dnsPort := freeUDPPort(t)
+
+	data := struct {
+		MgmtAddr string
+		DNSPort  string
+	}{
+		MgmtAddr: mgmtAddr,
+		DNSPort:  dnsPort,
+	}
 
 	// Render config A; this writes <tmpDir>/config.yaml.
 	cfgPath := renderConfig(t, tmpDir, "reload_a.yaml", data)
 	proxy := startProxy(t, binary, cfgPath, nil)
-
 	waitForTCP(t, mgmtAddr)
 
+	hostA := fmt.Sprintf("host-a.test:%d", upstreamPort)
+	hostB := fmt.Sprintf("host-b.test:%d", upstreamPort)
+
 	t.Run("config_a_active", func(t *testing.T) {
-		got := doSecretRequest(t, proxy.HTTPAddr, upstreamHost)
+		// host-a.test is allowed and its secret is swapped.
+		got, status := doSecretRequest(t, proxy.HTTPAddr, hostA)
+		require.Equal(t, http.StatusOK, status)
 		require.Equal(t, secretValueA, got)
+
+		// host-b.test is rejected by config A's allowlist.
+		_, status = doSecretRequest(t, proxy.HTTPAddr, hostB)
+		require.Equal(t, http.StatusForbidden, status)
 	})
 
 	// Overwrite the config file in place with config B and reload.
@@ -72,20 +93,27 @@ func TestManagementReload(t *testing.T) {
 	})
 
 	t.Run("config_b_active", func(t *testing.T) {
-		got := doSecretRequest(t, proxy.HTTPAddr, upstreamHost)
+		// host-b.test is now allowed and its secret is swapped.
+		got, status := doSecretRequest(t, proxy.HTTPAddr, hostB)
+		require.Equal(t, http.StatusOK, status)
 		require.Equal(t, secretValueB, got)
 		require.NotEqual(t, secretValueA, got)
+
+		// host-a.test is now rejected by config B's allowlist.
+		_, status = doSecretRequest(t, proxy.HTTPAddr, hostA)
+		require.Equal(t, http.StatusForbidden, status)
 	})
 }
 
 // doSecretRequest sends a request through the proxy with the proxy-token in
 // the X-Reload-Secret header and returns the value the upstream observed
-// (which the upstream echoes back as X-Got-Reload-Secret).
-func doSecretRequest(t *testing.T, proxyAddr, upstreamHost string) string {
+// (echoed back via X-Got-Reload-Secret) along with the response status.
+// When the request is rejected by the proxy, the value will be empty.
+func doSecretRequest(t *testing.T, proxyAddr, hostHeader string) (string, int) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", proxyAddr), nil)
 	require.NoError(t, err)
-	req.Host = upstreamHost
+	req.Host = hostHeader
 	req.Header.Set("X-Reload-Secret", "proxy-reload-token")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -93,8 +121,7 @@ func doSecretRequest(t *testing.T, proxyAddr, upstreamHost string) string {
 	defer resp.Body.Close()
 	_, err = io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	return resp.Header.Get("X-Got-Reload-Secret")
+	return resp.Header.Get("X-Got-Reload-Secret"), resp.StatusCode
 }
 
 // waitForTCP polls addr until a TCP connect succeeds. The management server
@@ -109,5 +136,17 @@ func waitForTCP(t *testing.T, addr string) {
 		}
 		_ = c.Close()
 		return true
-	}, 5*time.Second, 50*time.Millisecond, "management server never accepted connections at %s", addr)
+	}, 5*time.Second, 50*time.Millisecond, "tcp listener never accepted at %s", addr)
+}
+
+// freeUDPPort asks the OS for a free UDP port and returns it as a string.
+// Used to pin the proxy's DNS server to a port we know in advance so we can
+// point upstream_resolver back at it.
+func freeUDPPort(t *testing.T) string {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	require.NoError(t, c.Close())
+	return strconv.Itoa(port)
 }

--- a/integration_test/management_reload_test.go
+++ b/integration_test/management_reload_test.go
@@ -6,10 +6,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
+	"strings"
 	"testing"
-	"time"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,26 +41,18 @@ func TestManagementReload(t *testing.T) {
 	defer upstream.Close()
 	upstreamPort := upstream.Listener.Addr().(*net.TCPAddr).Port
 
-	// Pre-allocate fixed ports for the management server (TCP) and the
-	// proxy's DNS server (UDP). The management server logs only its
-	// configured Addr (not the resolved listener), and the DNS port has
-	// to be known up front so we can point the proxy's upstream resolver
-	// back at itself in the YAML.
-	mgmtAddr := "127.0.0.1:" + freePort(t)
-	dnsPort := freeUDPPort(t)
+	// In-process DNS server that resolves host-a.test and host-b.test to
+	// 127.0.0.1. The proxy's upstream_resolver is pointed at this so the
+	// proxy can dial those hostnames to our local httptest upstream. The
+	// server binds a real port, so there's no preallocate-and-race.
+	testDNSAddr := startTestDNSResolver(t)
 
-	data := struct {
-		MgmtAddr string
-		DNSPort  string
-	}{
-		MgmtAddr: mgmtAddr,
-		DNSPort:  dnsPort,
-	}
+	data := struct{ TestDNSAddr string }{TestDNSAddr: testDNSAddr}
 
 	// Render config A; this writes <tmpDir>/config.yaml.
 	cfgPath := renderConfig(t, tmpDir, "reload_a.yaml", data)
 	proxy := startProxy(t, binary, cfgPath, nil)
-	waitForTCP(t, mgmtAddr)
+	mgmtAddr := proxy.AddrFor(t, "management server starting")
 
 	hostA := fmt.Sprintf("host-a.test:%d", upstreamPort)
 	hostB := fmt.Sprintf("host-b.test:%d", upstreamPort)
@@ -124,29 +116,48 @@ func doSecretRequest(t *testing.T, proxyAddr, hostHeader string) (string, int) {
 	return resp.Header.Get("X-Got-Reload-Secret"), resp.StatusCode
 }
 
-// waitForTCP polls addr until a TCP connect succeeds. The management server
-// starts in its own goroutine after the proxy logs "http proxy starting", so
-// it may not be listening yet when startProxy returns.
-func waitForTCP(t *testing.T, addr string) {
+// startTestDNSResolver starts a tiny UDP DNS server on a random port that
+// resolves host-a.test and host-b.test to 127.0.0.1 and returns its addr.
+// The server is shut down when the test completes.
+func startTestDNSResolver(t *testing.T) string {
 	t.Helper()
-	require.Eventually(t, func() bool {
-		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-		if err != nil {
-			return false
-		}
-		_ = c.Close()
-		return true
-	}, 5*time.Second, 50*time.Millisecond, "tcp listener never accepted at %s", addr)
-}
-
-// freeUDPPort asks the OS for a free UDP port and returns it as a string.
-// Used to pin the proxy's DNS server to a port we know in advance so we can
-// point upstream_resolver back at it.
-func freeUDPPort(t *testing.T) string {
-	t.Helper()
-	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
-	port := c.LocalAddr().(*net.UDPAddr).Port
-	require.NoError(t, c.Close())
-	return strconv.Itoa(port)
+
+	answers := map[string]string{
+		"host-a.test.": "127.0.0.1",
+		"host-b.test.": "127.0.0.1",
+	}
+
+	srv := &dns.Server{
+		PacketConn: pc,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
+			resp := new(dns.Msg)
+			resp.SetReply(m)
+			resp.Authoritative = true
+			for _, q := range m.Question {
+				if q.Qtype != dns.TypeA {
+					continue
+				}
+				ip, ok := answers[strings.ToLower(q.Name)]
+				if !ok {
+					continue
+				}
+				rr, err := dns.NewRR(fmt.Sprintf("%s 60 IN A %s", q.Name, ip))
+				if err != nil {
+					continue
+				}
+				resp.Answer = append(resp.Answer, rr)
+			}
+			_ = w.WriteMsg(resp)
+		}),
+	}
+
+	started := make(chan struct{})
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ActivateAndServe() }()
+	<-started
+
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	return pc.LocalAddr().String()
 }

--- a/integration_test/testdata/reload_a.yaml
+++ b/integration_test/testdata/reload_a.yaml
@@ -1,6 +1,14 @@
 dns:
   proxy_ip: "127.0.0.1"
-  listen: "127.0.0.1:0"
+  listen: "127.0.0.1:{{.DNSPort}}"
+  upstream_resolver: "127.0.0.1:{{.DNSPort}}"
+  records:
+    - name: "host-a.test"
+      type: "A"
+      value: "127.0.0.1"
+    - name: "host-b.test"
+      type: "A"
+      value: "127.0.0.1"
 
 proxy:
   http_listen: "127.0.0.1:0"
@@ -15,10 +23,8 @@ tls:
 transforms:
   - name: allowlist
     config:
-      cidrs:
-        - "127.0.0.1/32"
       domains:
-        - "only-in-config-a.example"
+        - "host-a.test"
 
   - name: secrets
     config:
@@ -29,7 +35,7 @@ transforms:
           proxy_value: "proxy-reload-token"
           match_headers: ["X-Reload-Secret"]
           rules:
-            - host: "127.0.0.1"
+            - host: "host-a.test"
 
 management:
   listen: "{{.MgmtAddr}}"

--- a/integration_test/testdata/reload_a.yaml
+++ b/integration_test/testdata/reload_a.yaml
@@ -1,0 +1,41 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+        - "only-in-config-a.example"
+
+  - name: secrets
+    config:
+      secrets:
+        - source:
+            type: env
+            var: IRON_RELOAD_ITEST_SECRET_A
+          proxy_value: "proxy-reload-token"
+          match_headers: ["X-Reload-Secret"]
+          rules:
+            - host: "127.0.0.1"
+
+management:
+  listen: "{{.MgmtAddr}}"
+  api_key_env: IRON_RELOAD_ITEST_API_KEY
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/integration_test/testdata/reload_a.yaml
+++ b/integration_test/testdata/reload_a.yaml
@@ -1,14 +1,7 @@
 dns:
   proxy_ip: "127.0.0.1"
-  listen: "127.0.0.1:{{.DNSPort}}"
-  upstream_resolver: "127.0.0.1:{{.DNSPort}}"
-  records:
-    - name: "host-a.test"
-      type: "A"
-      value: "127.0.0.1"
-    - name: "host-b.test"
-      type: "A"
-      value: "127.0.0.1"
+  listen: "127.0.0.1:0"
+  upstream_resolver: "{{.TestDNSAddr}}"
 
 proxy:
   http_listen: "127.0.0.1:0"
@@ -38,7 +31,7 @@ transforms:
             - host: "host-a.test"
 
 management:
-  listen: "{{.MgmtAddr}}"
+  listen: "127.0.0.1:0"
   api_key_env: IRON_RELOAD_ITEST_API_KEY
 
 metrics:

--- a/integration_test/testdata/reload_a.yaml
+++ b/integration_test/testdata/reload_a.yaml
@@ -15,8 +15,9 @@ tls:
 transforms:
   - name: allowlist
     config:
+      cidrs:
+        - "127.0.0.1/32"
       domains:
-        - "127.0.0.1"
         - "only-in-config-a.example"
 
   - name: secrets

--- a/integration_test/testdata/reload_b.yaml
+++ b/integration_test/testdata/reload_b.yaml
@@ -1,14 +1,7 @@
 dns:
   proxy_ip: "127.0.0.1"
-  listen: "127.0.0.1:{{.DNSPort}}"
-  upstream_resolver: "127.0.0.1:{{.DNSPort}}"
-  records:
-    - name: "host-a.test"
-      type: "A"
-      value: "127.0.0.1"
-    - name: "host-b.test"
-      type: "A"
-      value: "127.0.0.1"
+  listen: "127.0.0.1:0"
+  upstream_resolver: "{{.TestDNSAddr}}"
 
 proxy:
   http_listen: "127.0.0.1:0"
@@ -38,7 +31,7 @@ transforms:
             - host: "host-b.test"
 
 management:
-  listen: "{{.MgmtAddr}}"
+  listen: "127.0.0.1:0"
   api_key_env: IRON_RELOAD_ITEST_API_KEY
 
 metrics:

--- a/integration_test/testdata/reload_b.yaml
+++ b/integration_test/testdata/reload_b.yaml
@@ -1,6 +1,14 @@
 dns:
   proxy_ip: "127.0.0.1"
-  listen: "127.0.0.1:0"
+  listen: "127.0.0.1:{{.DNSPort}}"
+  upstream_resolver: "127.0.0.1:{{.DNSPort}}"
+  records:
+    - name: "host-a.test"
+      type: "A"
+      value: "127.0.0.1"
+    - name: "host-b.test"
+      type: "A"
+      value: "127.0.0.1"
 
 proxy:
   http_listen: "127.0.0.1:0"
@@ -15,10 +23,8 @@ tls:
 transforms:
   - name: allowlist
     config:
-      cidrs:
-        - "127.0.0.1/32"
       domains:
-        - "only-in-config-b.example"
+        - "host-b.test"
 
   - name: secrets
     config:
@@ -29,7 +35,7 @@ transforms:
           proxy_value: "proxy-reload-token"
           match_headers: ["X-Reload-Secret"]
           rules:
-            - host: "127.0.0.1"
+            - host: "host-b.test"
 
 management:
   listen: "{{.MgmtAddr}}"

--- a/integration_test/testdata/reload_b.yaml
+++ b/integration_test/testdata/reload_b.yaml
@@ -15,8 +15,9 @@ tls:
 transforms:
   - name: allowlist
     config:
+      cidrs:
+        - "127.0.0.1/32"
       domains:
-        - "127.0.0.1"
         - "only-in-config-b.example"
 
   - name: secrets

--- a/integration_test/testdata/reload_b.yaml
+++ b/integration_test/testdata/reload_b.yaml
@@ -1,0 +1,41 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+        - "only-in-config-b.example"
+
+  - name: secrets
+    config:
+      secrets:
+        - source:
+            type: env
+            var: IRON_RELOAD_ITEST_SECRET_B
+          proxy_value: "proxy-reload-token"
+          match_headers: ["X-Reload-Secret"]
+          rules:
+            - host: "127.0.0.1"
+
+management:
+  listen: "{{.MgmtAddr}}"
+  api_key_env: IRON_RELOAD_ITEST_API_KEY
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -64,8 +64,13 @@ func New(cfg config.DNS, resolver Resolver, logger *slog.Logger) (*Server, error
 
 // ListenAndServe starts the DNS server. It blocks until the server is shut down.
 func (s *Server) ListenAndServe() error {
-	s.logger.Info("dns server starting", slog.String("addr", s.server.Addr))
-	return s.server.ListenAndServe()
+	pc, err := net.ListenPacket("udp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.server.PacketConn = pc
+	s.logger.Info("dns server starting", slog.String("addr", pc.LocalAddr().String()))
+	return s.server.ActivateAndServe()
 }
 
 // Shutdown gracefully stops the DNS server.

--- a/internal/dns/server.go
+++ b/internal/dns/server.go
@@ -64,13 +64,8 @@ func New(cfg config.DNS, resolver Resolver, logger *slog.Logger) (*Server, error
 
 // ListenAndServe starts the DNS server. It blocks until the server is shut down.
 func (s *Server) ListenAndServe() error {
-	pc, err := net.ListenPacket("udp", s.server.Addr)
-	if err != nil {
-		return err
-	}
-	s.server.PacketConn = pc
-	s.logger.Info("dns server starting", slog.String("addr", pc.LocalAddr().String()))
-	return s.server.ActivateAndServe()
+	s.logger.Info("dns server starting", slog.String("addr", s.server.Addr))
+	return s.server.ListenAndServe()
 }
 
 // Shutdown gracefully stops the DNS server.

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -71,8 +72,12 @@ func New(opts Options) *Server {
 
 // ListenAndServe starts the server. It blocks until the server is shut down.
 func (s *Server) ListenAndServe() error {
-	s.logger.Info("management server starting", slog.String("addr", s.server.Addr))
-	return s.server.ListenAndServe()
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.logger.Info("management server starting", slog.String("addr", ln.Addr().String()))
+	return s.server.Serve(ln)
 }
 
 // Shutdown gracefully stops the server.


### PR DESCRIPTION
Adds an integration test for the `/v1/reload` management API. The test boots the proxy with config A (allowlist + env-sourced secret pointing at `IRON_RELOAD_ITEST_SECRET_A`), confirms an upstream request sees secret A's value swapped in, overwrites the config file with config B (different allowlist entry, secret env var `..._SECRET_B`), POSTs to `/v1/reload`, and asserts the next request now sees secret B's value.