### PR TITLE
refactor(hostmatch): drop DNS resolution from CIDR matching

### DIFF
--- a/internal/hostmatch/hostmatch.go
+++ b/internal/hostmatch/hostmatch.go
@@ -1,29 +1,23 @@
-// Package hostmatch provides domain glob and CIDR matching for host-based
-// access control, shared by the allowlist and secrets transforms.
+// Package hostmatch provides domain glob and literal-IP CIDR matching for
+// host-based access control, shared by the allowlist and secrets transforms.
 package hostmatch
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"path"
 	"strings"
 )
 
-// Resolver looks up IP addresses for a hostname.
-type Resolver interface {
-	LookupHost(ctx context.Context, host string) ([]string, error)
-}
-
-// Matcher checks whether a host matches a set of domain globs and CIDR ranges.
+// Matcher checks whether a host matches a set of domain globs or, when the
+// host is a literal IP address, a set of CIDR ranges.
 type Matcher struct {
-	domains  []string
-	cidrs    []*net.IPNet
-	resolver Resolver
+	domains []string
+	cidrs   []*net.IPNet
 }
 
 // New creates a Matcher from domain globs and CIDR strings.
-func New(domains []string, cidrs []string, resolver Resolver) (*Matcher, error) {
+func New(domains []string, cidrs []string) (*Matcher, error) {
 	nets := make([]*net.IPNet, 0, len(cidrs))
 	for _, cidr := range cidrs {
 		_, ipNet, err := net.ParseCIDR(cidr)
@@ -34,15 +28,15 @@ func New(domains []string, cidrs []string, resolver Resolver) (*Matcher, error) 
 	}
 
 	return &Matcher{
-		domains:  domains,
-		cidrs:    nets,
-		resolver: resolver,
+		domains: domains,
+		cidrs:   nets,
 	}, nil
 }
 
-// Matches returns true if the host matches any domain glob or, after DNS
-// resolution, any CIDR range. The host should already have the port stripped.
-func (m *Matcher) Matches(ctx context.Context, host string) bool {
+// Matches returns true if the host matches any domain glob, or — when the
+// host is itself a literal IP — falls inside any configured CIDR range. The
+// host should already have the port stripped.
+func (m *Matcher) Matches(host string) bool {
 	for _, pattern := range m.domains {
 		if MatchGlob(pattern, host) {
 			return true
@@ -50,17 +44,10 @@ func (m *Matcher) Matches(ctx context.Context, host string) bool {
 	}
 
 	if len(m.cidrs) > 0 {
-		addrs, err := m.resolver.LookupHost(ctx, host)
-		if err == nil {
-			for _, addr := range addrs {
-				ip := net.ParseIP(addr)
-				if ip == nil {
-					continue
-				}
-				for _, cidr := range m.cidrs {
-					if cidr.Contains(ip) {
-						return true
-					}
+		if ip := net.ParseIP(host); ip != nil {
+			for _, cidr := range m.cidrs {
+				if cidr.Contains(ip) {
+					return true
 				}
 			}
 		}
@@ -82,19 +69,6 @@ func MatchGlob(pattern, name string) bool {
 	}
 	matched, _ := path.Match(pattern, name)
 	return matched
-}
-
-// DefaultResolver returns the system's default DNS resolver.
-func DefaultResolver() Resolver {
-	return net.DefaultResolver
-}
-
-// NullResolver is a Resolver that always returns "no such host". Useful when
-// only domain glob matching is needed and CIDR resolution is not required.
-type NullResolver struct{}
-
-func (NullResolver) LookupHost(_ context.Context, host string) ([]string, error) {
-	return nil, fmt.Errorf("no such host: %s", host)
 }
 
 // StripPort removes the port from a host:port string. If there's no port,

--- a/internal/hostmatch/rule.go
+++ b/internal/hostmatch/rule.go
@@ -1,7 +1,6 @@
 package hostmatch
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -23,8 +22,8 @@ type Rule struct {
 }
 
 // Matches returns true if the request matches this rule.
-func (r *Rule) Matches(ctx context.Context, host, method, path string) bool {
-	if !r.Matcher.Matches(ctx, host) {
+func (r *Rule) Matches(host, method, path string) bool {
+	if !r.Matcher.Matches(host) {
 		return false
 	}
 	if r.Methods != nil && !r.Methods[method] {
@@ -38,7 +37,7 @@ func (r *Rule) Matches(ctx context.Context, host, method, path string) bool {
 
 // CompileRules compiles a list of RuleConfigs into Rules.
 // The prefix is used for error messages (e.g. "allowlist" or "grpc transform \"foo\"").
-func CompileRules(configs []RuleConfig, resolver Resolver, prefix string) ([]Rule, error) {
+func CompileRules(configs []RuleConfig, prefix string) ([]Rule, error) {
 	var rules []Rule
 	for i, rc := range configs {
 		if rc.Host != "" && rc.CIDR != "" {
@@ -56,7 +55,7 @@ func CompileRules(configs []RuleConfig, resolver Resolver, prefix string) ([]Rul
 			cidrs = []string{rc.CIDR}
 		}
 
-		m, err := New(domains, cidrs, resolver)
+		m, err := New(domains, cidrs)
 		if err != nil {
 			return nil, fmt.Errorf("%s: rules[%d]: %w", prefix, i, err)
 		}
@@ -88,10 +87,10 @@ func isWildcard(methods []string) bool {
 }
 
 // MatchAnyRule returns true if the request matches any rule in the list.
-func MatchAnyRule(ctx context.Context, rules []Rule, req *http.Request) bool {
+func MatchAnyRule(rules []Rule, req *http.Request) bool {
 	host := StripPort(req.Host)
 	for _, r := range rules {
-		if r.Matches(ctx, host, req.Method, req.URL.Path) {
+		if r.Matches(host, req.Method, req.URL.Path) {
 			return true
 		}
 	}

--- a/internal/hostmatch/rule_test.go
+++ b/internal/hostmatch/rule_test.go
@@ -1,7 +1,6 @@
 package hostmatch
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,40 +9,37 @@ import (
 func TestCompileRules_WildcardMethodMatchesAll(t *testing.T) {
 	rules, err := CompileRules([]RuleConfig{
 		{Host: "example.com", Methods: []string{"*"}},
-	}, NullResolver{}, "test")
+	}, "test")
 	require.NoError(t, err)
 	require.Len(t, rules, 1)
 	require.Nil(t, rules[0].Methods, "wildcard method should result in nil Methods (match all)")
 
-	ctx := context.Background()
 	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"} {
-		require.True(t, rules[0].Matches(ctx, "example.com", method, "/"), "method %s should match", method)
+		require.True(t, rules[0].Matches("example.com", method, "/"), "method %s should match", method)
 	}
 }
 
 func TestCompileRules_ExplicitMethodsFiltered(t *testing.T) {
 	rules, err := CompileRules([]RuleConfig{
 		{Host: "example.com", Methods: []string{"GET", "post"}},
-	}, NullResolver{}, "test")
+	}, "test")
 	require.NoError(t, err)
 	require.Len(t, rules, 1)
 	require.NotNil(t, rules[0].Methods)
 
-	ctx := context.Background()
-	require.True(t, rules[0].Matches(ctx, "example.com", "GET", "/"))
-	require.True(t, rules[0].Matches(ctx, "example.com", "POST", "/"))
-	require.False(t, rules[0].Matches(ctx, "example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "GET", "/"))
+	require.True(t, rules[0].Matches("example.com", "POST", "/"))
+	require.False(t, rules[0].Matches("example.com", "DELETE", "/"))
 }
 
 func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
 	rules, err := CompileRules([]RuleConfig{
 		{Host: "example.com"},
-	}, NullResolver{}, "test")
+	}, "test")
 	require.NoError(t, err)
 	require.Len(t, rules, 1)
 	require.Nil(t, rules[0].Methods)
 
-	ctx := context.Background()
-	require.True(t, rules[0].Matches(ctx, "example.com", "GET", "/"))
-	require.True(t, rules[0].Matches(ctx, "example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "GET", "/"))
+	require.True(t, rules[0].Matches("example.com", "DELETE", "/"))
 }

--- a/internal/proxy/dnsguard_test.go
+++ b/internal/proxy/dnsguard_test.go
@@ -39,7 +39,7 @@ func TestUpstreamDenyGuard_HTTP(t *testing.T) {
 
 	build := func(t *testing.T, denyCIDRs []string) (proxyHTTPAddr string, audits func() []transform.PipelineResult) {
 		t.Helper()
-		al, err := allowlist.New([]string{"*"}, nil, &staticResolver{})
+		al, err := allowlist.New([]string{"*"}, nil)
 		require.NoError(t, err)
 		pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 
@@ -140,7 +140,7 @@ func TestUpstreamDenyGuard_SNIPassthrough(t *testing.T) {
 	_, upstreamPort, err := net.SplitHostPort(upstreamAddr)
 	require.NoError(t, err)
 
-	al, err := allowlist.New([]string{"*"}, nil, &staticResolver{hosts: sniTestHosts})
+	al, err := allowlist.New([]string{"*"}, nil)
 	require.NoError(t, err)
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -49,7 +49,7 @@ func startTunnelIntegrationProxy(t *testing.T, allowedHosts []string, logger *sl
 
 	ca := newIntegrationCA(t)
 
-	al, err := allowlist.New(allowedHosts, nil, &staticResolver{})
+	al, err := allowlist.New(allowedHosts, nil)
 	require.NoError(t, err)
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 	holder := transform.NewPipelineHolder(pipeline)
@@ -111,11 +111,7 @@ func TestIntegration_DNSToProxyToUpstream(t *testing.T) {
 	ca := newIntegrationCA(t)
 
 	// 3. Build transform pipeline with allowlist
-	al, err := allowlist.New(
-		[]string{fakeHost},
-		nil,
-		&staticResolver{},
-	)
+	al, err := allowlist.New([]string{fakeHost}, nil)
 	require.NoError(t, err)
 
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
@@ -498,15 +494,3 @@ func TestIntegration_SOCKS5(t *testing.T) {
 	})
 }
 
-// staticResolver is a test resolver that returns preconfigured addresses.
-type staticResolver struct {
-	hosts map[string][]string
-}
-
-func (r *staticResolver) LookupHost(_ context.Context, host string) ([]string, error) {
-	addrs, ok := r.hosts[host]
-	if !ok {
-		return nil, fmt.Errorf("no such host: %s", host)
-	}
-	return addrs, nil
-}

--- a/internal/proxy/sni_passthrough_test.go
+++ b/internal/proxy/sni_passthrough_test.go
@@ -27,19 +27,10 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
 
-// sniTestHosts covers every hostname used across the SNI passthrough tests.
-// The staticResolver maps each to 127.0.0.1 so the proxy's dial lands on our
-// local test upstream.
-var sniTestHosts = map[string][]string{
-	"localhost":       {"127.0.0.1"},
-	"blocked.example": {"127.0.0.1"},
-	"allowed.example": {"127.0.0.1"},
-}
-
 // startEchoTLSServer starts a TLS server on 127.0.0.1:0 that responds to any
 // request with "echo <path>\n". Returns the host:port address and a cert pool
-// trusting the server's self-signed leaf, whose SANs cover the hostnames in
-// sniTestHosts.
+// trusting the server's self-signed leaf, whose SANs cover localhost,
+// blocked.example, and allowed.example.
 func startEchoTLSServer(t *testing.T) (addr string, pool *x509.CertPool) {
 	t.Helper()
 	cert, pool := newLocalhostTLSCert(t)
@@ -85,7 +76,7 @@ func buildSNIProxy(t *testing.T, allowed []string, withTunnel bool) (*Proxy, fun
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	al, err := allowlist.New(allowed, nil, &staticResolver{hosts: sniTestHosts})
+	al, err := allowlist.New(allowed, nil)
 	require.NoError(t, err)
 	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
 

--- a/internal/transform/allowlist/allowlist.go
+++ b/internal/transform/allowlist/allowlist.go
@@ -25,8 +25,8 @@ type Allowlist struct {
 }
 
 type allowlistConfig struct {
-	Domains []string              `yaml:"domains"`
-	CIDRs   []string              `yaml:"cidrs"`
+	Domains []string               `yaml:"domains"`
+	CIDRs   []string               `yaml:"cidrs"`
 	Rules   []hostmatch.RuleConfig `yaml:"rules"`
 	Warn    bool                   `yaml:"warn"`
 }
@@ -36,15 +36,15 @@ func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing allowlist config: %w", err)
 	}
-	return newFromConfig(c, hostmatch.DefaultResolver())
+	return newFromConfig(c)
 }
 
-func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist, error) {
+func newFromConfig(cfg allowlistConfig) (*Allowlist, error) {
 	var rules []hostmatch.Rule
 
 	// Flat domains → rules with no method/path restrictions.
 	for _, d := range cfg.Domains {
-		m, err := hostmatch.New([]string{d}, nil, resolver)
+		m, err := hostmatch.New([]string{d}, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +53,7 @@ func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist
 
 	// Flat CIDRs → rules with no method/path restrictions.
 	for _, c := range cfg.CIDRs {
-		m, err := hostmatch.New(nil, []string{c}, resolver)
+		m, err := hostmatch.New(nil, []string{c})
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist
 	}
 
 	// Explicit rules with optional method/path restrictions.
-	compiled, err := hostmatch.CompileRules(cfg.Rules, resolver, "allowlist")
+	compiled, err := hostmatch.CompileRules(cfg.Rules, "allowlist")
 	if err != nil {
 		return nil, err
 	}
@@ -72,14 +72,14 @@ func newFromConfig(cfg allowlistConfig, resolver hostmatch.Resolver) (*Allowlist
 
 // New creates an Allowlist from domain globs and CIDR strings.
 // All methods and paths are allowed. This is the backwards-compatible constructor.
-func New(domains []string, cidrs []string, resolver hostmatch.Resolver) (*Allowlist, error) {
-	return newFromConfig(allowlistConfig{Domains: domains, CIDRs: cidrs}, resolver)
+func New(domains []string, cidrs []string) (*Allowlist, error) {
+	return newFromConfig(allowlistConfig{Domains: domains, CIDRs: cidrs})
 }
 
 func (a *Allowlist) Name() string { return "allowlist" }
 
-func (a *Allowlist) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
-	if hostmatch.MatchAnyRule(ctx, a.rules, req) {
+func (a *Allowlist) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if hostmatch.MatchAnyRule(a.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 	if a.warn {

--- a/internal/transform/allowlist/allowlist_test.go
+++ b/internal/transform/allowlist/allowlist_test.go
@@ -13,18 +13,6 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
-type mockResolver struct {
-	hosts map[string][]string
-}
-
-func (m *mockResolver) LookupHost(_ context.Context, host string) ([]string, error) {
-	addrs, ok := m.hosts[host]
-	if !ok {
-		return nil, fmt.Errorf("no such host: %s", host)
-	}
-	return addrs, nil
-}
-
 func result(t *testing.T, a *Allowlist, host string) *transform.TransformResult {
 	t.Helper()
 	req := httptest.NewRequest("GET", "http://"+host+"/", nil)
@@ -46,7 +34,7 @@ func resultWithMethodAndPath(t *testing.T, a *Allowlist, host, method, path stri
 // --- Existing tests (backwards compat via New) ---
 
 func TestAllowlist_ExactDomainMatch(t *testing.T) {
-	a, err := New([]string{"api.openai.com"}, nil, &mockResolver{})
+	a, err := New([]string{"api.openai.com"}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, result(t, a, "api.openai.com").Action)
@@ -54,7 +42,7 @@ func TestAllowlist_ExactDomainMatch(t *testing.T) {
 }
 
 func TestAllowlist_WildcardDomain(t *testing.T) {
-	a, err := New([]string{"*.anthropic.com"}, nil, &mockResolver{})
+	a, err := New([]string{"*.anthropic.com"}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, result(t, a, "api.anthropic.com").Action)
@@ -64,69 +52,57 @@ func TestAllowlist_WildcardDomain(t *testing.T) {
 }
 
 func TestAllowlist_HostWithPort(t *testing.T) {
-	a, err := New([]string{"api.openai.com"}, nil, &mockResolver{})
+	a, err := New([]string{"api.openai.com"}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, result(t, a, "api.openai.com:443").Action)
 	require.Equal(t, transform.ActionReject, result(t, a, "evil.com:443").Action)
 }
 
-func TestAllowlist_CIDRMatch(t *testing.T) {
-	resolver := &mockResolver{
-		hosts: map[string][]string{
-			"internal.service": {"10.0.1.5"},
-			"external.service": {"8.8.8.8"},
-		},
-	}
-	a, err := New(nil, []string{"10.0.0.0/8"}, resolver)
+func TestAllowlist_CIDRMatchesLiteralIP(t *testing.T) {
+	a, err := New(nil, []string{"10.0.0.0/8"})
 	require.NoError(t, err)
 
-	require.Equal(t, transform.ActionContinue, result(t, a, "internal.service").Action)
-	require.Equal(t, transform.ActionReject, result(t, a, "external.service").Action)
+	require.Equal(t, transform.ActionContinue, result(t, a, "10.0.1.5").Action)
+	require.Equal(t, transform.ActionContinue, result(t, a, "10.0.1.5:8080").Action)
+	require.Equal(t, transform.ActionReject, result(t, a, "8.8.8.8").Action)
+}
+
+func TestAllowlist_CIDRDoesNotResolveHostnames(t *testing.T) {
+	// Hostnames are never resolved to check against CIDRs — only literal IPs match.
+	a, err := New(nil, []string{"10.0.0.0/8"})
+	require.NoError(t, err)
+
+	require.Equal(t, transform.ActionReject, result(t, a, "internal.service").Action)
 }
 
 func TestAllowlist_MultipleCIDRs(t *testing.T) {
-	resolver := &mockResolver{
-		hosts: map[string][]string{
-			"a": {"10.0.0.1"},
-			"b": {"172.16.0.1"},
-			"c": {"8.8.8.8"},
-		},
-	}
-	a, err := New(nil, []string{"10.0.0.0/8", "172.16.0.0/12"}, resolver)
+	a, err := New(nil, []string{"10.0.0.0/8", "172.16.0.0/12"})
 	require.NoError(t, err)
 
-	require.Equal(t, transform.ActionContinue, result(t, a, "a").Action)
-	require.Equal(t, transform.ActionContinue, result(t, a, "b").Action)
-	require.Equal(t, transform.ActionReject, result(t, a, "c").Action)
+	require.Equal(t, transform.ActionContinue, result(t, a, "10.0.0.1").Action)
+	require.Equal(t, transform.ActionContinue, result(t, a, "172.16.0.1").Action)
+	require.Equal(t, transform.ActionReject, result(t, a, "8.8.8.8").Action)
 }
 
-func TestAllowlist_DomainMatchSkipsCIDR(t *testing.T) {
-	// If domain matches, CIDR check is not needed (even if resolver would fail)
-	resolver := &mockResolver{} // no hosts — would fail lookup
-	a, err := New([]string{"allowed.com"}, []string{"10.0.0.0/8"}, resolver)
+func TestAllowlist_DomainAndCIDRTogether(t *testing.T) {
+	a, err := New([]string{"allowed.com"}, []string{"10.0.0.0/8"})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, result(t, a, "allowed.com").Action)
-}
-
-func TestAllowlist_UnresolvableHostDenied(t *testing.T) {
-	resolver := &mockResolver{} // no hosts
-	a, err := New(nil, []string{"10.0.0.0/8"}, resolver)
-	require.NoError(t, err)
-
-	require.Equal(t, transform.ActionReject, result(t, a, "unknown.host").Action)
+	require.Equal(t, transform.ActionContinue, result(t, a, "10.0.1.5").Action)
+	require.Equal(t, transform.ActionReject, result(t, a, "evil.com").Action)
 }
 
 func TestAllowlist_EmptyAllowlistDeniesAll(t *testing.T) {
-	a, err := New(nil, nil, &mockResolver{})
+	a, err := New(nil, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionReject, result(t, a, "anything.com").Action)
 }
 
 func TestAllowlist_MultipleDomains(t *testing.T) {
-	a, err := New([]string{"a.com", "b.com", "*.c.com"}, nil, &mockResolver{})
+	a, err := New([]string{"a.com", "b.com", "*.c.com"}, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, result(t, a, "a.com").Action)
@@ -136,13 +112,13 @@ func TestAllowlist_MultipleDomains(t *testing.T) {
 }
 
 func TestAllowlist_InvalidCIDR(t *testing.T) {
-	_, err := New(nil, []string{"not-a-cidr"}, &mockResolver{})
+	_, err := New(nil, []string{"not-a-cidr"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parsing CIDR")
 }
 
 func TestAllowlist_ResponseIsNoop(t *testing.T) {
-	a, err := New(nil, nil, &mockResolver{})
+	a, err := New(nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "http://example.com/", nil)
@@ -153,7 +129,7 @@ func TestAllowlist_ResponseIsNoop(t *testing.T) {
 }
 
 func TestAllowlist_Name(t *testing.T) {
-	a, err := New(nil, nil, &mockResolver{})
+	a, err := New(nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "allowlist", a.Name())
 }
@@ -166,7 +142,7 @@ func TestAllowlist_MethodAllowed(t *testing.T) {
 			Host:    "api.openai.com",
 			Methods: []string{"GET", "POST"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/").Action)
@@ -180,7 +156,7 @@ func TestAllowlist_MethodsCaseInsensitive(t *testing.T) {
 			Host:    "api.openai.com",
 			Methods: []string{"post"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "POST", "/").Action)
@@ -191,7 +167,7 @@ func TestAllowlist_NoMethodsAllowsAll(t *testing.T) {
 		Rules: []hostmatch.RuleConfig{{
 			Host: "api.openai.com",
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/").Action)
@@ -207,7 +183,7 @@ func TestAllowlist_PathGlob(t *testing.T) {
 			Host:  "api.openai.com",
 			Paths: []string{"/v1/*"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/models").Action)
@@ -223,7 +199,7 @@ func TestAllowlist_PathExact(t *testing.T) {
 			Host:  "api.openai.com",
 			Paths: []string{"/health"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/health").Action)
@@ -236,7 +212,7 @@ func TestAllowlist_NoPathsAllowsAll(t *testing.T) {
 		Rules: []hostmatch.RuleConfig{{
 			Host: "api.openai.com",
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/anything").Action)
@@ -249,7 +225,7 @@ func TestAllowlist_MultiplePaths(t *testing.T) {
 			Host:  "api.openai.com",
 			Paths: []string{"/v1/chat", "/v1/models"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.openai.com", "GET", "/v1/chat").Action)
@@ -266,7 +242,7 @@ func TestAllowlist_HostMethodPathCombined(t *testing.T) {
 			Methods: []string{"POST"},
 			Paths:   []string{"/v1/*"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	// All three match
@@ -285,7 +261,7 @@ func TestAllowlist_MultiRuleSecondMatches(t *testing.T) {
 			{Host: "api.openai.com", Methods: []string{"POST"}},
 			{Host: "api.anthropic.com", Methods: []string{"GET"}},
 		},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "api.anthropic.com", "GET", "/").Action)
@@ -299,7 +275,7 @@ func TestAllowlist_FlatDomainsAndRulesMixed(t *testing.T) {
 			Host:    "restricted.com",
 			Methods: []string{"GET"},
 		}},
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	// Flat domain: all methods allowed
@@ -310,21 +286,17 @@ func TestAllowlist_FlatDomainsAndRulesMixed(t *testing.T) {
 }
 
 func TestAllowlist_RuleWithCIDR(t *testing.T) {
-	resolver := &mockResolver{
-		hosts: map[string][]string{
-			"internal.service": {"10.0.1.5"},
-		},
-	}
 	a, err := newFromConfig(allowlistConfig{
 		Rules: []hostmatch.RuleConfig{{
 			CIDR:    "10.0.0.0/8",
 			Methods: []string{"GET"},
 		}},
-	}, resolver)
+	})
 	require.NoError(t, err)
 
-	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "internal.service", "GET", "/").Action)
-	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "internal.service", "POST", "/").Action)
+	require.Equal(t, transform.ActionContinue, resultWithMethodAndPath(t, a, "10.0.1.5", "GET", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "10.0.1.5", "POST", "/").Action)
+	require.Equal(t, transform.ActionReject, resultWithMethodAndPath(t, a, "internal.service", "GET", "/").Action)
 }
 
 // --- Warn mode tests ---
@@ -333,7 +305,7 @@ func TestAllowlist_WarnModeAllowsBlockedRequests(t *testing.T) {
 	a, err := newFromConfig(allowlistConfig{
 		Domains: []string{"api.openai.com"},
 		Warn:    true,
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	// Allowed request: no annotation
@@ -360,7 +332,7 @@ func TestAllowlist_WarnFalseStillRejects(t *testing.T) {
 	a, err := newFromConfig(allowlistConfig{
 		Domains: []string{"api.openai.com"},
 		Warn:    false,
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, transform.ActionReject, result(t, a, "evil.com").Action)
@@ -373,7 +345,7 @@ func TestAllowlist_WarnModeWithRules(t *testing.T) {
 			Methods: []string{"GET"},
 		}},
 		Warn: true,
-	}, &mockResolver{})
+	})
 	require.NoError(t, err)
 
 	// Wrong method in warn mode: continues with annotation
@@ -402,7 +374,7 @@ func TestAllowlist_WarnModeWithRules(t *testing.T) {
 func TestAllowlist_RuleBothHostAndCIDR(t *testing.T) {
 	_, err := newFromConfig(allowlistConfig{
 		Rules: []hostmatch.RuleConfig{{Host: "a.com", CIDR: "10.0.0.0/8"}},
-	}, &mockResolver{})
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "mutually exclusive")
 }
@@ -410,7 +382,7 @@ func TestAllowlist_RuleBothHostAndCIDR(t *testing.T) {
 func TestAllowlist_RuleNeitherHostNorCIDR(t *testing.T) {
 	_, err := newFromConfig(allowlistConfig{
 		Rules: []hostmatch.RuleConfig{{Methods: []string{"GET"}}},
-	}, &mockResolver{})
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "one of host or cidr is required")
 }
@@ -418,7 +390,7 @@ func TestAllowlist_RuleNeitherHostNorCIDR(t *testing.T) {
 func TestAllowlist_RuleInvalidPath(t *testing.T) {
 	_, err := newFromConfig(allowlistConfig{
 		Rules: []hostmatch.RuleConfig{{Host: "a.com", Paths: []string{"no-leading-slash"}}},
-	}, &mockResolver{})
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must start with /")
 }

--- a/internal/transform/annotate/annotate.go
+++ b/internal/transform/annotate/annotate.go
@@ -43,10 +43,10 @@ func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing annotate config: %w", err)
 	}
-	return newFromConfig(c, hostmatch.NullResolver{})
+	return newFromConfig(c)
 }
 
-func newFromConfig(cfg annotateConfig, resolver hostmatch.Resolver) (*Annotate, error) {
+func newFromConfig(cfg annotateConfig) (*Annotate, error) {
 	if len(cfg.Annotations) == 0 {
 		return nil, fmt.Errorf("annotate: at least one annotation group is required")
 	}
@@ -60,7 +60,7 @@ func newFromConfig(cfg annotateConfig, resolver hostmatch.Resolver) (*Annotate, 
 			return nil, fmt.Errorf("annotate: annotations[%d]: at least one header is required", i)
 		}
 
-		compiled, err := hostmatch.CompileRules(ag.Rules, resolver, fmt.Sprintf("annotate annotations[%d]", i))
+		compiled, err := hostmatch.CompileRules(ag.Rules, fmt.Sprintf("annotate annotations[%d]", i))
 		if err != nil {
 			return nil, err
 		}
@@ -78,9 +78,9 @@ func newFromConfig(cfg annotateConfig, resolver hostmatch.Resolver) (*Annotate, 
 
 func (a *Annotate) Name() string { return "annotate" }
 
-func (a *Annotate) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+func (a *Annotate) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
 	for _, g := range a.groups {
-		if !hostmatch.MatchAnyRule(ctx, g.rules, req) {
+		if !hostmatch.MatchAnyRule(g.rules, req) {
 			continue
 		}
 		for _, h := range g.headers {

--- a/internal/transform/annotate/annotate_test.go
+++ b/internal/transform/annotate/annotate_test.go
@@ -14,7 +14,7 @@ import (
 
 func makeAnnotate(t *testing.T, groups []annotationGroup) *Annotate {
 	t.Helper()
-	a, err := newFromConfig(annotateConfig{Annotations: groups}, hostmatch.NullResolver{})
+	a, err := newFromConfig(annotateConfig{Annotations: groups})
 	require.NoError(t, err)
 	return a
 }
@@ -223,7 +223,7 @@ func TestAnnotate_MultipleHeaderValues(t *testing.T) {
 // --- Validation tests ---
 
 func TestAnnotate_EmptyAnnotationsValidation(t *testing.T) {
-	_, err := newFromConfig(annotateConfig{}, hostmatch.NullResolver{})
+	_, err := newFromConfig(annotateConfig{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "at least one annotation group is required")
 }
@@ -233,7 +233,7 @@ func TestAnnotate_EmptyRulesValidation(t *testing.T) {
 		Annotations: []annotationGroup{{
 			Headers: []string{"x-foo"},
 		}},
-	}, hostmatch.NullResolver{})
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "at least one rule is required")
 }
@@ -243,7 +243,7 @@ func TestAnnotate_EmptyHeadersValidation(t *testing.T) {
 		Annotations: []annotationGroup{{
 			Rules: []hostmatch.RuleConfig{{Host: "example.com"}},
 		}},
-	}, hostmatch.NullResolver{})
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "at least one header is required")
 }

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -106,7 +106,7 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 	}
 
 	prefix := fmt.Sprintf("grpc transform %q", cfg.Name)
-	rules, err := hostmatch.CompileRules(cfg.Rules, hostmatch.DefaultResolver(), prefix)
+	rules, err := hostmatch.CompileRules(cfg.Rules, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 func (g *GRPCTransform) Name() string { return g.name }
 
 func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
-	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(ctx, g.rules, req) {
+	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(g.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 
@@ -166,7 +166,7 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 }
 
 func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.TransformContext, req *http.Request, resp *http.Response) (*transform.TransformResult, error) {
-	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(ctx, g.rules, req) {
+	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(g.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 

--- a/internal/transform/judge/transform.go
+++ b/internal/transform/judge/transform.go
@@ -101,7 +101,7 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 		return nil, fmt.Errorf("judge transform %q: %w", c.Name, err)
 	}
 
-	rules, err := hostmatch.CompileRules(c.Rules, hostmatch.DefaultResolver(), fmt.Sprintf("judge transform %q", c.Name))
+	rules, err := hostmatch.CompileRules(c.Rules, fmt.Sprintf("judge transform %q", c.Name))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (j *Judge) TransformResponse(_ context.Context, _ *transform.TransformConte
 // TransformRequest runs the judge over a request. See the package doc-style
 // comment on the judge transform for the full control-flow description.
 func (j *Judge) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
-	if !hostmatch.MatchAnyRule(ctx, j.rules, req) {
+	if !hostmatch.MatchAnyRule(j.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 

--- a/internal/transform/judge/transform_test.go
+++ b/internal/transform/judge/transform_test.go
@@ -79,7 +79,7 @@ func makeJudge(t *testing.T, adapter llm.Adapter, overrides func(*judgeConfig)) 
 	if overrides != nil {
 		overrides(&cfg)
 	}
-	rules, err := hostmatch.CompileRules(cfg.Rules, hostmatch.NullResolver{}, "test")
+	rules, err := hostmatch.CompileRules(cfg.Rules, "test")
 	require.NoError(t, err)
 	j, err := newFromConfig(cfg, adapter, rules, slog.Default())
 	require.NoError(t, err)
@@ -281,7 +281,7 @@ func TestJudge_Name(t *testing.T) {
 
 func TestJudge_ConfigValidation(t *testing.T) {
 	// These tests go through newFromConfig to bypass the yaml.Node plumbing.
-	rules, err := hostmatch.CompileRules([]hostmatch.RuleConfig{{Host: "x"}}, hostmatch.NullResolver{}, "test")
+	rules, err := hostmatch.CompileRules([]hostmatch.RuleConfig{{Host: "x"}}, "test")
 	require.NoError(t, err)
 
 	_, err = newFromConfig(judgeConfig{Name: "j", Prompt: "p", Fallback: "maybe"}, &fakeAdapter{}, rules, nil)

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -140,7 +140,7 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 			return nil, fmt.Errorf("secrets[%d]: %w", i, err)
 		}
 
-		rules, err := hostmatch.CompileRules(entry.Rules, hostmatch.NullResolver{}, fmt.Sprintf("secrets[%d]", i))
+		rules, err := hostmatch.CompileRules(entry.Rules, fmt.Sprintf("secrets[%d]", i))
 		if err != nil {
 			return nil, err
 		}
@@ -261,7 +261,7 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	var swapped, injected []secretRecord
 
 	for _, sec := range s.secrets {
-		if !hostmatch.MatchAnyRule(ctx, sec.rules, req) {
+		if !hostmatch.MatchAnyRule(sec.rules, req) {
 			continue
 		}
 


### PR DESCRIPTION
Removes the `Resolver` interface, `DefaultResolver`, `NullResolver`, and the resolver param plumbed through every transform. CIDR rules match literal CIDRs, while hostnames match literal hostnames. This is the intended behavior. Resolution inside rules was never possible due to config validation, so this is mostly dead code.