### PR TITLE
feat(secrets): support regex match_headers patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ iron-proxy scans outbound requests and replaces proxy tokens with the real
 values before forwarding upstream. You control where it looks:
 
 - **`match_headers`:** list of header names to scan. Empty list = all headers.
+  Entries delimited by `/.../` are compiled as case-insensitive regular
+  expressions matched against canonical header names (e.g. `/^x-.*-key$/`).
 - **`match_body`:** scan the request body (buffered up to `max_request_body_bytes`).
 - **`match_path`:** scan the URL path. Defaults to `false`; opt in for upstreams
   like Telegram that embed the secret in the path (e.g.

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -67,7 +68,7 @@ type resolvedSecret struct {
 
 	// replace mode fields
 	proxyValue   string
-	matchHeaders []string // empty = all headers
+	matchHeaders []headerMatcher // empty = all headers
 	matchBody    bool
 	matchPath    bool
 	require      bool
@@ -76,6 +77,34 @@ type resolvedSecret struct {
 	injectHeader     string
 	injectQueryParam string
 	formatter        *template.Template // nil = identity (raw value)
+}
+
+// headerMatcher selects request headers to scan. Exactly one of name or re is set.
+type headerMatcher struct {
+	name string         // canonical header name; "" if regex
+	re   *regexp.Regexp // nil if literal name match
+}
+
+// parseHeaderMatchers compiles match_headers entries. Patterns delimited by
+// "/.../" are compiled as case-insensitive regular expressions matched against
+// canonical header names; all other entries are literal header names.
+func parseHeaderMatchers(patterns []string, ctx string) ([]headerMatcher, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	matchers := make([]headerMatcher, 0, len(patterns))
+	for _, p := range patterns {
+		if len(p) >= 2 && strings.HasPrefix(p, "/") && strings.HasSuffix(p, "/") {
+			re, err := regexp.Compile("(?i)" + p[1:len(p)-1])
+			if err != nil {
+				return nil, fmt.Errorf("%s: invalid match_headers regex %q: %w", ctx, p, err)
+			}
+			matchers = append(matchers, headerMatcher{re: re})
+			continue
+		}
+		matchers = append(matchers, headerMatcher{name: http.CanonicalHeaderKey(p)})
+	}
+	return matchers, nil
 }
 
 // formatterData is the template context for inject formatters.
@@ -163,12 +192,16 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 			}
 			resolved = append(resolved, sec)
 		} else {
+			matchers, err := parseHeaderMatchers(replace.MatchHeaders, fmt.Sprintf("secrets[%d]", i))
+			if err != nil {
+				return nil, err
+			}
 			resolved = append(resolved, resolvedSecret{
 				name:         result.Name,
 				mode:         "replace",
 				proxyValue:   replace.ProxyValue,
 				getValue:     result.GetValue,
-				matchHeaders: replace.MatchHeaders,
+				matchHeaders: matchers,
 				matchBody:    replace.MatchBody,
 				matchPath:    replace.MatchPath,
 				require:      replace.Require,
@@ -352,22 +385,7 @@ func (s *Secrets) TransformResponse(_ context.Context, _ *transform.TransformCon
 
 func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue string) []string {
 	var locations []string
-	if len(sec.matchHeaders) > 0 {
-		for _, name := range sec.matchHeaders {
-			if vals := req.Header.Values(name); len(vals) > 0 {
-				for _, v := range vals {
-					if headerContains(name, v, sec.proxyValue) {
-						locations = append(locations, "header:"+name)
-						break
-					}
-				}
-				req.Header.Del(name)
-				for _, v := range vals {
-					req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, realValue))
-				}
-			}
-		}
-	} else {
+	if len(sec.matchHeaders) == 0 {
 		for name, vals := range req.Header {
 			for i, v := range vals {
 				if headerContains(name, v, sec.proxyValue) {
@@ -376,6 +394,44 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue 
 				}
 			}
 		}
+		return locations
+	}
+
+	processed := make(map[string]struct{})
+	swap := func(name string) {
+		if _, done := processed[name]; done {
+			return
+		}
+		processed[name] = struct{}{}
+		vals := req.Header.Values(name)
+		if len(vals) == 0 {
+			return
+		}
+		hit := false
+		for _, v := range vals {
+			if headerContains(name, v, sec.proxyValue) {
+				hit = true
+				break
+			}
+		}
+		req.Header.Del(name)
+		for _, v := range vals {
+			req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, realValue))
+		}
+		if hit {
+			locations = append(locations, "header:"+name)
+		}
+	}
+	for _, m := range sec.matchHeaders {
+		if m.re != nil {
+			for name := range req.Header {
+				if m.re.MatchString(name) {
+					swap(name)
+				}
+			}
+			continue
+		}
+		swap(m.name)
 	}
 	return locations
 }

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -262,6 +262,98 @@ func TestSecrets_EmptyMatchHeadersSearchesAll(t *testing.T) {
 	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Custom"))
 }
 
+func TestSecrets_RegexMatchHeaders(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{`/^X-.*-Key$/`}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123")
+	req.Header.Set("X-Other-Key", "proxy-openai-abc123")
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123") // not matched
+	req.Header.Set("X-Trace", "proxy-openai-abc123")              // not matched
+
+	doTransform(t, s, req)
+
+	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Api-Key"))
+	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Other-Key"))
+	require.Equal(t, "Bearer proxy-openai-abc123", req.Header.Get("Authorization"))
+	require.Equal(t, "proxy-openai-abc123", req.Header.Get("X-Trace"))
+}
+
+func TestSecrets_RegexMatchHeaders_CaseInsensitiveByDefault(t *testing.T) {
+	// Lowercase pattern matches the canonical "Authorization" header.
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{`/^authorization$/`}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+}
+
+func TestSecrets_RegexMatchHeaders_MixedWithLiteral(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{"Authorization", `/^X-Api-.*$/`}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123")
+	req.Header.Set("X-Custom", "proxy-openai-abc123") // not matched
+
+	doTransform(t, s, req)
+
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Api-Key"))
+	require.Equal(t, "proxy-openai-abc123", req.Header.Get("X-Custom"))
+}
+
+func TestSecrets_RegexMatchHeaders_OverlappingPatternsDontDoubleSwap(t *testing.T) {
+	// Two patterns that both match "X-Api-Key": ensure the swap runs once and
+	// doesn't replace twice (which would be idempotent for non-Basic, but the
+	// location annotation would duplicate).
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{"X-Api-Key", `/^X-.*$/`}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Api-Key"))
+}
+
+func TestSecrets_RegexMatchHeaders_RequireRejectsWhenNoMatch(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{`/^X-.*-Key$/`}
+		e.Require = true
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "no-token-here")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestSecrets_RegexMatchHeaders_InvalidRegex(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source:       envSource("OPENAI_API_KEY"),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{`/[invalid/`},
+		Rules:        []hostmatch.RuleConfig{{Host: "example.com"}},
+	}}}
+	_, err := newFromConfig(context.Background(), cfg, testRegistry())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid match_headers regex")
+}
+
 func TestSecrets_ConfigErrors(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
The secrets transform's `match_headers` list now accepts regex patterns delimited by `/.../`. Patterns are compiled at config time as case-insensitive regular expressions and matched against canonical header names; literal entries continue to work and can be mixed with regex entries.