### PR TITLE
feat(transforms): add header_allowlist transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,43 @@ transforms:
           headers: ["x-request-id"]
 ```
 
+### Header allowlist
+
+Default-deny request header filter. Any request header whose canonical name is
+not in the configured `headers` list is stripped before the request goes
+upstream. Useful for blocking tracking, fingerprinting, or accidental leakage
+headers (cookies, internal correlation IDs, `X-Forwarded-*`, etc.) that the
+sandbox might attach.
+
+Entries are matched case-insensitively against the canonical header name.
+Patterns delimited by `/.../` (e.g. `/^X-Trace-.*$/`) are case-insensitive
+regular expressions, mirroring the `secrets` transform's `match_headers`
+syntax.
+
+Optional `rules` limit the allowlist to specific hosts/methods/paths. When
+omitted, the allowlist applies to every request that reaches this transform.
+
+When at least one header is stripped, the trace is annotated with
+`stripped_headers` listing the removed names.
+
+> **Placement:** put `header_allowlist` *after* `secrets` (so injected
+> credentials are not stripped if not in the allowlist, you can list them) and
+> *after* `annotate` (so annotation reads the original headers).
+
+```yaml
+transforms:
+  - name: header_allowlist
+    config:
+      headers:
+        - "Authorization"
+        - "Content-Type"
+        - "User-Agent"
+        - "Accept"
+        - "/^X-Trace-.*$/"
+      rules:
+        - host: "api.openai.com"
+```
+
 ### Secrets
 
 The sandbox never holds real credentials. Instead:

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
+	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )

--- a/internal/transform/headerallowlist/headerallowlist.go
+++ b/internal/transform/headerallowlist/headerallowlist.go
@@ -1,0 +1,129 @@
+// Package headerallowlist implements a default-deny request header allowlist
+// transform. Any request header whose canonical name is not in the configured
+// list (and does not match a configured regex pattern) is stripped before the
+// request is sent upstream.
+package headerallowlist
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func init() {
+	transform.Register("header_allowlist", factory)
+}
+
+type config struct {
+	Headers []string               `yaml:"headers"`
+	Rules   []hostmatch.RuleConfig `yaml:"rules"`
+}
+
+// HeaderAllowlist strips request headers not in the configured allowlist.
+type HeaderAllowlist struct {
+	matchers []headerMatcher
+	rules    []hostmatch.Rule // nil = apply to all requests
+}
+
+// headerMatcher matches a single allowlist entry. Exactly one of name or re is set.
+type headerMatcher struct {
+	name string
+	re   *regexp.Regexp
+}
+
+func (m headerMatcher) matches(canonical string) bool {
+	if m.re != nil {
+		return m.re.MatchString(canonical)
+	}
+	return m.name == canonical
+}
+
+func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing header_allowlist config: %w", err)
+	}
+	return newFromConfig(c)
+}
+
+func newFromConfig(c config) (*HeaderAllowlist, error) {
+	if len(c.Headers) == 0 {
+		return nil, fmt.Errorf("header_allowlist: at least one header is required")
+	}
+
+	matchers, err := parseHeaderMatchers(c.Headers)
+	if err != nil {
+		return nil, err
+	}
+
+	rules, err := hostmatch.CompileRules(c.Rules, "header_allowlist")
+	if err != nil {
+		return nil, err
+	}
+
+	return &HeaderAllowlist{matchers: matchers, rules: rules}, nil
+}
+
+// parseHeaderMatchers compiles allowlist entries. Patterns delimited by
+// "/.../" are compiled as case-insensitive regular expressions matched against
+// canonical header names; all other entries are literal header names.
+func parseHeaderMatchers(patterns []string) ([]headerMatcher, error) {
+	matchers := make([]headerMatcher, 0, len(patterns))
+	for _, p := range patterns {
+		if len(p) >= 2 && strings.HasPrefix(p, "/") && strings.HasSuffix(p, "/") {
+			re, err := regexp.Compile("(?i)" + p[1:len(p)-1])
+			if err != nil {
+				return nil, fmt.Errorf("header_allowlist: invalid headers regex %q: %w", p, err)
+			}
+			matchers = append(matchers, headerMatcher{re: re})
+			continue
+		}
+		matchers = append(matchers, headerMatcher{name: http.CanonicalHeaderKey(p)})
+	}
+	return matchers, nil
+}
+
+func (h *HeaderAllowlist) Name() string { return "header_allowlist" }
+
+func (h *HeaderAllowlist) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if len(h.rules) > 0 && !hostmatch.MatchAnyRule(h.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	var stripped []string
+	for name := range req.Header {
+		if h.allowed(name) {
+			continue
+		}
+		req.Header.Del(name)
+		stripped = append(stripped, name)
+	}
+
+	if len(stripped) > 0 {
+		tctx.Annotate("stripped_headers", stripped)
+	}
+
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (h *HeaderAllowlist) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (h *HeaderAllowlist) allowed(name string) bool {
+	canonical := http.CanonicalHeaderKey(name)
+	for _, m := range h.matchers {
+		if m.matches(canonical) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/transform/headerallowlist/headerallowlist_test.go
+++ b/internal/transform/headerallowlist/headerallowlist_test.go
@@ -1,0 +1,169 @@
+package headerallowlist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func runRequest(t *testing.T, h *HeaderAllowlist, req *http.Request) (*transform.TransformContext, *transform.TransformResult) {
+	t.Helper()
+	tctx := &transform.TransformContext{}
+	res, err := h.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	return tctx, res
+}
+
+func headerNames(req *http.Request) []string {
+	names := make([]string, 0, len(req.Header))
+	for k := range req.Header {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestHeaderAllowlist_StripsDisallowed(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"Authorization", "Content-Type"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "http://api.example.com/", nil)
+	req.Header.Set("Authorization", "Bearer x")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", "session=abc")
+	req.Header.Set("X-Sneaky", "1")
+
+	tctx, _ := runRequest(t, h, req)
+
+	require.Equal(t, []string{"Authorization", "Content-Type"}, headerNames(req))
+
+	stripped := tctx.DrainAnnotations()["stripped_headers"].([]string)
+	sort.Strings(stripped)
+	require.Equal(t, []string{"Cookie", "X-Sneaky"}, stripped)
+}
+
+func TestHeaderAllowlist_CaseInsensitiveMatch(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"x-request-id"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("X-Request-Id", "abc")
+	req.Header.Set("x-other", "1")
+
+	runRequest(t, h, req)
+	require.Equal(t, []string{"X-Request-Id"}, headerNames(req))
+}
+
+func TestHeaderAllowlist_RegexEntry(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"/^X-Trace-.*$/"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("X-Trace-Id", "1")
+	req.Header.Set("X-Trace-Parent", "2")
+	req.Header.Set("X-Other", "3")
+
+	runRequest(t, h, req)
+	require.Equal(t, []string{"X-Trace-Id", "X-Trace-Parent"}, headerNames(req))
+}
+
+func TestHeaderAllowlist_AllAllowed_NoAnnotation(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"Authorization"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Authorization", "Bearer x")
+
+	tctx, _ := runRequest(t, h, req)
+	require.Equal(t, []string{"Authorization"}, headerNames(req))
+	require.Nil(t, tctx.DrainAnnotations())
+}
+
+func TestHeaderAllowlist_RulesScopeMatching(t *testing.T) {
+	h, err := newFromConfig(config{
+		Headers: []string{"Authorization"},
+		Rules: []hostmatch.RuleConfig{
+			{Host: "api.example.com"},
+		},
+	})
+	require.NoError(t, err)
+
+	// In-scope: stripping happens.
+	req1 := httptest.NewRequest("GET", "http://api.example.com/", nil)
+	req1.Host = "api.example.com"
+	req1.Header.Set("Authorization", "Bearer x")
+	req1.Header.Set("X-Other", "1")
+	runRequest(t, h, req1)
+	require.Equal(t, []string{"Authorization"}, headerNames(req1))
+
+	// Out-of-scope: untouched.
+	req2 := httptest.NewRequest("GET", "http://other.example.com/", nil)
+	req2.Host = "other.example.com"
+	req2.Header.Set("Authorization", "Bearer x")
+	req2.Header.Set("X-Other", "1")
+	runRequest(t, h, req2)
+	require.Equal(t, []string{"Authorization", "X-Other"}, headerNames(req2))
+}
+
+func TestHeaderAllowlist_NoRulesAppliesToAll(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"Content-Type"}})
+	require.NoError(t, err)
+
+	for _, host := range []string{"a.example.com", "b.example.com"} {
+		req := httptest.NewRequest("GET", "http://"+host+"/", nil)
+		req.Host = host
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Drop", "1")
+		runRequest(t, h, req)
+		require.Equal(t, []string{"Content-Type"}, headerNames(req))
+	}
+}
+
+func TestHeaderAllowlist_ResponseIsNoop(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"Authorization"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	resp.Header.Set("X-Server", "nginx")
+
+	res, err := h.TransformResponse(context.Background(), &transform.TransformContext{}, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	// Response headers untouched.
+	require.Equal(t, "nginx", resp.Header.Get("X-Server"))
+}
+
+func TestHeaderAllowlist_Name(t *testing.T) {
+	h, err := newFromConfig(config{Headers: []string{"Authorization"}})
+	require.NoError(t, err)
+	require.Equal(t, "header_allowlist", h.Name())
+}
+
+func TestHeaderAllowlist_RequiresHeaders(t *testing.T) {
+	_, err := newFromConfig(config{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one header is required")
+}
+
+func TestHeaderAllowlist_InvalidRegex(t *testing.T) {
+	_, err := newFromConfig(config{Headers: []string{"/[unterminated/"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid headers regex")
+}
+
+func TestHeaderAllowlist_InvalidRule(t *testing.T) {
+	_, err := newFromConfig(config{
+		Headers: []string{"Authorization"},
+		Rules:   []hostmatch.RuleConfig{{Host: "a.com", CIDR: "10.0.0.0/8"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -210,6 +210,23 @@ transforms:
         #   rules:
         #     - host: "api.openai.com"
 
+  # Header allowlist: strips any request header not listed below before the
+  # request goes upstream. Default-deny — every header must either match a
+  # literal name (case-insensitive) or a /regex/ pattern. Place this AFTER
+  # transforms that inject headers (e.g. secrets) so injected headers survive.
+  # - name: header_allowlist
+  #   config:
+  #     headers:
+  #       - "Authorization"
+  #       - "Content-Type"
+  #       - "User-Agent"
+  #       - "Accept"
+  #       - "/^X-Trace-.*$/"
+  #     # Optional rules limit the allowlist to specific hosts/methods/paths.
+  #     # Omit for all requests.
+  #     rules:
+  #       - host: "api.openai.com"
+
   # gRPC transforms: each entry delegates to one external TransformService server.
   # Use multiple entries for multiple servers; they run in pipeline order.
   - name: grpc


### PR DESCRIPTION
Adds a default-deny request header allowlist transform. Any request header whose canonical name is not in the configured `headers` list (or matching `/regex/` entry) is stripped before the request is forwarded upstream, with stripped names recorded in the trace annotation `stripped_headers`. Optional `rules` scope the allowlist to specific host/method/path combinations.