### PR TITLE
feat(mcp): add MCP-aware policy interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,50 @@ trace, including `judge.instance`, `judge.decision`, `judge.reason`,
 Credits: thanks to Brex for their CrabTrap project (MIT-licensed), which
 informed this design.
 
+## MCP policy
+
+iron-proxy can speak [MCP's Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports). When a request matches a configured MCP server, the proxy parses the JSON-RPC body, applies a default-deny tool allowlist, and filters `tools/list` responses so denied tools never reach the agent. SSE responses are filtered per event so long-lived MCP streams stay live.
+
+This is a first-class proxy capability rather than a transform: MCP responses can be open-ended SSE streams carrying arbitrary server-initiated messages, which does not fit the request/response transform contract.
+
+```yaml
+mcp:
+  # JSON-RPC error envelope returned to the agent on policy denial.
+  # Defaults: code -32001, message "blocked by iron-proxy policy".
+  error:
+    code: -32001
+    message: "blocked by iron-proxy policy"
+  servers:
+    - name: github                         # appears in audit as mcp.server
+      rules:                               # standard host/method/path rules
+        - host: "mcp.github.com"
+          paths: ["/mcp", "/mcp/*"]
+      tools:
+        - name: "search_repositories"      # always allowed
+        - name: "create_issue"
+          when:                            # all clauses must hold; otherwise deny
+            - path: "owner"                # dotted path against arguments
+              equals: "ironsh"
+            - path: "repo"
+              in: ["iron-proxy", "tunis-v2"]
+        # Anything not listed is denied (default-deny).
+```
+
+Behavior:
+
+- **`tools/call` enforcement.** Calls to tools that are not in the server's `tools` list, or whose `arguments` fail any `when` clause, are rejected without reaching upstream. The proxy returns a JSON-RPC error response with the configured code and message and the request's original `id`, so the MCP client sees a normal protocol error rather than an HTTP failure.
+- **`tools/list` filtering.** Responses to `tools/list` have any tool not on the allowlist removed before reaching the agent. Works for both `application/json` and `text/event-stream` responses; SSE filtering operates per event so heartbeats and other messages on the stream pass through untouched.
+- **Argument matching.** Each `when` clause has a dotted `path` (e.g. `arguments.repo`, `labels.0`) and one of `equals` (any JSON scalar), `in` (a list of scalars), or `matches` (a regex on string values). Clauses AND together. Omitting `when` allows the tool unconditionally.
+- **Audit.** Every observed JSON-RPC message is recorded under a new `mcp` section in the audit log entry: server name, direction (`request` or `response`), method, tool, decision (`allow`, `deny`, or `filtered`), reason on denials, and the count of tools removed on filter events.
+
+Pipeline ordering: the MCP interceptor runs after the transform pipeline, so `allowlist` still gates which hosts can be reached and `secrets` has already swapped proxy tokens by the time the interceptor evaluates the body.
+
+Limitations in v1:
+
+- Only Streamable HTTP transport is supported. The legacy HTTP+SSE transport (separate `/messages` and `/sse` endpoints) is not.
+- A JSON-RPC batch with any denied entry is rejected as a whole batch; partial-batch forwarding is not supported.
+- Resources and prompts are not enforced. Agents can still call `resources/list`, `resources/read`, etc. without policy filtering.
+
 ### Body limits
 
 Transforms that inspect or forward request/response bodies (secrets body

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -198,11 +198,9 @@ func main() {
 		)
 	}
 
-	// Compile MCP policy from the top-level mcp: block, if present. Validate
-	// has already vetted the config; Compile here returns the runtime form.
-	mcpPolicy, err := mcp.Compile(cfg.MCP)
+	mcpPolicy, err := mcp.LoadFromNode(cfg.MCP)
 	if err != nil {
-		logger.Error("compiling mcp policy", slog.String("error", err.Error()))
+		logger.Error("loading mcp policy", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	if mcpPolicy != nil {

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	idns "github.com/ironsh/iron-proxy/internal/dns"
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/management"
+	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/metrics"
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/proxy"
@@ -197,6 +198,17 @@ func main() {
 		)
 	}
 
+	// Compile MCP policy from the top-level mcp: block, if present. Validate
+	// has already vetted the config; Compile here returns the runtime form.
+	mcpPolicy, err := mcp.Compile(cfg.MCP)
+	if err != nil {
+		logger.Error("compiling mcp policy", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if mcpPolicy != nil {
+		logger.Info("mcp policy enabled")
+	}
+
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
@@ -207,6 +219,7 @@ func main() {
 		Pipeline:                      holder,
 		Resolver:                      resolver,
 		Guard:                         guard,
+		MCPPolicy:                     mcpPolicy,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 	})

--- a/integration_test/mcp_test.go
+++ b/integration_test/mcp_test.go
@@ -37,16 +37,19 @@ func TestMCPPolicy(t *testing.T) {
 		_ = json.Unmarshal([]byte(body), &msg)
 
 		// Switch on a hint header so the test can ask for SSE responses.
+		// Write errors are ignored: this is a fixture HTTP handler running in
+		// a background goroutine, and a broken client connection cannot be
+		// surfaced from here anyway.
 		if r.Header.Get("X-Test-Response") == "sse" {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
 			flusher, _ := w.(http.Flusher)
 			payload := buildToolsListPayload(msg.ID)
-			fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
+			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
 			if flusher != nil {
 				flusher.Flush()
 			}
-			fmt.Fprint(w, ": keepalive\n\n")
+			_, _ = fmt.Fprint(w, ": keepalive\n\n")
 			if flusher != nil {
 				flusher.Flush()
 			}
@@ -59,7 +62,7 @@ func TestMCPPolicy(t *testing.T) {
 		case "tools/list":
 			_, _ = w.Write([]byte(buildToolsListPayload(msg.ID)))
 		default:
-			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, idOrNull(msg.ID))
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, idOrNull(msg.ID))
 		}
 	}))
 	t.Cleanup(upstream.Close)

--- a/integration_test/mcp_test.go
+++ b/integration_test/mcp_test.go
@@ -1,0 +1,211 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPPolicy boots a fake MCP server and an iron-proxy with an mcp policy
+// configured, then exercises the full request/response interception path:
+// allowed tools/call, denied tools/call (returning a JSON-RPC error envelope
+// without reaching upstream), and tools/list response filtering over both
+// JSON and SSE responses.
+func TestMCPPolicy(t *testing.T) {
+	type upstreamHit struct {
+		method string
+		body   string
+	}
+	hits := make(chan upstreamHit, 8)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		hits <- upstreamHit{method: r.Method, body: string(body)}
+
+		// Inspect what was asked: tools/list returns a list of tools.
+		// tools/call returns a generic ok result.
+		var msg struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		_ = json.Unmarshal([]byte(body), &msg)
+
+		// Switch on a hint header so the test can ask for SSE responses.
+		if r.Header.Get("X-Test-Response") == "sse" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			payload := buildToolsListPayload(msg.ID)
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", payload)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			fmt.Fprint(w, ": keepalive\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch msg.Method {
+		case "tools/list":
+			_, _ = w.Write([]byte(buildToolsListPayload(msg.ID)))
+		default:
+			fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":{"ok":true}}`, idOrNull(msg.ID))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfgPath := renderConfig(t, t.TempDir(), "mcp_pipeline.yaml", nil)
+	proxy := startProxy(t, proxyBinary(t), cfgPath, nil)
+
+	upstreamHost := upstream.Listener.Addr().String()
+
+	doReq := func(t *testing.T, body string, headers map[string]string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest("POST", "http://"+proxy.HTTPAddr+"/mcp", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Host = upstreamHost
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	drainHits := func() {
+		for {
+			select {
+			case <-hits:
+			default:
+				return
+			}
+		}
+	}
+
+	t.Run("allowed_tools_call_reaches_upstream", func(t *testing.T) {
+		drainHits()
+		resp := doReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories","arguments":{"q":"foo"}}}`, nil)
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var msg struct {
+			Result struct {
+				OK bool `json:"ok"`
+			} `json:"result"`
+			Error any `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(body, &msg))
+		require.True(t, msg.Result.OK)
+		require.Nil(t, msg.Error)
+
+		select {
+		case hit := <-hits:
+			require.Contains(t, hit.body, "search_repositories")
+		default:
+			t.Fatal("upstream was not reached")
+		}
+	})
+
+	t.Run("denied_tools_call_returns_json_rpc_error", func(t *testing.T) {
+		drainHits()
+		resp := doReq(t, `{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"delete_repo","arguments":{}}}`, nil)
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var msg struct {
+			ID    json.RawMessage `json:"id"`
+			Error *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(body, &msg))
+		require.NotNil(t, msg.Error)
+		require.Equal(t, -32001, msg.Error.Code)
+		require.Equal(t, "blocked by iron-proxy policy", msg.Error.Message)
+		require.Equal(t, "42", string(msg.ID))
+
+		select {
+		case hit := <-hits:
+			t.Fatalf("upstream should not have been reached; got hit %+v", hit)
+		default:
+		}
+	})
+
+	t.Run("argument_constraint_denies", func(t *testing.T) {
+		drainHits()
+		resp := doReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_issue","arguments":{"owner":"someoneelse"}}}`, nil)
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		var msg struct {
+			Error *struct {
+				Code int `json:"code"`
+			} `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal(body, &msg))
+		require.NotNil(t, msg.Error)
+		require.Equal(t, -32001, msg.Error.Code)
+	})
+
+	t.Run("tools_list_json_response_filtered", func(t *testing.T) {
+		drainHits()
+		resp := doReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, nil)
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		var msg struct {
+			Result struct {
+				Tools []map[string]any `json:"tools"`
+			} `json:"result"`
+		}
+		require.NoError(t, json.Unmarshal(body, &msg))
+
+		names := make([]string, 0, len(msg.Result.Tools))
+		for _, t := range msg.Result.Tools {
+			if n, ok := t["name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+		require.ElementsMatch(t, []string{"search_repositories", "create_issue"}, names,
+			"hidden_tool should be filtered from response")
+	})
+
+	t.Run("tools_list_sse_response_filtered", func(t *testing.T) {
+		drainHits()
+		resp := doReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, map[string]string{"X-Test-Response": "sse"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+
+		out := string(body)
+		require.Contains(t, out, "search_repositories")
+		require.Contains(t, out, "create_issue")
+		require.NotContains(t, out, "hidden_tool")
+		require.Contains(t, out, ": keepalive")
+	})
+}
+
+func buildToolsListPayload(id json.RawMessage) string {
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{"tools":[{"name":"search_repositories"},{"name":"hidden_tool"},{"name":"create_issue"}]}}`, idOrNull(id))
+}
+
+func idOrNull(id json.RawMessage) string {
+	if len(id) == 0 {
+		return "null"
+	}
+	return string(id)
+}

--- a/integration_test/testdata/mcp_pipeline.yaml
+++ b/integration_test/testdata/mcp_pipeline.yaml
@@ -1,0 +1,41 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+mcp:
+  error:
+    code: -32001
+    message: "blocked by iron-proxy policy"
+  servers:
+    - name: testserver
+      rules:
+        - host: "127.0.0.1"
+          paths: ["/mcp"]
+      tools:
+        - name: search_repositories
+        - name: create_issue
+          when:
+            - path: "owner"
+              equals: "ironsh"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
-	"github.com/ironsh/iron-proxy/internal/mcp"
 )
 
 // DefaultUpstreamResponseHeaderTimeout is the default cap on how long the
@@ -41,12 +40,17 @@ func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // Config is the top-level configuration for iron-proxy.
+//
+// The MCP block is parsed as a raw yaml.Node and decoded by internal/mcp at
+// pipeline-build time, mirroring how Transforms are handled: the config
+// package stays decoupled from the consumer's typed schema, and validation
+// errors surface where the value is actually used.
 type Config struct {
 	DNS        DNS         `yaml:"dns"`
 	Proxy      Proxy       `yaml:"proxy"`
 	TLS        TLS         `yaml:"tls"`
 	Transforms []Transform `yaml:"transforms"`
-	MCP        mcp.Config  `yaml:"mcp"`
+	MCP        yaml.Node   `yaml:"mcp"`
 	Metrics    Metrics     `yaml:"metrics"`
 	Management Management  `yaml:"management"`
 	Log        Log         `yaml:"log"`
@@ -279,10 +283,6 @@ func Validate(cfg *Config) error {
 		if os.Getenv(cfg.Management.APIKeyEnv) == "" {
 			return fmt.Errorf("management.api_key_env %q is not set in the environment", cfg.Management.APIKeyEnv)
 		}
-	}
-
-	if _, err := mcp.Compile(cfg.MCP); err != nil {
-		return fmt.Errorf("mcp: %w", err)
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/ironsh/iron-proxy/internal/mcp"
 )
 
 // DefaultUpstreamResponseHeaderTimeout is the default cap on how long the
@@ -45,6 +46,7 @@ type Config struct {
 	Proxy      Proxy       `yaml:"proxy"`
 	TLS        TLS         `yaml:"tls"`
 	Transforms []Transform `yaml:"transforms"`
+	MCP        mcp.Config  `yaml:"mcp"`
 	Metrics    Metrics     `yaml:"metrics"`
 	Management Management  `yaml:"management"`
 	Log        Log         `yaml:"log"`
@@ -277,6 +279,10 @@ func Validate(cfg *Config) error {
 		if os.Getenv(cfg.Management.APIKeyEnv) == "" {
 			return fmt.Errorf("management.api_key_env %q is not set in the environment", cfg.Management.APIKeyEnv)
 		}
+	}
+
+	if _, err := mcp.Compile(cfg.MCP); err != nil {
+		return fmt.Errorf("mcp: %w", err)
 	}
 
 	for i, rec := range cfg.DNS.Records {

--- a/internal/mcp/argmatch.go
+++ b/internal/mcp/argmatch.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// clause is a compiled argument constraint. Exactly one of equals, in, or
+// matches is set.
+type clause struct {
+	path    []string
+	equals  any
+	hasEq   bool
+	in      []any
+	matches *regexp.Regexp
+}
+
+func compileClauses(configs []ClauseConfig, prefix string) ([]clause, error) {
+	if len(configs) == 0 {
+		return nil, nil
+	}
+	out := make([]clause, 0, len(configs))
+	for i, cc := range configs {
+		if cc.Path == "" {
+			return nil, fmt.Errorf("%s.when[%d]: path is required", prefix, i)
+		}
+		set := 0
+		if cc.Equals != nil {
+			set++
+		}
+		if cc.In != nil {
+			set++
+		}
+		if cc.Matches != "" {
+			set++
+		}
+		if set != 1 {
+			return nil, fmt.Errorf("%s.when[%d]: exactly one of equals, in, matches is required", prefix, i)
+		}
+		c := clause{path: splitPath(cc.Path)}
+		switch {
+		case cc.Equals != nil:
+			c.equals = normalizeJSONScalar(cc.Equals)
+			c.hasEq = true
+		case cc.In != nil:
+			c.in = make([]any, len(cc.In))
+			for j, v := range cc.In {
+				c.in[j] = normalizeJSONScalar(v)
+			}
+		case cc.Matches != "":
+			re, err := regexp.Compile(cc.Matches)
+			if err != nil {
+				return nil, fmt.Errorf("%s.when[%d]: invalid matches regex: %w", prefix, i, err)
+			}
+			c.matches = re
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func splitPath(p string) []string {
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, ".")
+}
+
+// evaluate returns true if the clause holds for the supplied params (typically
+// the JSON-RPC params object).
+func (c clause) evaluate(params any) bool {
+	v, ok := resolvePath(params, c.path)
+	if !ok {
+		return false
+	}
+	switch {
+	case c.hasEq:
+		return jsonScalarEquals(v, c.equals)
+	case c.in != nil:
+		for _, want := range c.in {
+			if jsonScalarEquals(v, want) {
+				return true
+			}
+		}
+		return false
+	case c.matches != nil:
+		s, ok := v.(string)
+		if !ok {
+			return false
+		}
+		return c.matches.MatchString(s)
+	}
+	return false
+}
+
+// resolvePath walks a dotted path through a JSON-decoded value. Numeric
+// segments index into arrays; all other segments index into maps. Returns
+// (value, true) on success, (nil, false) on missing or type mismatch.
+func resolvePath(root any, segments []string) (any, bool) {
+	cur := root
+	for _, seg := range segments {
+		switch v := cur.(type) {
+		case map[string]any:
+			next, ok := v[seg]
+			if !ok {
+				return nil, false
+			}
+			cur = next
+		case []any:
+			idx, err := strconv.Atoi(seg)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil, false
+			}
+			cur = v[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// normalizeJSONScalar coerces YAML-decoded scalars into their JSON-decoded
+// equivalents so equality checks are consistent: YAML decodes 5 as int, JSON
+// decodes 5 as float64, and YAML decodes "5" as string. We coerce numeric
+// types to float64 to match encoding/json's default decoding.
+func normalizeJSONScalar(v any) any {
+	switch x := v.(type) {
+	case int:
+		return float64(x)
+	case int32:
+		return float64(x)
+	case int64:
+		return float64(x)
+	case uint:
+		return float64(x)
+	case uint32:
+		return float64(x)
+	case uint64:
+		return float64(x)
+	case float32:
+		return float64(x)
+	}
+	return v
+}
+
+func jsonScalarEquals(a, b any) bool {
+	a = normalizeJSONScalar(a)
+	b = normalizeJSONScalar(b)
+	return a == b
+}

--- a/internal/mcp/argmatch_test.go
+++ b/internal/mcp/argmatch_test.go
@@ -1,0 +1,67 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePath(t *testing.T) {
+	root := map[string]any{
+		"a": map[string]any{
+			"b": []any{"first", "second", map[string]any{"c": 42}},
+		},
+	}
+	cases := []struct {
+		path string
+		want any
+		ok   bool
+	}{
+		{"a.b.0", "first", true},
+		{"a.b.1", "second", true},
+		{"a.b.2.c", 42, true},
+		{"a.missing", nil, false},
+		{"a.b.99", nil, false},
+		{"a.b.x", nil, false},
+		{"a.b", []any{"first", "second", map[string]any{"c": 42}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			got, ok := resolvePath(root, splitPath(tc.path))
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestClauseEvaluateScalarTypes(t *testing.T) {
+	// JSON-decoded values use float64 for numbers; YAML may decode int.
+	// The clause must equate the two.
+	clauses, err := compileClauses([]ClauseConfig{
+		{Path: "n", Equals: 5},
+	}, "test")
+	require.NoError(t, err)
+	require.Len(t, clauses, 1)
+
+	require.True(t, clauses[0].evaluate(map[string]any{"n": float64(5)}))
+	require.False(t, clauses[0].evaluate(map[string]any{"n": float64(6)}))
+	require.False(t, clauses[0].evaluate(map[string]any{"n": "5"}))
+}
+
+func TestClauseEvaluateRegex(t *testing.T) {
+	clauses, err := compileClauses([]ClauseConfig{{Path: "name", Matches: "^foo-"}}, "test")
+	require.NoError(t, err)
+	require.True(t, clauses[0].evaluate(map[string]any{"name": "foo-bar"}))
+	require.False(t, clauses[0].evaluate(map[string]any{"name": "bar"}))
+	require.False(t, clauses[0].evaluate(map[string]any{"name": 123})) // not a string
+}
+
+func TestClauseEvaluateIn(t *testing.T) {
+	clauses, err := compileClauses([]ClauseConfig{{Path: "env", In: []any{"prod", "stage"}}}, "test")
+	require.NoError(t, err)
+	require.True(t, clauses[0].evaluate(map[string]any{"env": "prod"}))
+	require.True(t, clauses[0].evaluate(map[string]any{"env": "stage"}))
+	require.False(t, clauses[0].evaluate(map[string]any{"env": "dev"}))
+}

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -33,8 +33,7 @@ type Message struct {
 	Filtered int `json:"filtered,omitempty"`
 }
 
-// Append records a message on the trace under a lock so concurrent streamed
-// SSE writes do not race.
+// Append records a message on the trace.
 func (t *Trace) Append(m Message) {
 	if t == nil {
 		return

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -1,0 +1,157 @@
+package mcp
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// Trace is the per-request MCP audit record attached to a PipelineResult. It
+// collects one Message entry per JSON-RPC message observed on either side of
+// the proxy, in the order they were processed.
+type Trace struct {
+	Server   string    `json:"server"`
+	Messages []Message `json:"messages,omitempty"`
+
+	mu sync.Mutex
+	// toolsListIDs is the set of JSON-RPC request IDs whose method was
+	// tools/list, used to correlate request → response so that the response
+	// filter only rewrites tool lists. Without this, a tools/call result
+	// that happens to contain a top-level tools array would have entries
+	// stripped by the allowlist.
+	toolsListIDs map[string]bool
+}
+
+// Message is a single JSON-RPC message audit record.
+type Message struct {
+	Direction string `json:"direction"`
+	Method    string `json:"method,omitempty"`
+	Tool      string `json:"tool,omitempty"`
+	Decision  string `json:"decision"`
+	Reason    string `json:"reason,omitempty"`
+	// Filtered counts items removed from a tools/list response when this
+	// message represents a response-side filter event.
+	Filtered int `json:"filtered,omitempty"`
+}
+
+// Append records a message on the trace under a lock so concurrent streamed
+// SSE writes do not race.
+func (t *Trace) Append(m Message) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.Messages = append(t.Messages, m)
+	t.mu.Unlock()
+}
+
+// recordToolsListID notes that this trace saw a request with method
+// tools/list and the supplied id, so the response-side filter knows to
+// rewrite the matching response. Notification ids (absent or null) are
+// ignored: notifications cannot have responses, and a null id cannot be
+// distinguished from another null id at correlation time.
+func (t *Trace) recordToolsListID(id json.RawMessage) {
+	if t == nil {
+		return
+	}
+	key, ok := canonicalIDKey(id)
+	if !ok {
+		return
+	}
+	t.mu.Lock()
+	if t.toolsListIDs == nil {
+		t.toolsListIDs = make(map[string]bool)
+	}
+	t.toolsListIDs[key] = true
+	t.mu.Unlock()
+}
+
+// isToolsListResponse reports whether a response with the supplied id
+// corresponds to a previously recorded tools/list request.
+func (t *Trace) isToolsListResponse(id json.RawMessage) bool {
+	if t == nil {
+		return false
+	}
+	key, ok := canonicalIDKey(id)
+	if !ok {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.toolsListIDs[key]
+}
+
+// canonicalIDKey returns a stable string key for a JSON-RPC id. Returns
+// ("", false) for absent or null ids since those cannot be correlated to a
+// specific request.
+func canonicalIDKey(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		// Fall back to raw bytes when the id is not valid JSON; the worst
+		// case is a missed correlation, which means we conservatively pass
+		// the response through unfiltered.
+		return string(raw), true
+	}
+	if v == nil {
+		return "", false
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return string(raw), true
+	}
+	return string(out), true
+}
+
+// MessagesSnapshot returns a copy of the recorded messages safe for use after
+// the trace is still being mutated.
+func (t *Trace) MessagesSnapshot() []Message {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]Message, len(t.Messages))
+	copy(out, t.Messages)
+	return out
+}
+
+// MCPServer implements transform.MCPAudit.
+func (t *Trace) MCPServer() string {
+	if t == nil {
+		return ""
+	}
+	return t.Server
+}
+
+// MCPMessages implements transform.MCPAudit by flattening Message values into
+// JSON-friendly maps. Returning maps avoids creating an import cycle between
+// transform and mcp.
+func (t *Trace) MCPMessages() []map[string]any {
+	if t == nil {
+		return nil
+	}
+	snap := t.MessagesSnapshot()
+	out := make([]map[string]any, 0, len(snap))
+	for _, m := range snap {
+		entry := map[string]any{
+			"direction": m.Direction,
+			"decision":  m.Decision,
+		}
+		if m.Method != "" {
+			entry["method"] = m.Method
+		}
+		if m.Tool != "" {
+			entry["tool"] = m.Tool
+		}
+		if m.Reason != "" {
+			entry["reason"] = m.Reason
+		}
+		if m.Filtered > 0 {
+			entry["filtered"] = m.Filtered
+		}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/internal/mcp/intercept.go
+++ b/internal/mcp/intercept.go
@@ -1,0 +1,404 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strconv"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// mediaTypeIs reports whether ct names the given media type, ignoring case
+// and any parameters (e.g. "; charset=utf-8"). RFC 7231 §3.1.1.1 requires
+// case-insensitive comparison of type and subtype.
+func mediaTypeIs(ct, want string) bool {
+	if ct == "" {
+		return false
+	}
+	mt, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return false
+	}
+	return mt == want
+}
+
+// EvaluateRequest applies the policy to an MCP request that has already
+// matched a configured server. When the request should be rejected, returns a
+// non-nil http.Response that the proxy must write to the client (and skip the
+// upstream call). When it returns (nil, nil), the request is allowed; the
+// caller forwards to upstream and then invokes WrapResponseBody on the
+// response. When err is non-nil, the proxy should treat it as a 502.
+//
+// The req.Body must be a *transform.BufferedBody. EvaluateRequest reads it
+// and resets so subsequent transforms (and the upstream forward) re-read
+// cleanly.
+func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace) (*http.Response, error) {
+	if p == nil || server == nil {
+		return nil, nil
+	}
+
+	// We only inspect application/json POST requests. GET listeners and other
+	// shapes pass through; their responses are still wrapped if they arrive
+	// over text/event-stream so the listener stream is filtered.
+	if req.Method != http.MethodPost {
+		return nil, nil
+	}
+	if !mediaTypeIs(req.Header.Get("Content-Type"), "application/json") {
+		return nil, nil
+	}
+
+	bb, ok := req.Body.(*transform.BufferedBody)
+	if !ok {
+		return nil, fmt.Errorf("mcp: expected *transform.BufferedBody, got %T", req.Body)
+	}
+	body, err := io.ReadAll(bb)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: reading request body: %w", err)
+	}
+	bb.Reset()
+
+	// Detect oversize: if the upstream Content-Length exceeded the buffered
+	// body cap, the read returned a truncated body. We cannot reliably parse
+	// JSON-RPC in that case, so deny.
+	if req.ContentLength > 0 && int64(len(body)) < req.ContentLength {
+		trace.Append(Message{
+			Direction: DirectionRequest,
+			Decision:  DecisionDeny,
+			Reason:    ReasonOversizeBody,
+		})
+		return p.errorResponse(req, nil, false), nil
+	}
+
+	msgs, isBatch, err := decodeJSONRPC(body)
+	if err != nil {
+		trace.Append(Message{
+			Direction: DirectionRequest,
+			Decision:  DecisionDeny,
+			Reason:    ReasonMalformedJSONRPC,
+		})
+		return p.errorResponse(req, nil, isBatch), nil
+	}
+
+	denyAny := false
+	ids := make([]json.RawMessage, len(msgs))
+	for i, m := range msgs {
+		ids[i] = m.ID
+		entry := Message{
+			Direction: DirectionRequest,
+			Method:    m.Method,
+			Decision:  DecisionAllow,
+		}
+		switch m.Method {
+		case MethodToolsCall:
+			name, args, ok := extractToolCallName(m.Params)
+			entry.Tool = name
+			if !ok {
+				entry.Decision = DecisionDeny
+				entry.Reason = ReasonMalformedJSONRPC
+				denyAny = true
+			} else if allowed, reason := server.EvaluateTool(name, args); !allowed {
+				entry.Decision = DecisionDeny
+				entry.Reason = reason
+				denyAny = true
+			}
+		case MethodToolsList:
+			// Record the request id so the response wrapper knows this
+			// specific response is the one whose tools array should be
+			// filtered. Other JSON-RPC results that happen to contain a
+			// tools array are left alone.
+			trace.recordToolsListID(m.ID)
+		}
+		trace.Append(entry)
+	}
+
+	if !denyAny {
+		return nil, nil
+	}
+
+	if isBatch {
+		body, err := batchErrorResponseBody(ids, p.errorCode, p.errorMessage)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: building batch error response: %w", err)
+		}
+		return jsonRPCResponse(req, body), nil
+	}
+	body2, err := errorResponseBody(ids[0], p.errorCode, p.errorMessage)
+	if err != nil {
+		return nil, fmt.Errorf("mcp: building error response: %w", err)
+	}
+	return jsonRPCResponse(req, body2), nil
+}
+
+// errorResponse builds a synthetic JSON-RPC error envelope to return when a
+// request is denied without per-item ids (malformed/oversize cases).
+func (p *Policy) errorResponse(req *http.Request, _ json.RawMessage, isBatch bool) *http.Response {
+	var body []byte
+	var err error
+	if isBatch {
+		body, err = batchErrorResponseBody([]json.RawMessage{nil}, p.errorCode, p.errorMessage)
+	} else {
+		body, err = errorResponseBody(nil, p.errorCode, p.errorMessage)
+	}
+	if err != nil {
+		// Should not happen — fall back to a plain 403.
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1, ProtoMinor: 1,
+			Header:        http.Header{"Content-Type": {"text/plain"}},
+			Body:          http.NoBody,
+			Request:       req,
+			ContentLength: 0,
+		}
+	}
+	return jsonRPCResponse(req, body)
+}
+
+// jsonRPCResponse wraps a JSON-RPC response body in an http.Response. The
+// proxy's writeResponse copies headers and body so we always return 200 OK
+// with application/json — JSON-RPC errors are encoded inside the envelope.
+func jsonRPCResponse(req *http.Request, body []byte) *http.Response {
+	hdr := http.Header{}
+	hdr.Set("Content-Type", "application/json")
+	hdr.Set("Content-Length", strconv.Itoa(len(body)))
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        "200 OK",
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        hdr,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		Request:       req,
+		ContentLength: int64(len(body)),
+	}
+}
+
+// WrapResponseBody installs the response-side filter for an MCP-matched
+// response. The returned body must replace resp.Body before the proxy's
+// streaming or buffered writeResponse path runs.
+//
+// Behavior depends on Content-Type:
+//   - application/json: read and decode the full body, filter tools/list
+//     results, re-marshal, return a NewBufferedBodyFromBytes wrapper.
+//   - text/event-stream: return a streaming reader that scans events as they
+//     arrive, decodes the data payload as JSON-RPC, filters tools/list result
+//     payloads, and re-emits the event. Other event shapes pass through.
+//   - anything else: returns the original body unchanged.
+func (p *Policy) WrapResponseBody(server *Server, contentType string, body io.ReadCloser, trace *Trace) (io.ReadCloser, error) {
+	if p == nil || server == nil {
+		return body, nil
+	}
+	allowed := server.AllowedToolNames()
+
+	if mediaTypeIs(contentType, "text/event-stream") {
+		return newSSEFilter(body, allowed, trace), nil
+	}
+	if !mediaTypeIs(contentType, "application/json") {
+		return body, nil
+	}
+
+	raw, err := io.ReadAll(body)
+	closeErr := body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("mcp: reading response body: %w", err)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("mcp: closing upstream response body: %w", closeErr)
+	}
+
+	filtered, err := filterJSONResponseBody(raw, allowed, trace)
+	if err != nil {
+		// On filter failure, pass the original body through untouched.
+		return transform.NewBufferedBodyFromBytes(raw), nil
+	}
+	return transform.NewBufferedBodyFromBytes(filtered), nil
+}
+
+// filterJSONResponseBody filters tools/list responses inside a non-streaming
+// JSON body. The body may be a single JSON-RPC response or a batch. Only
+// responses whose id was previously recorded as a tools/list request are
+// rewritten; other results are emitted unchanged so a tools/call result that
+// happens to contain a tools array is left alone.
+func filterJSONResponseBody(raw []byte, allowed map[string]bool, trace *Trace) ([]byte, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return raw, nil
+	}
+	if trimmed[0] == '[' {
+		var batch []rpcMessage
+		if err := json.Unmarshal(trimmed, &batch); err != nil {
+			return nil, err
+		}
+		changed := false
+		for i := range batch {
+			removed := 0
+			if trace.isToolsListResponse(batch[i].ID) {
+				_, removed = filterMessageInPlace(&batch[i], allowed)
+			}
+			appendResponseAudit(trace, batch[i], removed)
+			if removed > 0 {
+				changed = true
+			}
+		}
+		if !changed {
+			return raw, nil
+		}
+		return json.Marshal(batch)
+	}
+	var single rpcMessage
+	if err := json.Unmarshal(trimmed, &single); err != nil {
+		return nil, err
+	}
+	removed := 0
+	if trace.isToolsListResponse(single.ID) {
+		_, removed = filterMessageInPlace(&single, allowed)
+	}
+	appendResponseAudit(trace, single, removed)
+	if removed == 0 {
+		return raw, nil
+	}
+	return json.Marshal(single)
+}
+
+// filterMessageInPlace mutates msg.Result if its tools array contains entries
+// not in allowed. Caller is responsible for ensuring this is a tools/list
+// response (via trace.isToolsListResponse) before invoking — otherwise an
+// unrelated result whose payload happens to carry a top-level tools array
+// would be rewritten.
+func filterMessageInPlace(msg *rpcMessage, allowed map[string]bool) (json.RawMessage, int) {
+	if len(msg.Result) == 0 {
+		return msg.Result, 0
+	}
+	newRes, removed, err := filterToolsListResult(msg.Result, allowed)
+	if err != nil || removed == 0 {
+		return msg.Result, 0
+	}
+	msg.Result = newRes
+	return newRes, removed
+}
+
+// appendResponseAudit records a single response-side audit entry for a
+// JSON-RPC message. We do not always know the method on a response (servers
+// echo only the id), so method is left blank unless the message itself was a
+// server-initiated request carrying a method.
+func appendResponseAudit(trace *Trace, msg rpcMessage, filtered int) {
+	if trace == nil {
+		return
+	}
+	entry := Message{
+		Direction: DirectionResponse,
+		Method:    msg.Method,
+		Decision:  DecisionAllow,
+	}
+	if filtered > 0 {
+		entry.Method = MethodToolsList
+		entry.Decision = DecisionFiltered
+		entry.Filtered = filtered
+	}
+	trace.Append(entry)
+}
+
+// sseFilter streams SSE events from upstream, filters JSON-RPC payloads, and
+// re-emits the events to the client. It implements io.ReadCloser. Reads are
+// driven by the proxy's streamSSE flush loop — each call returns enough bytes
+// to make forward progress; we buffer at most one rewritten event at a time.
+type sseFilter struct {
+	upstream io.ReadCloser
+	br       *bufio.Reader
+	allowed  map[string]bool
+	trace    *Trace
+	pending  []byte
+	done     bool
+}
+
+func newSSEFilter(upstream io.ReadCloser, allowed map[string]bool, trace *Trace) io.ReadCloser {
+	return &sseFilter{
+		upstream: upstream,
+		br:       bufio.NewReader(upstream),
+		allowed:  allowed,
+		trace:    trace,
+	}
+}
+
+func (f *sseFilter) Read(p []byte) (int, error) {
+	if len(f.pending) > 0 {
+		n := copy(p, f.pending)
+		f.pending = f.pending[n:]
+		return n, nil
+	}
+	if f.done {
+		return 0, io.EOF
+	}
+	ev, err := readSSEEvent(f.br)
+	if ev != nil {
+		f.handleEvent(ev)
+	}
+	if err != nil {
+		f.done = true
+		if err == io.EOF && len(f.pending) > 0 {
+			// Flush trailing buffered bytes before EOF.
+			n := copy(p, f.pending)
+			f.pending = f.pending[n:]
+			if len(f.pending) == 0 {
+				return n, io.EOF
+			}
+			return n, nil
+		}
+		if err != io.EOF {
+			return 0, err
+		}
+		if len(f.pending) == 0 {
+			return 0, io.EOF
+		}
+	}
+	if len(f.pending) == 0 {
+		return 0, nil
+	}
+	n := copy(p, f.pending)
+	f.pending = f.pending[n:]
+	return n, nil
+}
+
+func (f *sseFilter) handleEvent(ev *sseEvent) {
+	payload := ev.dataPayload()
+	if len(payload) == 0 {
+		f.pending = append(f.pending, ev.raw...)
+		return
+	}
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		f.pending = append(f.pending, ev.raw...)
+		return
+	}
+	var msg rpcMessage
+	if err := json.Unmarshal(trimmed, &msg); err != nil {
+		f.pending = append(f.pending, ev.raw...)
+		return
+	}
+	removed := 0
+	if f.trace.isToolsListResponse(msg.ID) {
+		_, removed = filterMessageInPlace(&msg, f.allowed)
+	}
+	appendResponseAudit(f.trace, msg, removed)
+	if removed == 0 {
+		f.pending = append(f.pending, ev.raw...)
+		return
+	}
+	newPayload, err := json.Marshal(msg)
+	if err != nil {
+		f.pending = append(f.pending, ev.raw...)
+		return
+	}
+	f.pending = append(f.pending, ev.rewriteData(newPayload)...)
+}
+
+func (f *sseFilter) Close() error {
+	return f.upstream.Close()
+}

--- a/internal/mcp/intercept.go
+++ b/internal/mcp/intercept.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
+const (
+	mediaTypeJSON = "application/json"
+	mediaTypeSSE  = "text/event-stream"
+)
+
 // mediaTypeIs reports whether ct names the given media type, ignoring case
 // and any parameters (e.g. "; charset=utf-8"). RFC 7231 §3.1.1.1 requires
 // case-insensitive comparison of type and subtype.
@@ -48,7 +53,7 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 	if req.Method != http.MethodPost {
 		return nil, nil
 	}
-	if !mediaTypeIs(req.Header.Get("Content-Type"), "application/json") {
+	if !mediaTypeIs(req.Header.Get("Content-Type"), mediaTypeJSON) {
 		return nil, nil
 	}
 
@@ -62,16 +67,15 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 	}
 	bb.Reset()
 
-	// Detect oversize: if the upstream Content-Length exceeded the buffered
-	// body cap, the read returned a truncated body. We cannot reliably parse
-	// JSON-RPC in that case, so deny.
+	// If the upstream Content-Length exceeded the buffered body cap, the
+	// read returned a truncated body and we cannot reliably parse JSON-RPC.
 	if req.ContentLength > 0 && int64(len(body)) < req.ContentLength {
 		trace.Append(Message{
 			Direction: DirectionRequest,
 			Decision:  DecisionDeny,
 			Reason:    ReasonOversizeBody,
 		})
-		return p.errorResponse(req, nil, false), nil
+		return p.policyErrorResponse(req, nil, false)
 	}
 
 	msgs, isBatch, err := decodeJSONRPC(body)
@@ -81,7 +85,7 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 			Decision:  DecisionDeny,
 			Reason:    ReasonMalformedJSONRPC,
 		})
-		return p.errorResponse(req, nil, isBatch), nil
+		return p.policyErrorResponse(req, nil, isBatch)
 	}
 
 	denyAny := false
@@ -107,10 +111,6 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 				denyAny = true
 			}
 		case MethodToolsList:
-			// Record the request id so the response wrapper knows this
-			// specific response is the one whose tools array should be
-			// filtered. Other JSON-RPC results that happen to contain a
-			// tools array are left alone.
 			trace.recordToolsListID(m.ID)
 		}
 		trace.Append(entry)
@@ -119,53 +119,37 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 	if !denyAny {
 		return nil, nil
 	}
-
-	if isBatch {
-		body, err := batchErrorResponseBody(ids, p.errorCode, p.errorMessage)
-		if err != nil {
-			return nil, fmt.Errorf("mcp: building batch error response: %w", err)
-		}
-		return jsonRPCResponse(req, body), nil
-	}
-	body2, err := errorResponseBody(ids[0], p.errorCode, p.errorMessage)
-	if err != nil {
-		return nil, fmt.Errorf("mcp: building error response: %w", err)
-	}
-	return jsonRPCResponse(req, body2), nil
+	return p.policyErrorResponse(req, ids, isBatch)
 }
 
-// errorResponse builds a synthetic JSON-RPC error envelope to return when a
-// request is denied without per-item ids (malformed/oversize cases).
-func (p *Policy) errorResponse(req *http.Request, _ json.RawMessage, isBatch bool) *http.Response {
+// policyErrorResponse builds the synthetic JSON-RPC error envelope returned
+// to the agent on policy denial. Single (isBatch=false) returns one error
+// object using ids[0] (or null when ids is empty); batch returns an array of
+// error objects, one per id.
+func (p *Policy) policyErrorResponse(req *http.Request, ids []json.RawMessage, isBatch bool) (*http.Response, error) {
 	var body []byte
 	var err error
 	if isBatch {
-		body, err = batchErrorResponseBody([]json.RawMessage{nil}, p.errorCode, p.errorMessage)
+		if len(ids) == 0 {
+			ids = []json.RawMessage{nil}
+		}
+		body, err = batchErrorResponseBody(ids, p.errorCode, p.errorMessage)
 	} else {
-		body, err = errorResponseBody(nil, p.errorCode, p.errorMessage)
+		var id json.RawMessage
+		if len(ids) > 0 {
+			id = ids[0]
+		}
+		body, err = errorResponseBody(id, p.errorCode, p.errorMessage)
 	}
 	if err != nil {
-		// Should not happen — fall back to a plain 403.
-		return &http.Response{
-			StatusCode: http.StatusForbidden,
-			Status:     "403 Forbidden",
-			Proto:      "HTTP/1.1",
-			ProtoMajor: 1, ProtoMinor: 1,
-			Header:        http.Header{"Content-Type": {"text/plain"}},
-			Body:          http.NoBody,
-			Request:       req,
-			ContentLength: 0,
-		}
+		return nil, fmt.Errorf("mcp: building policy error response: %w", err)
 	}
-	return jsonRPCResponse(req, body)
+	return jsonRPCResponse(req, body), nil
 }
 
-// jsonRPCResponse wraps a JSON-RPC response body in an http.Response. The
-// proxy's writeResponse copies headers and body so we always return 200 OK
-// with application/json — JSON-RPC errors are encoded inside the envelope.
 func jsonRPCResponse(req *http.Request, body []byte) *http.Response {
 	hdr := http.Header{}
-	hdr.Set("Content-Type", "application/json")
+	hdr.Set("Content-Type", mediaTypeJSON)
 	hdr.Set("Content-Length", strconv.Itoa(len(body)))
 	return &http.Response{
 		StatusCode:    http.StatusOK,
@@ -181,26 +165,32 @@ func jsonRPCResponse(req *http.Request, body []byte) *http.Response {
 }
 
 // WrapResponseBody installs the response-side filter for an MCP-matched
-// response. The returned body must replace resp.Body before the proxy's
+// response. The returned body replaces resp.Body before the proxy's
 // streaming or buffered writeResponse path runs.
 //
 // Behavior depends on Content-Type:
 //   - application/json: read and decode the full body, filter tools/list
 //     results, re-marshal, return a NewBufferedBodyFromBytes wrapper.
-//   - text/event-stream: return a streaming reader that scans events as they
+//   - text/event-stream: return a streaming filter that scans events as they
 //     arrive, decodes the data payload as JSON-RPC, filters tools/list result
 //     payloads, and re-emits the event. Other event shapes pass through.
-//   - anything else: returns the original body unchanged.
+//   - anything else: return the original body unchanged.
+//
+// When body is a *transform.BufferedBody on the SSE path, the filter reads
+// through to the underlying upstream reader rather than the BufferedBody
+// itself; otherwise the BufferedBody's eager io.ReadAll on first Read would
+// block forever on a long-lived MCP listener stream.
 func (p *Policy) WrapResponseBody(server *Server, contentType string, body io.ReadCloser, trace *Trace) (io.ReadCloser, error) {
 	if p == nil || server == nil {
 		return body, nil
 	}
 	allowed := server.AllowedToolNames()
 
-	if mediaTypeIs(contentType, "text/event-stream") {
-		return newSSEFilter(body, allowed, trace), nil
+	if mediaTypeIs(contentType, mediaTypeSSE) {
+		inner := unwrapBufferedBody(body)
+		return transform.NewBufferedBody(newSSEFilter(inner, allowed, trace), 0), nil
 	}
-	if !mediaTypeIs(contentType, "application/json") {
+	if !mediaTypeIs(contentType, mediaTypeJSON) {
 		return body, nil
 	}
 
@@ -215,10 +205,24 @@ func (p *Policy) WrapResponseBody(server *Server, contentType string, body io.Re
 
 	filtered, err := filterJSONResponseBody(raw, allowed, trace)
 	if err != nil {
-		// On filter failure, pass the original body through untouched.
 		return transform.NewBufferedBodyFromBytes(raw), nil
 	}
 	return transform.NewBufferedBodyFromBytes(filtered), nil
+}
+
+// unwrapBufferedBody returns an io.ReadCloser that reads directly from the
+// upstream reader when body is a *transform.BufferedBody. The returned
+// closer routes through the BufferedBody so the upstream connection is
+// freed when the filter is closed.
+func unwrapBufferedBody(body io.ReadCloser) io.ReadCloser {
+	bb, ok := body.(*transform.BufferedBody)
+	if !ok {
+		return body
+	}
+	return struct {
+		io.Reader
+		io.Closer
+	}{Reader: bb.StreamingReader(), Closer: bb}
 }
 
 // filterJSONResponseBody filters tools/list responses inside a non-streaming
@@ -305,10 +309,10 @@ func appendResponseAudit(trace *Trace, msg rpcMessage, filtered int) {
 	trace.Append(entry)
 }
 
-// sseFilter streams SSE events from upstream, filters JSON-RPC payloads, and
-// re-emits the events to the client. It implements io.ReadCloser. Reads are
-// driven by the proxy's streamSSE flush loop — each call returns enough bytes
-// to make forward progress; we buffer at most one rewritten event at a time.
+// sseFilter streams SSE events from upstream, filters JSON-RPC payloads,
+// and re-emits the events to the client. Reads are driven by the proxy's
+// streamSSE flush loop; each Read consumes one upstream event and copies
+// the rewritten (or pass-through) bytes into the caller's buffer.
 type sseFilter struct {
 	upstream io.ReadCloser
 	br       *bufio.Reader
@@ -328,59 +332,48 @@ func newSSEFilter(upstream io.ReadCloser, allowed map[string]bool, trace *Trace)
 }
 
 func (f *sseFilter) Read(p []byte) (int, error) {
-	if len(f.pending) > 0 {
-		n := copy(p, f.pending)
-		f.pending = f.pending[n:]
-		return n, nil
-	}
-	if f.done {
-		return 0, io.EOF
-	}
-	ev, err := readSSEEvent(f.br)
-	if ev != nil {
-		f.handleEvent(ev)
-	}
-	if err != nil {
-		f.done = true
-		if err == io.EOF && len(f.pending) > 0 {
-			// Flush trailing buffered bytes before EOF.
-			n := copy(p, f.pending)
-			f.pending = f.pending[n:]
-			if len(f.pending) == 0 {
-				return n, io.EOF
-			}
-			return n, nil
-		}
-		if err != io.EOF {
-			return 0, err
-		}
-		if len(f.pending) == 0 {
+	for len(f.pending) == 0 {
+		if f.done {
 			return 0, io.EOF
 		}
-	}
-	if len(f.pending) == 0 {
-		return 0, nil
+		ev, err := readSSEEvent(f.br)
+		if ev != nil {
+			f.pending = append(f.pending, f.rewriteEvent(ev)...)
+		}
+		if err != nil {
+			f.done = true
+			if err != io.EOF {
+				if len(f.pending) == 0 {
+					return 0, err
+				}
+				// Yield buffered bytes first; the next Read returns EOF.
+				break
+			}
+		}
 	}
 	n := copy(p, f.pending)
 	f.pending = f.pending[n:]
+	if len(f.pending) == 0 {
+		f.pending = nil
+	}
 	return n, nil
 }
 
-func (f *sseFilter) handleEvent(ev *sseEvent) {
+// rewriteEvent returns the bytes to emit for ev — the rewritten event when a
+// tools/list result was filtered, or ev.raw verbatim for everything else
+// (heartbeats, comments, non-JSON payloads, unrelated JSON-RPC messages).
+func (f *sseFilter) rewriteEvent(ev *sseEvent) []byte {
 	payload := ev.dataPayload()
 	if len(payload) == 0 {
-		f.pending = append(f.pending, ev.raw...)
-		return
+		return ev.raw
 	}
 	trimmed := bytes.TrimSpace(payload)
 	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
-		f.pending = append(f.pending, ev.raw...)
-		return
+		return ev.raw
 	}
 	var msg rpcMessage
 	if err := json.Unmarshal(trimmed, &msg); err != nil {
-		f.pending = append(f.pending, ev.raw...)
-		return
+		return ev.raw
 	}
 	removed := 0
 	if f.trace.isToolsListResponse(msg.ID) {
@@ -388,15 +381,13 @@ func (f *sseFilter) handleEvent(ev *sseEvent) {
 	}
 	appendResponseAudit(f.trace, msg, removed)
 	if removed == 0 {
-		f.pending = append(f.pending, ev.raw...)
-		return
+		return ev.raw
 	}
 	newPayload, err := json.Marshal(msg)
 	if err != nil {
-		f.pending = append(f.pending, ev.raw...)
-		return
+		return ev.raw
 	}
-	f.pending = append(f.pending, ev.rewriteData(newPayload)...)
+	return ev.rewriteData(newPayload)
 }
 
 func (f *sseFilter) Close() error {

--- a/internal/mcp/intercept_test.go
+++ b/internal/mcp/intercept_test.go
@@ -1,0 +1,305 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func newTestPolicy(t *testing.T) *Policy {
+	t.Helper()
+	p, err := Compile(Config{
+		Servers: []ServerConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "mcp.github.com"}},
+			Tools: []ToolConfig{
+				{Name: "search_repositories"},
+				{Name: "create_issue", When: []ClauseConfig{
+					{Path: "owner", Equals: "ironsh"},
+				}},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func newJSONRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	u, _ := url.Parse("https://mcp.github.com/mcp")
+	r := &http.Request{
+		Method:        http.MethodPost,
+		Host:          "mcp.github.com",
+		URL:           u,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		ContentLength: int64(len(body)),
+		Body:          transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 0),
+	}
+	return r
+}
+
+func TestEvaluateRequestAllow(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+	require.NotNil(t, s)
+
+	req := newJSONRequest(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories","arguments":{"q":"foo"}}}`)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, tr.Messages, 1)
+	require.Equal(t, DecisionAllow, tr.Messages[0].Decision)
+	require.Equal(t, "search_repositories", tr.Messages[0].Tool)
+}
+
+func TestEvaluateRequestDenyToolNotAllowed(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	req := newJSONRequest(t, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"delete_repo","arguments":{}}}`)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var msg rpcMessage
+	require.NoError(t, json.Unmarshal(body, &msg))
+	require.Equal(t, "7", string(msg.ID))
+	require.NotNil(t, msg.Error)
+	require.Equal(t, DefaultErrorCode, msg.Error.Code)
+
+	require.Len(t, tr.Messages, 1)
+	require.Equal(t, DecisionDeny, tr.Messages[0].Decision)
+	require.Equal(t, ReasonToolNotAllowed, tr.Messages[0].Reason)
+}
+
+func TestEvaluateRequestDenyArgumentConstraint(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	req := newJSONRequest(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_issue","arguments":{"owner":"someoneelse"}}}`)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, ReasonArgumentConstraint, tr.Messages[0].Reason)
+}
+
+func TestEvaluateRequestPassThroughNonToolsCall(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	req := newJSONRequest(t, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, tr.Messages, 1)
+	require.Equal(t, DecisionAllow, tr.Messages[0].Decision)
+	require.Equal(t, "tools/list", tr.Messages[0].Method)
+}
+
+func TestEvaluateRequestSkipsNonJSON(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	u, _ := url.Parse("https://mcp.github.com/mcp")
+	req := &http.Request{
+		Method: http.MethodGet,
+		Host:   "mcp.github.com",
+		URL:    u,
+		Header: http.Header{},
+		Body:   transform.NewBufferedBody(io.NopCloser(strings.NewReader("")), 0),
+	}
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Empty(t, tr.Messages)
+}
+
+func TestEvaluateRequestMalformedDenies(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	req := newJSONRequest(t, `not json`)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, ReasonMalformedJSONRPC, tr.Messages[0].Reason)
+}
+
+func TestEvaluateRequestBatchAllAllowed(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	body := `[
+		{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories"}},
+		{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+	]`
+	req := newJSONRequest(t, body)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Len(t, tr.Messages, 2)
+}
+
+func TestEvaluateRequestBatchAnyDeniedDeniesAll(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	body := `[
+		{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories"}},
+		{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_repo"}}
+	]`
+	req := newJSONRequest(t, body)
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var msgs []rpcMessage
+	require.NoError(t, json.Unmarshal(respBody, &msgs))
+	require.Len(t, msgs, 2)
+	for _, m := range msgs {
+		require.NotNil(t, m.Error)
+	}
+}
+
+func TestWrapResponseBodyJSON(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	tr := &Trace{Server: s.Name}
+	tr.recordToolsListID(json.RawMessage(`1`))
+
+	body := `{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"search_repositories"},{"name":"hidden"},{"name":"create_issue"}]}}`
+	wrapped, err := p.WrapResponseBody(s, "application/json", io.NopCloser(strings.NewReader(body)), tr)
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+
+	var msg rpcMessage
+	require.NoError(t, json.Unmarshal(out, &msg))
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(msg.Result, &result))
+	tools := result["tools"].([]any)
+	require.Len(t, tools, 2)
+}
+
+func TestWrapResponseBodySSEFiltersToolsList(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	tr := &Trace{Server: s.Name}
+	tr.recordToolsListID(json.RawMessage(`1`))
+
+	stream := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"search_repositories\"},{\"name\":\"hidden\"}]}}\n\n" +
+		": keepalive\n\n" +
+		"data: not-json\n\n"
+	wrapped, err := p.WrapResponseBody(s, "text/event-stream", io.NopCloser(strings.NewReader(stream)), tr)
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+	outStr := string(out)
+
+	require.Contains(t, outStr, "search_repositories")
+	require.NotContains(t, outStr, "hidden")
+	require.Contains(t, outStr, ": keepalive")
+	require.Contains(t, outStr, "data: not-json")
+}
+
+// TestWrapResponseBodyJSONLeavesUnrelatedToolsArrayAlone is a regression test
+// for the bug where any result containing a top-level "tools" array was
+// rewritten, even when the response was not a tools/list reply (e.g. a
+// tools/call result whose payload happens to contain a "tools" array). The
+// trace records no tools/list id, so the response must pass through verbatim.
+func TestWrapResponseBodyJSONLeavesUnrelatedToolsArrayAlone(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	body := `{"jsonrpc":"2.0","id":7,"result":{"tools":[{"name":"hidden"},{"name":"another_unknown"}],"summary":"ok"}}`
+	tr := &Trace{Server: s.Name} // no tools/list id recorded
+	wrapped, err := p.WrapResponseBody(s, "application/json", io.NopCloser(strings.NewReader(body)), tr)
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, body, string(out), "non tools/list response with a tools array must be untouched")
+}
+
+// TestWrapResponseBodySSELeavesUnrelatedToolsArrayAlone is the SSE counterpart
+// to TestWrapResponseBodyJSONLeavesUnrelatedToolsArrayAlone.
+func TestWrapResponseBodySSELeavesUnrelatedToolsArrayAlone(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	stream := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"tools\":[{\"name\":\"hidden\"},{\"name\":\"another_unknown\"}]}}\n\n"
+	tr := &Trace{Server: s.Name}
+	wrapped, err := p.WrapResponseBody(s, "text/event-stream", io.NopCloser(strings.NewReader(stream)), tr)
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+	require.Contains(t, string(out), "hidden")
+	require.Contains(t, string(out), "another_unknown")
+}
+
+// TestEvaluateRequestUppercaseContentType is a regression test for the bug
+// where Content-Type comparison was case-sensitive. Per RFC 7231, media
+// types are case-insensitive, so "Application/JSON" must trigger MCP
+// inspection just like "application/json".
+func TestEvaluateRequestUppercaseContentType(t *testing.T) {
+	p := newTestPolicy(t)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_repo"}}`
+	u, _ := url.Parse("https://mcp.github.com/mcp")
+	req := &http.Request{
+		Method:        http.MethodPost,
+		Host:          "mcp.github.com",
+		URL:           u,
+		Header:        http.Header{"Content-Type": {"Application/JSON; charset=utf-8"}},
+		ContentLength: int64(len(body)),
+		Body:          transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 0),
+	}
+
+	s := p.MatchServer(req)
+	require.NotNil(t, s)
+
+	tr := &Trace{Server: s.Name}
+	resp, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.NotNil(t, resp, "uppercase Content-Type must still trigger MCP enforcement")
+	require.Len(t, tr.Messages, 1)
+	require.Equal(t, DecisionDeny, tr.Messages[0].Decision)
+}
+
+func TestWrapResponseBodyOtherContentTypePassesThrough(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	body := bytes.NewReader([]byte("plain text"))
+	wrapped, err := p.WrapResponseBody(s, "text/plain", io.NopCloser(body), &Trace{Server: s.Name})
+	require.NoError(t, err)
+
+	out, err := io.ReadAll(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, "plain text", string(out))
+}

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,0 +1,180 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// MCP JSON-RPC method names that the policy handles structurally.
+const (
+	MethodToolsCall = "tools/call"
+	MethodToolsList = "tools/list"
+)
+
+// rpcMessage is a permissive view of a JSON-RPC 2.0 message. A message is a
+// request when Method is set, a response otherwise. ID is a raw message so we
+// preserve numeric/string/null distinctions when echoing it back.
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// errMalformedJSONRPC indicates the body did not parse as a JSON-RPC message
+// or batch.
+var errMalformedJSONRPC = errors.New("malformed JSON-RPC")
+
+// decodeJSONRPC parses a request body that may be a single JSON-RPC message
+// or a batch (array). Returns the messages and a bool indicating whether the
+// input was a batch.
+func decodeJSONRPC(body []byte) ([]rpcMessage, bool, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, false, errMalformedJSONRPC
+	}
+	if trimmed[0] == '[' {
+		var batch []rpcMessage
+		if err := json.Unmarshal(trimmed, &batch); err != nil {
+			return nil, true, fmt.Errorf("%w: %v", errMalformedJSONRPC, err)
+		}
+		if len(batch) == 0 {
+			return nil, true, errMalformedJSONRPC
+		}
+		return batch, true, nil
+	}
+	var single rpcMessage
+	if err := json.Unmarshal(trimmed, &single); err != nil {
+		return nil, false, fmt.Errorf("%w: %v", errMalformedJSONRPC, err)
+	}
+	return []rpcMessage{single}, false, nil
+}
+
+// errorResponseBody builds a JSON-RPC error response body for a single
+// request id and error code/message. Notification ids (absent or null) are
+// preserved as JSON null.
+func errorResponseBody(id json.RawMessage, code int, message string) ([]byte, error) {
+	resp := rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &rpcError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	if len(resp.ID) == 0 {
+		resp.ID = json.RawMessage("null")
+	}
+	return json.Marshal(resp)
+}
+
+// batchErrorResponseBody builds a JSON-RPC batch error response with one error
+// entry per supplied id. ids that are nil/empty are emitted as null.
+func batchErrorResponseBody(ids []json.RawMessage, code int, message string) ([]byte, error) {
+	resps := make([]rpcMessage, len(ids))
+	for i, id := range ids {
+		if len(id) == 0 {
+			id = json.RawMessage("null")
+		}
+		resps[i] = rpcMessage{
+			JSONRPC: "2.0",
+			ID:      id,
+			Error: &rpcError{
+				Code:    code,
+				Message: message,
+			},
+		}
+	}
+	return json.Marshal(resps)
+}
+
+// extractToolCallName pulls the tool name and decoded arguments from a
+// tools/call params payload. Returns ("", nil, false) when the params do not
+// carry a recognizable tool name (caller treats this as malformed).
+func extractToolCallName(params json.RawMessage) (string, any, bool) {
+	if len(params) == 0 {
+		return "", nil, false
+	}
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return "", nil, false
+	}
+	if p.Name == "" {
+		return "", nil, false
+	}
+	if len(p.Arguments) == 0 {
+		return p.Name, nil, true
+	}
+	var args any
+	if err := json.Unmarshal(p.Arguments, &args); err != nil {
+		return p.Name, nil, true
+	}
+	return p.Name, args, true
+}
+
+// filterToolsListResult takes a tools/list result payload and returns a new
+// payload with the tools array filtered to allowed names. Returns the
+// re-encoded result and the number of removed entries. If the result does not
+// contain a tools array, the input is returned unchanged with removed=0.
+func filterToolsListResult(result json.RawMessage, allowed map[string]bool) (json.RawMessage, int, error) {
+	if len(result) == 0 {
+		return result, 0, nil
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(result, &decoded); err != nil {
+		return result, 0, nil
+	}
+	rawTools, ok := decoded["tools"]
+	if !ok {
+		return result, 0, nil
+	}
+	var tools []map[string]json.RawMessage
+	if err := json.Unmarshal(rawTools, &tools); err != nil {
+		return result, 0, nil
+	}
+	kept := make([]map[string]json.RawMessage, 0, len(tools))
+	removed := 0
+	for _, t := range tools {
+		nameRaw, hasName := t["name"]
+		if !hasName {
+			kept = append(kept, t)
+			continue
+		}
+		var name string
+		if err := json.Unmarshal(nameRaw, &name); err != nil {
+			kept = append(kept, t)
+			continue
+		}
+		if allowed[name] {
+			kept = append(kept, t)
+		} else {
+			removed++
+		}
+	}
+	if removed == 0 {
+		return result, 0, nil
+	}
+	newTools, err := json.Marshal(kept)
+	if err != nil {
+		return result, 0, err
+	}
+	decoded["tools"] = newTools
+	out, err := json.Marshal(decoded)
+	if err != nil {
+		return result, 0, err
+	}
+	return out, removed, nil
+}

--- a/internal/mcp/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeJSONRPCSingle(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x"}}`)
+	msgs, batch, err := decodeJSONRPC(body)
+	require.NoError(t, err)
+	require.False(t, batch)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "tools/call", msgs[0].Method)
+}
+
+func TestDecodeJSONRPCBatch(t *testing.T) {
+	body := []byte(`[{"jsonrpc":"2.0","id":1,"method":"a"},{"jsonrpc":"2.0","id":2,"method":"b"}]`)
+	msgs, batch, err := decodeJSONRPC(body)
+	require.NoError(t, err)
+	require.True(t, batch)
+	require.Len(t, msgs, 2)
+}
+
+func TestDecodeJSONRPCMalformed(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		[]byte(""),
+		[]byte("not-json"),
+		[]byte("[]"),
+		[]byte("[{not json}]"),
+	}
+	for _, c := range cases {
+		_, _, err := decodeJSONRPC(c)
+		require.Error(t, err)
+	}
+}
+
+func TestExtractToolCallName(t *testing.T) {
+	params := json.RawMessage(`{"name":"create_issue","arguments":{"owner":"ironsh"}}`)
+	name, args, ok := extractToolCallName(params)
+	require.True(t, ok)
+	require.Equal(t, "create_issue", name)
+	m, ok := args.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "ironsh", m["owner"])
+
+	_, _, ok = extractToolCallName(json.RawMessage(`{}`))
+	require.False(t, ok)
+
+	_, _, ok = extractToolCallName(nil)
+	require.False(t, ok)
+}
+
+func TestErrorResponseBody(t *testing.T) {
+	body, err := errorResponseBody(json.RawMessage(`42`), -32001, "blocked")
+	require.NoError(t, err)
+	var msg rpcMessage
+	require.NoError(t, json.Unmarshal(body, &msg))
+	require.Equal(t, "2.0", msg.JSONRPC)
+	require.Equal(t, "42", string(msg.ID))
+	require.NotNil(t, msg.Error)
+	require.Equal(t, -32001, msg.Error.Code)
+	require.Equal(t, "blocked", msg.Error.Message)
+
+	// nil id becomes JSON null.
+	body, err = errorResponseBody(nil, -1, "x")
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(body, &raw))
+	require.Nil(t, raw["id"])
+	_, hasID := raw["id"]
+	require.True(t, hasID, "id field must be present even when null")
+}
+
+func TestBatchErrorResponseBody(t *testing.T) {
+	ids := []json.RawMessage{json.RawMessage(`1`), nil, json.RawMessage(`"x"`)}
+	body, err := batchErrorResponseBody(ids, -32001, "blocked")
+	require.NoError(t, err)
+	var msgs []rpcMessage
+	require.NoError(t, json.Unmarshal(body, &msgs))
+	require.Len(t, msgs, 3)
+	require.Equal(t, "1", string(msgs[0].ID))
+	require.Equal(t, "null", string(msgs[1].ID))
+	require.Equal(t, `"x"`, string(msgs[2].ID))
+}
+
+func TestFilterToolsListResult(t *testing.T) {
+	result := json.RawMessage(`{"tools":[{"name":"keep","description":"a"},{"name":"drop"},{"name":"keep2"}]}`)
+	filtered, removed, err := filterToolsListResult(result, map[string]bool{"keep": true, "keep2": true})
+	require.NoError(t, err)
+	require.Equal(t, 1, removed)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(filtered, &decoded))
+	tools := decoded["tools"].([]any)
+	require.Len(t, tools, 2)
+}
+
+func TestFilterToolsListResultNoMatchPassthrough(t *testing.T) {
+	result := json.RawMessage(`{"tools":[{"name":"a"}]}`)
+	filtered, removed, err := filterToolsListResult(result, map[string]bool{"a": true})
+	require.NoError(t, err)
+	require.Equal(t, 0, removed)
+	require.Equal(t, string(result), string(filtered))
+}
+
+func TestFilterToolsListResultNoToolsField(t *testing.T) {
+	result := json.RawMessage(`{"other":"value"}`)
+	filtered, removed, err := filterToolsListResult(result, map[string]bool{"a": true})
+	require.NoError(t, err)
+	require.Equal(t, 0, removed)
+	require.Equal(t, string(result), string(filtered))
+}

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/ironsh/iron-proxy/internal/hostmatch"
 )
 
@@ -103,6 +105,20 @@ type Server struct {
 type Tool struct {
 	Name    string
 	clauses []clause
+}
+
+// LoadFromNode decodes a raw yaml.Node into a Config and compiles it. An
+// empty node (the mcp: block absent from the source document) returns
+// (nil, nil) so callers can treat "no MCP policy" as a normal case.
+func LoadFromNode(node yaml.Node) (*Policy, error) {
+	if node.Kind == 0 {
+		return nil, nil
+	}
+	var c Config
+	if err := node.Decode(&c); err != nil {
+		return nil, fmt.Errorf("decoding mcp config: %w", err)
+	}
+	return Compile(c)
 }
 
 // Compile validates and compiles a Config into a Policy. Returns nil when the

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -93,6 +93,10 @@ type Server struct {
 	Name  string
 	rules []hostmatch.Rule
 	tools map[string]*Tool
+	// allowedNames is the set of tool names allowed on this server, derived
+	// from tools at compile time. Cached so the response-side filter does
+	// not rebuild the map on every response.
+	allowedNames map[string]bool
 }
 
 // Tool is a compiled tool allowlist entry with optional argument constraints.
@@ -140,9 +144,10 @@ func Compile(c Config) (*Policy, error) {
 		}
 
 		s := &Server{
-			Name:  sc.Name,
-			rules: rules,
-			tools: make(map[string]*Tool, len(sc.Tools)),
+			Name:         sc.Name,
+			rules:        rules,
+			tools:        make(map[string]*Tool, len(sc.Tools)),
+			allowedNames: make(map[string]bool, len(sc.Tools)),
 		}
 
 		for j, tc := range sc.Tools {
@@ -157,6 +162,7 @@ func Compile(c Config) (*Policy, error) {
 				return nil, err
 			}
 			s.tools[tc.Name] = &Tool{Name: tc.Name, clauses: clauses}
+			s.allowedNames[tc.Name] = true
 		}
 
 		p.servers = append(p.servers, s)
@@ -165,10 +171,7 @@ func Compile(c Config) (*Policy, error) {
 	return p, nil
 }
 
-// ErrorCode returns the configured JSON-RPC error code for policy denials.
-func (p *Policy) ErrorCode() int { return p.errorCode }
-
-// ErrorMessage returns the configured JSON-RPC error message for policy denials.
+func (p *Policy) ErrorCode() int       { return p.errorCode }
 func (p *Policy) ErrorMessage() string { return p.errorMessage }
 
 // MatchServer returns the first server whose rules match the request, or nil.
@@ -187,14 +190,10 @@ func (p *Policy) MatchServer(req *http.Request) *Server {
 	return nil
 }
 
-// AllowedToolNames returns the set of tool names allowed on this server, used
-// for tools/list response filtering.
+// AllowedToolNames returns the precompiled set of tool names allowed on this
+// server. The map is shared (not copied) and must not be mutated.
 func (s *Server) AllowedToolNames() map[string]bool {
-	names := make(map[string]bool, len(s.tools))
-	for n := range s.tools {
-		names[n] = true
-	}
-	return names
+	return s.allowedNames
 }
 
 // EvaluateTool checks whether a tool call is allowed under this server's

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -1,0 +1,217 @@
+// Package mcp implements an MCP-aware policy that inspects Streamable HTTP
+// JSON-RPC traffic to enforce per-server tool allowlists with optional
+// argument constraints. It runs alongside the proxy's transform pipeline as a
+// first-class interceptor: requests are evaluated before forwarding upstream
+// and responses are filtered per-event before reaching the client, which
+// matches MCP's long-lived SSE response semantics that the request/response
+// transform contract does not.
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+)
+
+// Default JSON-RPC error code and message used when policy denies a tools/call.
+// Both are configurable via the top-level mcp.error block.
+const (
+	DefaultErrorCode    = -32001
+	DefaultErrorMessage = "blocked by iron-proxy policy"
+)
+
+// Reason codes recorded on denial audit messages.
+const (
+	ReasonToolNotAllowed     = "tool_not_allowed"
+	ReasonArgumentConstraint = "argument_constraint"
+	ReasonOversizeBody       = "oversize_body"
+	ReasonMalformedJSONRPC   = "malformed_jsonrpc"
+	ReasonBatchNotSupported  = "batch_not_supported"
+)
+
+// Decision values recorded on audit messages.
+const (
+	DecisionAllow    = "allow"
+	DecisionDeny     = "deny"
+	DecisionFiltered = "filtered"
+)
+
+// Direction values recorded on audit messages.
+const (
+	DirectionRequest  = "request"
+	DirectionResponse = "response"
+)
+
+// Config is the YAML shape of the top-level mcp: block.
+type Config struct {
+	Error   ErrorConfig    `yaml:"error"`
+	Servers []ServerConfig `yaml:"servers"`
+}
+
+// ErrorConfig customizes the JSON-RPC error envelope used for policy denials.
+// Both fields use defaults when unset.
+type ErrorConfig struct {
+	Code    *int    `yaml:"code"`
+	Message *string `yaml:"message"`
+}
+
+// ServerConfig declares a logical MCP server: a set of host/path rules that
+// identify its traffic plus the allowlist of tools that may be called on it.
+type ServerConfig struct {
+	Name  string                 `yaml:"name"`
+	Rules []hostmatch.RuleConfig `yaml:"rules"`
+	Tools []ToolConfig           `yaml:"tools"`
+}
+
+// ToolConfig is a single allowed tool, optionally constrained by argument
+// matchers. All matchers AND together; an omitted when block means the tool
+// name match is sufficient.
+type ToolConfig struct {
+	Name string         `yaml:"name"`
+	When []ClauseConfig `yaml:"when"`
+}
+
+// ClauseConfig is a single argument constraint. Exactly one of equals, in, or
+// matches must be set.
+type ClauseConfig struct {
+	Path    string `yaml:"path"`
+	Equals  any    `yaml:"equals"`
+	In      []any  `yaml:"in"`
+	Matches string `yaml:"matches"`
+}
+
+// Policy is the compiled, runtime form of the mcp config.
+type Policy struct {
+	errorCode    int
+	errorMessage string
+	servers      []*Server
+}
+
+// Server is a compiled MCP server definition.
+type Server struct {
+	Name  string
+	rules []hostmatch.Rule
+	tools map[string]*Tool
+}
+
+// Tool is a compiled tool allowlist entry with optional argument constraints.
+type Tool struct {
+	Name    string
+	clauses []clause
+}
+
+// Compile validates and compiles a Config into a Policy. Returns nil when the
+// supplied config has no servers — the caller can treat this as "MCP policy
+// not configured".
+func Compile(c Config) (*Policy, error) {
+	if len(c.Servers) == 0 {
+		return nil, nil
+	}
+
+	p := &Policy{
+		errorCode:    DefaultErrorCode,
+		errorMessage: DefaultErrorMessage,
+	}
+	if c.Error.Code != nil {
+		p.errorCode = *c.Error.Code
+	}
+	if c.Error.Message != nil {
+		p.errorMessage = *c.Error.Message
+	}
+
+	seenNames := make(map[string]bool)
+	for i, sc := range c.Servers {
+		if sc.Name == "" {
+			return nil, fmt.Errorf("mcp.servers[%d]: name is required", i)
+		}
+		if seenNames[sc.Name] {
+			return nil, fmt.Errorf("mcp.servers[%d]: duplicate server name %q", i, sc.Name)
+		}
+		seenNames[sc.Name] = true
+
+		if len(sc.Rules) == 0 {
+			return nil, fmt.Errorf("mcp.servers[%q]: at least one rule is required", sc.Name)
+		}
+
+		rules, err := hostmatch.CompileRules(sc.Rules, fmt.Sprintf("mcp.servers[%q]", sc.Name))
+		if err != nil {
+			return nil, err
+		}
+
+		s := &Server{
+			Name:  sc.Name,
+			rules: rules,
+			tools: make(map[string]*Tool, len(sc.Tools)),
+		}
+
+		for j, tc := range sc.Tools {
+			if tc.Name == "" {
+				return nil, fmt.Errorf("mcp.servers[%q].tools[%d]: name is required", sc.Name, j)
+			}
+			if _, dup := s.tools[tc.Name]; dup {
+				return nil, fmt.Errorf("mcp.servers[%q].tools: duplicate tool name %q", sc.Name, tc.Name)
+			}
+			clauses, err := compileClauses(tc.When, fmt.Sprintf("mcp.servers[%q].tools[%q]", sc.Name, tc.Name))
+			if err != nil {
+				return nil, err
+			}
+			s.tools[tc.Name] = &Tool{Name: tc.Name, clauses: clauses}
+		}
+
+		p.servers = append(p.servers, s)
+	}
+
+	return p, nil
+}
+
+// ErrorCode returns the configured JSON-RPC error code for policy denials.
+func (p *Policy) ErrorCode() int { return p.errorCode }
+
+// ErrorMessage returns the configured JSON-RPC error message for policy denials.
+func (p *Policy) ErrorMessage() string { return p.errorMessage }
+
+// MatchServer returns the first server whose rules match the request, or nil.
+func (p *Policy) MatchServer(req *http.Request) *Server {
+	if p == nil {
+		return nil
+	}
+	host := hostmatch.StripPort(req.Host)
+	for _, s := range p.servers {
+		for _, r := range s.rules {
+			if r.Matches(host, req.Method, req.URL.Path) {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+// AllowedToolNames returns the set of tool names allowed on this server, used
+// for tools/list response filtering.
+func (s *Server) AllowedToolNames() map[string]bool {
+	names := make(map[string]bool, len(s.tools))
+	for n := range s.tools {
+		names[n] = true
+	}
+	return names
+}
+
+// EvaluateTool checks whether a tool call is allowed under this server's
+// policy. params is the decoded JSON-RPC params (typically a map containing
+// "name" and "arguments"). Returns the decision reason on deny.
+func (s *Server) EvaluateTool(toolName string, args any) (allowed bool, reason string) {
+	t, ok := s.tools[toolName]
+	if !ok {
+		return false, ReasonToolNotAllowed
+	}
+	if len(t.clauses) == 0 {
+		return true, ""
+	}
+	for _, cl := range t.clauses {
+		if !cl.evaluate(args) {
+			return false, ReasonArgumentConstraint
+		}
+	}
+	return true, ""
+}

--- a/internal/mcp/policy_test.go
+++ b/internal/mcp/policy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/hostmatch"
 )
@@ -31,6 +32,48 @@ func TestCompileEmptyConfig(t *testing.T) {
 	p, err := Compile(Config{})
 	require.NoError(t, err)
 	require.Nil(t, p)
+}
+
+func TestLoadFromNodeAbsent(t *testing.T) {
+	p, err := LoadFromNode(yaml.Node{})
+	require.NoError(t, err)
+	require.Nil(t, p)
+}
+
+func TestLoadFromNodeRoundTrip(t *testing.T) {
+	src := `
+error:
+  code: -32099
+  message: "denied"
+servers:
+  - name: github
+    rules:
+      - host: "mcp.github.com"
+    tools:
+      - name: search_repositories
+`
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &n))
+	// yaml.Unmarshal into a Node yields a document node; descend to the
+	// mapping the way config.LoadConfig does when it pulls cfg.MCP out of
+	// the parent struct.
+	require.Equal(t, yaml.DocumentNode, n.Kind)
+	require.Len(t, n.Content, 1)
+
+	p, err := LoadFromNode(*n.Content[0])
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.Equal(t, -32099, p.ErrorCode())
+	require.Equal(t, "denied", p.ErrorMessage())
+	require.Len(t, p.servers, 1)
+}
+
+func TestLoadFromNodeDecodeError(t *testing.T) {
+	// Wrong shape: servers should be a list, not a string.
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`servers: "not a list"`), &n))
+	_, err := LoadFromNode(*n.Content[0])
+	require.Error(t, err)
 }
 
 func TestCompileCustomError(t *testing.T) {

--- a/internal/mcp/policy_test.go
+++ b/internal/mcp/policy_test.go
@@ -1,0 +1,221 @@
+package mcp
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+)
+
+func intPtr(i int) *int       { return &i }
+func strPtr(s string) *string { return &s }
+
+func TestCompileDefaults(t *testing.T) {
+	p, err := Compile(Config{
+		Servers: []ServerConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "mcp.github.com"}},
+			Tools: []ToolConfig{{Name: "search_repositories"}},
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.Equal(t, DefaultErrorCode, p.ErrorCode())
+	require.Equal(t, DefaultErrorMessage, p.ErrorMessage())
+}
+
+func TestCompileEmptyConfig(t *testing.T) {
+	p, err := Compile(Config{})
+	require.NoError(t, err)
+	require.Nil(t, p)
+}
+
+func TestCompileCustomError(t *testing.T) {
+	p, err := Compile(Config{
+		Error: ErrorConfig{Code: intPtr(-32099), Message: strPtr("custom")},
+		Servers: []ServerConfig{{
+			Name:  "x",
+			Rules: []hostmatch.RuleConfig{{Host: "x.example.com"}},
+			Tools: []ToolConfig{{Name: "ok"}},
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, -32099, p.ErrorCode())
+	require.Equal(t, "custom", p.ErrorMessage())
+}
+
+func TestCompileValidation(t *testing.T) {
+	cases := []struct {
+		name   string
+		config Config
+		errSub string
+	}{
+		{
+			name: "missing server name",
+			config: Config{Servers: []ServerConfig{{
+				Rules: []hostmatch.RuleConfig{{Host: "x"}},
+			}}},
+			errSub: "name is required",
+		},
+		{
+			name: "duplicate server name",
+			config: Config{Servers: []ServerConfig{
+				{Name: "a", Rules: []hostmatch.RuleConfig{{Host: "a"}}},
+				{Name: "a", Rules: []hostmatch.RuleConfig{{Host: "b"}}},
+			}},
+			errSub: "duplicate server name",
+		},
+		{
+			name: "no rules",
+			config: Config{Servers: []ServerConfig{{
+				Name: "a",
+			}}},
+			errSub: "at least one rule",
+		},
+		{
+			name: "duplicate tool",
+			config: Config{Servers: []ServerConfig{{
+				Name:  "a",
+				Rules: []hostmatch.RuleConfig{{Host: "a"}},
+				Tools: []ToolConfig{{Name: "x"}, {Name: "x"}},
+			}}},
+			errSub: "duplicate tool name",
+		},
+		{
+			name: "missing tool name",
+			config: Config{Servers: []ServerConfig{{
+				Name:  "a",
+				Rules: []hostmatch.RuleConfig{{Host: "a"}},
+				Tools: []ToolConfig{{}},
+			}}},
+			errSub: "name is required",
+		},
+		{
+			name: "clause with no constraint",
+			config: Config{Servers: []ServerConfig{{
+				Name:  "a",
+				Rules: []hostmatch.RuleConfig{{Host: "a"}},
+				Tools: []ToolConfig{{Name: "x", When: []ClauseConfig{{Path: "p"}}}},
+			}}},
+			errSub: "exactly one of equals, in, matches",
+		},
+		{
+			name: "clause with two constraints",
+			config: Config{Servers: []ServerConfig{{
+				Name:  "a",
+				Rules: []hostmatch.RuleConfig{{Host: "a"}},
+				Tools: []ToolConfig{{Name: "x", When: []ClauseConfig{{Path: "p", Equals: "v", Matches: ".*"}}}},
+			}}},
+			errSub: "exactly one of equals, in, matches",
+		},
+		{
+			name: "bad regex",
+			config: Config{Servers: []ServerConfig{{
+				Name:  "a",
+				Rules: []hostmatch.RuleConfig{{Host: "a"}},
+				Tools: []ToolConfig{{Name: "x", When: []ClauseConfig{{Path: "p", Matches: "["}}}},
+			}}},
+			errSub: "invalid matches regex",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Compile(tc.config)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errSub)
+		})
+	}
+}
+
+func TestMatchServer(t *testing.T) {
+	p := mustCompile(t, Config{Servers: []ServerConfig{
+		{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "mcp.github.com", Paths: []string{"/mcp"}}},
+			Tools: []ToolConfig{{Name: "ok"}},
+		},
+		{
+			Name:  "anthropic",
+			Rules: []hostmatch.RuleConfig{{Host: "*.anthropic.com"}},
+			Tools: []ToolConfig{{Name: "ok"}},
+		},
+	}})
+
+	r := func(host, path string) *http.Request {
+		u, _ := url.Parse("https://" + host + path)
+		return &http.Request{Method: "POST", Host: host, URL: u}
+	}
+
+	require.Equal(t, "github", p.MatchServer(r("mcp.github.com", "/mcp")).Name)
+	require.Nil(t, p.MatchServer(r("mcp.github.com", "/other")))
+	require.Equal(t, "anthropic", p.MatchServer(r("api.anthropic.com", "/")).Name)
+	require.Nil(t, p.MatchServer(r("example.com", "/mcp")))
+}
+
+func TestEvaluateTool(t *testing.T) {
+	p := mustCompile(t, Config{Servers: []ServerConfig{{
+		Name:  "github",
+		Rules: []hostmatch.RuleConfig{{Host: "mcp.github.com"}},
+		Tools: []ToolConfig{
+			{Name: "search_repositories"},
+			{Name: "create_issue", When: []ClauseConfig{
+				{Path: "owner", Equals: "ironsh"},
+				{Path: "repo", In: []any{"a", "b"}},
+			}},
+			{Name: "rename", When: []ClauseConfig{
+				{Path: "name", Matches: "^safe-"},
+			}},
+		},
+	}}})
+	s := p.MatchServer(httpReq("mcp.github.com", "/", "POST"))
+	require.NotNil(t, s)
+
+	// Allowed without constraints.
+	allowed, _ := s.EvaluateTool("search_repositories", nil)
+	require.True(t, allowed)
+
+	// Tool not in allowlist.
+	allowed, reason := s.EvaluateTool("delete_repo", nil)
+	require.False(t, allowed)
+	require.Equal(t, ReasonToolNotAllowed, reason)
+
+	// Constraints all hold.
+	allowed, _ = s.EvaluateTool("create_issue", map[string]any{"owner": "ironsh", "repo": "a"})
+	require.True(t, allowed)
+
+	// One constraint fails.
+	allowed, reason = s.EvaluateTool("create_issue", map[string]any{"owner": "elsewhere", "repo": "a"})
+	require.False(t, allowed)
+	require.Equal(t, ReasonArgumentConstraint, reason)
+
+	// In clause negative.
+	allowed, reason = s.EvaluateTool("create_issue", map[string]any{"owner": "ironsh", "repo": "c"})
+	require.False(t, allowed)
+	require.Equal(t, ReasonArgumentConstraint, reason)
+
+	// Missing path.
+	allowed, _ = s.EvaluateTool("create_issue", map[string]any{"owner": "ironsh"})
+	require.False(t, allowed)
+
+	// Regex match.
+	allowed, _ = s.EvaluateTool("rename", map[string]any{"name": "safe-thing"})
+	require.True(t, allowed)
+	allowed, _ = s.EvaluateTool("rename", map[string]any{"name": "danger"})
+	require.False(t, allowed)
+}
+
+func mustCompile(t *testing.T, c Config) *Policy {
+	t.Helper()
+	p, err := Compile(c)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	return p
+}
+
+func httpReq(host, path, method string) *http.Request {
+	u, _ := url.Parse("https://" + host + path)
+	return &http.Request{Method: method, Host: host, URL: u}
+}

--- a/internal/mcp/sse.go
+++ b/internal/mcp/sse.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+// sseEvent is one parsed SSE event. Lines other than data:/event:/id:/retry:
+// are preserved verbatim under "extra" so re-emission produces a structurally
+// identical event when the data payload is unchanged.
+type sseEvent struct {
+	// raw is the original event bytes (including the trailing blank-line
+	// terminator) as read from the upstream. Preserved so events whose data
+	// payload we do not rewrite can be passed through byte-for-byte.
+	raw []byte
+
+	// dataLines are the values of the "data:" fields, in order. Per the SSE
+	// spec, multi-line data is concatenated with a single newline between
+	// lines. dataLines is nil when the event has no data (e.g. a comment-only
+	// keepalive).
+	dataLines [][]byte
+
+	// other holds the verbatim non-data lines (event:, id:, retry:, comments,
+	// blank lines aside from the terminator) so we can re-emit them around a
+	// rewritten data payload.
+	other [][]byte
+}
+
+// readSSEEvent reads a single SSE event terminated by a blank line from r.
+// Returns io.EOF when no more events are available. Lines that are not in
+// "key:value" form (e.g. malformed) are preserved under other.
+func readSSEEvent(r *bufio.Reader) (*sseEvent, error) {
+	var raw bytes.Buffer
+	ev := &sseEvent{}
+	gotAny := false
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			gotAny = true
+			raw.Write(line)
+		}
+		if err != nil {
+			if err == io.EOF {
+				if gotAny {
+					ev.raw = raw.Bytes()
+					return ev, nil
+				}
+				return nil, io.EOF
+			}
+			return nil, err
+		}
+
+		trimmed := stripCRLF(line)
+		// Blank line terminates an event.
+		if len(trimmed) == 0 {
+			ev.raw = raw.Bytes()
+			return ev, nil
+		}
+		if len(trimmed) > 0 && trimmed[0] == ':' {
+			// Comment line: preserve verbatim under other.
+			ev.other = append(ev.other, append([]byte(nil), line...))
+			continue
+		}
+		key, value := splitField(trimmed)
+		if key == "data" {
+			ev.dataLines = append(ev.dataLines, append([]byte(nil), value...))
+			continue
+		}
+		ev.other = append(ev.other, append([]byte(nil), line...))
+	}
+}
+
+// dataPayload returns the concatenated SSE data payload (lines joined with \n
+// per the spec). Returns nil when the event has no data lines.
+func (e *sseEvent) dataPayload() []byte {
+	if len(e.dataLines) == 0 {
+		return nil
+	}
+	if len(e.dataLines) == 1 {
+		return e.dataLines[0]
+	}
+	return bytes.Join(e.dataLines, []byte{'\n'})
+}
+
+// rewriteData returns the bytes for the event with data: lines replaced by
+// payload (split on newlines) while preserving non-data lines.
+func (e *sseEvent) rewriteData(payload []byte) []byte {
+	var buf bytes.Buffer
+	for _, ln := range e.other {
+		buf.Write(ln)
+		if !bytes.HasSuffix(ln, []byte{'\n'}) {
+			buf.WriteByte('\n')
+		}
+	}
+	if len(payload) > 0 {
+		for _, ln := range bytes.Split(payload, []byte{'\n'}) {
+			buf.WriteString("data: ")
+			buf.Write(ln)
+			buf.WriteByte('\n')
+		}
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+func splitField(line []byte) (string, []byte) {
+	idx := bytes.IndexByte(line, ':')
+	if idx < 0 {
+		return string(line), nil
+	}
+	key := string(line[:idx])
+	value := line[idx+1:]
+	if len(value) > 0 && value[0] == ' ' {
+		value = value[1:]
+	}
+	return key, value
+}
+
+func stripCRLF(line []byte) []byte {
+	for len(line) > 0 && (line[len(line)-1] == '\n' || line[len(line)-1] == '\r') {
+		line = line[:len(line)-1]
+	}
+	return line
+}

--- a/internal/mcp/sse_test.go
+++ b/internal/mcp/sse_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSSEEventSingle(t *testing.T) {
+	stream := "event: message\ndata: hello\n\n"
+	br := bufio.NewReader(strings.NewReader(stream))
+
+	ev, err := readSSEEvent(br)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	require.Equal(t, "hello", string(ev.dataPayload()))
+
+	_, err = readSSEEvent(br)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestReadSSEEventMultiline(t *testing.T) {
+	stream := "data: line1\ndata: line2\n\n"
+	br := bufio.NewReader(strings.NewReader(stream))
+
+	ev, err := readSSEEvent(br)
+	require.NoError(t, err)
+	require.Equal(t, "line1\nline2", string(ev.dataPayload()))
+}
+
+func TestReadSSEEventComment(t *testing.T) {
+	stream := ": keepalive\n\ndata: payload\n\n"
+	br := bufio.NewReader(strings.NewReader(stream))
+
+	ev1, err := readSSEEvent(br)
+	require.NoError(t, err)
+	require.Empty(t, ev1.dataLines)
+
+	ev2, err := readSSEEvent(br)
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(ev2.dataPayload()))
+}
+
+func TestRewriteData(t *testing.T) {
+	stream := "id: 1\nevent: message\ndata: original\n\n"
+	br := bufio.NewReader(strings.NewReader(stream))
+
+	ev, err := readSSEEvent(br)
+	require.NoError(t, err)
+
+	out := ev.rewriteData([]byte("rewritten"))
+	require.Contains(t, string(out), "id: 1\n")
+	require.Contains(t, string(out), "event: message\n")
+	require.Contains(t, string(out), "data: rewritten\n")
+	require.True(t, bytes.HasSuffix(out, []byte("\n\n")))
+}
+
+func TestRewriteDataMultiline(t *testing.T) {
+	stream := "data: x\n\n"
+	br := bufio.NewReader(strings.NewReader(stream))
+
+	ev, err := readSSEEvent(br)
+	require.NoError(t, err)
+
+	out := ev.rewriteData([]byte("a\nb\nc"))
+	lines := strings.Split(strings.TrimSuffix(string(out), "\n\n"), "\n")
+	require.Equal(t, []string{"data: a", "data: b", "data: c"}, lines)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/certcache"
 	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -42,6 +43,7 @@ type Proxy struct {
 	transport      *http.Transport
 	resolver       *net.Resolver
 	guard          *dnsguard.Guard
+	mcpPolicy      *mcp.Policy
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -65,6 +67,7 @@ type Options struct {
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
 	Guard      *dnsguard.Guard // nil is treated as an empty (no-op) guard
+	MCPPolicy  *mcp.Policy     // optional MCP-aware policy interceptor
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -93,6 +96,7 @@ func New(opts Options) *Proxy {
 		transport:      buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout),
 		resolver:       opts.Resolver,
 		guard:          guard,
+		mcpPolicy:      opts.MCPPolicy,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -313,6 +317,32 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 
+	// MCP policy: evaluate the request against any matching MCP server. Runs
+	// after the transform pipeline so allowlist/secrets have already applied.
+	var mcpServer *mcp.Server
+	var mcpTrace *mcp.Trace
+	if p.mcpPolicy != nil {
+		if s := p.mcpPolicy.MatchServer(r); s != nil {
+			mcpServer = s
+			mcpTrace = &mcp.Trace{Server: s.Name}
+			result.MCP = mcpTrace
+			rejectResp, err := p.mcpPolicy.EvaluateRequest(s, r, mcpTrace)
+			if err != nil {
+				result.Action = transform.ActionContinue
+				result.StatusCode = http.StatusBadGateway
+				result.Err = err
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			if rejectResp != nil {
+				result.Action = transform.ActionReject
+				result.StatusCode = rejectResp.StatusCode
+				p.writeResponse(w, rejectResp)
+				return
+			}
+		}
+	}
+
 	// WebSocket upgrade: hijack and proxy bidirectionally
 	if isWebSocketUpgrade(r) {
 		result.Action = transform.ActionContinue
@@ -375,6 +405,26 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	result.Action = transform.ActionContinue
 	result.StatusCode = finalResp.StatusCode
+
+	// MCP response wrapping: filter tools/list payloads and other JSON-RPC
+	// messages on streams from a matched MCP server.
+	if mcpServer != nil && p.mcpPolicy != nil {
+		ct := finalResp.Header.Get("Content-Type")
+		// The wrapper consumes the upstream BufferedBody. The proxy's
+		// streamSSE/writeResponse paths require a *transform.BufferedBody,
+		// so we re-wrap whatever the policy returns.
+		original := finalResp.Body
+		wrapped, err := p.mcpPolicy.WrapResponseBody(mcpServer, ct, original, mcpTrace)
+		if err != nil {
+			p.logger.Warn("mcp response wrap error", slog.String("error", err.Error()))
+		} else if wrapped != nil && wrapped != original {
+			if _, isBuffered := wrapped.(*transform.BufferedBody); isBuffered {
+				finalResp.Body = wrapped
+			} else {
+				finalResp.Body = transform.NewBufferedBody(wrapped, 0)
+			}
+		}
+	}
 
 	// SSE: stream with flushing
 	if isSSE(finalResp) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -407,22 +407,16 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	result.StatusCode = finalResp.StatusCode
 
 	// MCP response wrapping: filter tools/list payloads and other JSON-RPC
-	// messages on streams from a matched MCP server.
+	// messages on streams from a matched MCP server. WrapResponseBody
+	// returns a *transform.BufferedBody (or the original body untouched)
+	// so the proxy's streamSSE/writeResponse paths can consume it directly.
 	if mcpServer != nil && p.mcpPolicy != nil {
 		ct := finalResp.Header.Get("Content-Type")
-		// The wrapper consumes the upstream BufferedBody. The proxy's
-		// streamSSE/writeResponse paths require a *transform.BufferedBody,
-		// so we re-wrap whatever the policy returns.
-		original := finalResp.Body
-		wrapped, err := p.mcpPolicy.WrapResponseBody(mcpServer, ct, original, mcpTrace)
+		wrapped, err := p.mcpPolicy.WrapResponseBody(mcpServer, ct, finalResp.Body, mcpTrace)
 		if err != nil {
 			p.logger.Warn("mcp response wrap error", slog.String("error", err.Error()))
-		} else if wrapped != nil && wrapped != original {
-			if _, isBuffered := wrapped.(*transform.BufferedBody); isBuffered {
-				finalResp.Body = wrapped
-			} else {
-				finalResp.Body = transform.NewBufferedBody(wrapped, 0)
-			}
+		} else if wrapped != nil {
+			finalResp.Body = wrapped
 		}
 	}
 

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -68,6 +68,13 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 		if len(result.ResponseTransforms) > 0 {
 			attrs = append(attrs, slog.Any("response_transforms", buildTraceEntries(result.ResponseTransforms)))
 		}
+		if result.MCP != nil && result.MCP.MCPServer() != "" {
+			mcpAttrs := []any{slog.String("server", result.MCP.MCPServer())}
+			if msgs := result.MCP.MCPMessages(); len(msgs) > 0 {
+				mcpAttrs = append(mcpAttrs, slog.Any("messages", msgs))
+			}
+			attrs = append(attrs, slog.Group("mcp", mcpAttrs...))
+		}
 
 		switch {
 		case result.Err != nil:

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -78,6 +78,17 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 				Value: transformTracesValue(result.ResponseTransforms),
 			})
 		}
+		if result.MCP != nil && result.MCP.MCPServer() != "" {
+			mcpKVs := []log.KeyValue{log.String("server", result.MCP.MCPServer())}
+			if msgs := result.MCP.MCPMessages(); len(msgs) > 0 {
+				vals := make([]log.Value, len(msgs))
+				for i, m := range msgs {
+					vals[i] = toLogValue(m)
+				}
+				mcpKVs = append(mcpKVs, log.KeyValue{Key: "messages", Value: log.SliceValue(vals...)})
+			}
+			attrs = append(attrs, log.KeyValue{Key: "mcp", Value: log.MapValue(mcpKVs...)})
+		}
 
 		rec.AddAttributes(attrs...)
 		logger.Emit(context.Background(), rec)
@@ -166,6 +177,10 @@ func toLogValue(v any) log.Value {
 		return log.BoolValue(x)
 	case string:
 		return log.StringValue(x)
+	case int:
+		return log.Int64Value(int64(x))
+	case int64:
+		return log.Int64Value(x)
 	case float64:
 		return log.Float64Value(x)
 	case []any:

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -110,7 +110,26 @@ type PipelineResult struct {
 	RequestTransforms  []TransformTrace
 	ResponseTransforms []TransformTrace
 
+	// MCP carries audit data from the MCP policy interceptor when the
+	// request matched a configured server. nil otherwise. Populated and
+	// consumed by the proxy and rendered by the audit functions; the
+	// transform package treats it as opaque to avoid an import cycle with
+	// internal/mcp.
+	MCP MCPAudit
+
 	Err error
+}
+
+// MCPAudit is the read-only view of the MCP interceptor's per-request audit
+// trace. The interface decouples internal/transform's audit renderers from
+// the concrete *mcp.Trace type so we can render its data without importing
+// the mcp package.
+type MCPAudit interface {
+	// MCPServer returns the matched server name, or "" when nothing matched.
+	MCPServer() string
+	// MCPMessages returns the audit messages in observed order. Each entry
+	// is a flat key/value map suitable for JSON encoding (string-keyed).
+	MCPMessages() []map[string]any
 }
 
 // TransformTrace records what a single transform did.

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -284,6 +284,38 @@ transforms:
         repository under review. Deny writes to user settings, organization
         management, billing, or any repository the agent is not reviewing.
 
+# MCP-aware policy. Inspects Streamable HTTP JSON-RPC traffic to a configured
+# MCP server, blocks tools/call invocations that are not on the allowlist,
+# and filters tools/list responses so denied tools are hidden from the agent.
+# When this block is omitted, MCP traffic is treated as opaque JSON like any
+# other HTTP body.
+#
+# Pipeline placement: the MCP interceptor runs AFTER transforms, so allowlist
+# still gates which hosts can be reached. Argument matchers see whatever wire
+# form transforms (e.g. secrets) have already produced.
+# mcp:
+#   # JSON-RPC error envelope returned to the agent on policy denial. Both
+#   # fields are optional. Defaults: code: -32001, message: "blocked by
+#   # iron-proxy policy". Code -32001 is in the JSON-RPC server-defined range.
+#   error:
+#     code: -32001
+#     message: "blocked by iron-proxy policy"
+#   servers:
+#     - name: github                       # appears in audit as mcp.server
+#       rules:                             # standard host/method/path rules
+#         - host: "mcp.github.com"
+#           paths: ["/mcp", "/mcp/*"]
+#       tools:
+#         - name: "search_repositories"    # always allowed
+#         - name: "create_issue"
+#           when:                          # all clauses must hold; otherwise deny
+#             - path: "owner"              # dotted path against arguments
+#               equals: "ironsh"
+#             - path: "repo"
+#               in: ["iron-proxy", "tunis-v2"]
+#             # `matches: "^safe-"` is also supported (regex on string values)
+#         # Anything not listed is denied (default-deny).
+
 # Optional management API. When `listen` is empty (default), the management
 # server is disabled. When set, the proxy serves an authenticated
 # POST /v1/reload endpoint that re-reads this YAML file and atomically swaps in


### PR DESCRIPTION
Adds a top-level `mcp:` config block that enforces a default-deny tool allowlist on Streamable HTTP MCP servers, with optional argument matchers (`equals`/`in`/`matches`) against `params.arguments`. Denied `tools/call` invocations return a JSON-RPC error envelope without reaching upstream, and `tools/list` responses are filtered per-event over both `application/json` and `text/event-stream` so denied tools never reach the agent.

Implemented in a new `internal/mcp` package as a first-class proxy capability rather than a transform: long-lived MCP SSE responses can carry arbitrary server-initiated messages over time, which does not fit the request/response transform contract. Audit log gains an `mcp` section with one structured record per JSON-RPC message observed.