### PR TITLE
feat(mcp): hot-swap MCP policy from control plane sync

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -115,11 +115,12 @@ func main() {
 	// and (in managed mode) the config poller.
 	errc := make(chan error, 5)
 	var holder *transform.PipelineHolder
+	var mcpHolder *mcp.PolicyHolder
 	var otelCfg iotel.ExportConfig
 
 	if managed {
 		var ingestToken string
-		holder, ingestToken = initManaged(ctx, bodyLimits, errc, stateStore, enrollmentToken, cred, logger)
+		holder, mcpHolder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, stateStore, enrollmentToken, cred, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -127,7 +128,7 @@ func main() {
 			}
 		}
 	} else {
-		holder = initStandalone(cfg, bodyLimits, logger)
+		holder, mcpHolder = initStandalone(cfg, bodyLimits, logger)
 	}
 
 	// 5. Validate the fully-assembled config.
@@ -198,15 +199,6 @@ func main() {
 		)
 	}
 
-	mcpPolicy, err := mcp.LoadFromNode(cfg.MCP)
-	if err != nil {
-		logger.Error("loading mcp policy", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	if mcpPolicy != nil {
-		logger.Info("mcp policy enabled")
-	}
-
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
@@ -217,7 +209,7 @@ func main() {
 		Pipeline:                      holder,
 		Resolver:                      resolver,
 		Guard:                         guard,
-		MCPPolicy:                     mcpPolicy,
+		MCPPolicy:                     mcpHolder,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 	})
@@ -231,7 +223,7 @@ func main() {
 		mgmtServer = management.New(management.Options{
 			Addr:   cfg.Management.Listen,
 			APIKey: os.Getenv(cfg.Management.APIKeyEnv),
-			Reload: newReloadFunc(*configPath, holder, bodyLimits, logger),
+			Reload: newReloadFunc(*configPath, holder, mcpHolder, bodyLimits, logger),
 			Logger: logger,
 		})
 	}
@@ -299,10 +291,14 @@ func main() {
 }
 
 // initManaged registers with the control plane, performs an initial sync, builds
-// the initial pipeline, and starts the config poller. The poller runs until ctx
-// is canceled and sends fatal errors on errc. Returns the pipeline holder and
-// the ingest token from the initial sync (empty if the sync failed).
-func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, enrollmentToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, string) {
+// the initial pipeline and MCP policy, and starts the config poller. The poller
+// runs until ctx is canceled and sends fatal errors on errc. Returns the
+// pipeline holder, the MCP policy holder, and the ingest token from the initial
+// sync (empty if the sync failed).
+//
+// Initial MCP policy preference: control-plane-supplied mcp block first, then
+// fall back to cfg.MCP from the YAML if the sync did not include one.
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, stateStore, enrollmentToken string, cred *controlplane.Credential, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -349,13 +345,14 @@ func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan
 
 	configHash := ""
 	ingestToken := ""
-	var initialRules, initialSecrets json.RawMessage
+	var initialRules, initialSecrets, initialMCP json.RawMessage
 	if syncResp != nil {
 		configHash = syncResp.ConfigHash
 		initialRules = syncResp.Rules
 		initialSecrets = syncResp.Secrets
+		initialMCP = syncResp.MCP
 		ingestToken = syncResp.IngestToken
-		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 {
+		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 || len(syncResp.MCP) > 0 {
 			logger.Info("received initial config from control plane",
 				slog.String("config_hash", syncResp.ConfigHash),
 			)
@@ -376,9 +373,23 @@ func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan
 	}
 	holder := transform.NewPipelineHolder(pipeline)
 
+	// Build initial MCP policy: prefer the control-plane-supplied block; fall
+	// back to cfg.MCP from the YAML so an operator can ship a default that
+	// applies until the first sync arrives.
+	mcpHolder, err := buildInitialMCPHolder(cfg, initialMCP, logger)
+	if err != nil {
+		logger.Error("building initial mcp policy", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
 	// Start config poller.
-	poller := controlplane.NewPoller(client, configHash, func(rules json.RawMessage, secrets json.RawMessage) error {
-		applyPipelineSync(holder, bodyLimits, logger, rules, secrets)
+	poller := controlplane.NewPoller(client, configHash, func(u controlplane.SyncUpdate) error {
+		if u.Rules != nil || u.Secrets != nil {
+			applyPipelineSync(holder, bodyLimits, logger, u.Rules, u.Secrets)
+		}
+		if u.MCP != nil {
+			applyMCPSync(mcpHolder, logger, u.MCP)
+		}
 		return nil
 	}, logger)
 
@@ -386,17 +397,46 @@ func initManaged(ctx context.Context, bodyLimits transform.BodyLimits, errc chan
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, ingestToken
+	return holder, mcpHolder, ingestToken
 }
 
-// initStandalone builds the pipeline from the YAML config's transforms.
-func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger *slog.Logger) *transform.PipelineHolder {
+// buildInitialMCPHolder picks the initial MCP policy source: a control-plane
+// MCP block when present, otherwise the YAML cfg.MCP fallback. A nil holder
+// means "no policy configured"; the proxy treats it as MCP disabled.
+func buildInitialMCPHolder(cfg *config.Config, initialMCP json.RawMessage, logger *slog.Logger) (*mcp.PolicyHolder, error) {
+	node, present, err := config.MCPFromSync(initialMCP)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		node = cfg.MCP
+	}
+	policy, err := mcp.LoadFromNode(node)
+	if err != nil {
+		return nil, err
+	}
+	if policy != nil {
+		logger.Info("mcp policy enabled")
+	}
+	return mcp.NewPolicyHolder(policy), nil
+}
+
+// initStandalone builds the pipeline and MCP policy from the YAML config.
+func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder) {
 	pipeline, err := buildPipeline(cfg.Transforms, bodyLimits, logger)
 	if err != nil {
 		logger.Error("building transform pipeline", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	return transform.NewPipelineHolder(pipeline)
+	mcpPolicy, err := mcp.LoadFromNode(cfg.MCP)
+	if err != nil {
+		logger.Error("loading mcp policy", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if mcpPolicy != nil {
+		logger.Info("mcp policy enabled")
+	}
+	return transform.NewPipelineHolder(pipeline), mcp.NewPolicyHolder(mcpPolicy)
 }
 
 // stateStorePath returns the state store path without creating any directories.
@@ -440,11 +480,40 @@ func applyPipelineSync(holder *transform.PipelineHolder, bodyLimits transform.Bo
 	logger.Info("pipeline reloaded", slog.String("transforms", newPipeline.Names()))
 }
 
+// applyMCPSync compiles a new MCP policy from a sync payload and atomically
+// swaps it in. Parse or compile errors are logged and the prior policy is
+// preserved: an invalid push from the control plane must not take down a
+// running proxy. An empty/null mcp block is interpreted by the caller as
+// "no update" and is not delivered here.
+func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMessage) {
+	node, present, err := config.MCPFromSync(raw)
+	if err != nil {
+		logger.Error("rejecting invalid mcp policy from sync, keeping current policy", slog.String("error", err.Error()))
+		return
+	}
+	if !present {
+		// Should not happen — caller filters absent/null — but treat as no-op.
+		return
+	}
+	policy, err := mcp.LoadFromNode(node)
+	if err != nil {
+		logger.Error("rejecting invalid mcp policy from sync, keeping current policy", slog.String("error", err.Error()))
+		return
+	}
+	holder.Store(policy)
+	if policy == nil {
+		logger.Info("mcp policy cleared by control plane")
+	} else {
+		logger.Info("mcp policy reloaded")
+	}
+}
+
 // newReloadFunc returns a management.ReloadFunc that re-reads the YAML config
-// from configPath, rebuilds the pipeline, and atomically swaps it in. Parse,
-// validation, and pipeline-build errors are wrapped in *management.ValidationError
-// so the management server returns 422; the existing pipeline is preserved.
-func newReloadFunc(configPath string, holder *transform.PipelineHolder, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
+// from configPath, rebuilds the pipeline and MCP policy, and atomically swaps
+// them in. Parse, validation, and build errors are wrapped in
+// *management.ValidationError so the management server returns 422; the
+// existing pipeline and policy are preserved.
+func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolder *mcp.PolicyHolder, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
 	return func() error {
 		newCfg, err := config.LoadConfig(configPath)
 		if err != nil {
@@ -457,8 +526,13 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, bodyLimi
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
+		newPolicy, err := mcp.LoadFromNode(newCfg.MCP)
+		if err != nil {
+			return &management.ValidationError{Err: err}
+		}
 		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 		holder.Store(newPipeline)
+		mcpHolder.Store(newPolicy)
 		logger.Info("pipeline reloaded via management API", slog.String("transforms", newPipeline.Names()))
 		return nil
 	}

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -41,6 +41,37 @@ func TransformsFromSync(rules, secrets json.RawMessage) ([]Transform, error) {
 	return transforms, nil
 }
 
+// MCPFromSync converts a JSON document for the top-level mcp: block into a
+// yaml.Node so internal/mcp.LoadFromNode can decode it the same way as the
+// YAML config path.
+//
+// present is true when raw is non-nil and not JSON null. Callers use it to
+// distinguish "the control plane sent an mcp block" (apply, even if empty)
+// from "the control plane omitted mcp" (preserve current state).
+func MCPFromSync(raw json.RawMessage) (node yaml.Node, present bool, err error) {
+	if !isNonNullJSON(raw) {
+		return yaml.Node{}, false, nil
+	}
+	node, err = yamlNodeFromRawJSON(raw)
+	if err != nil {
+		return yaml.Node{}, false, fmt.Errorf("parsing mcp: %w", err)
+	}
+	return node, true, nil
+}
+
+// yamlNodeFromRawJSON parses raw JSON bytes as a yaml.Node. JSON is valid YAML,
+// and gopkg.in/yaml.v3 handles it natively.
+func yamlNodeFromRawJSON(raw []byte) (yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return yaml.Node{}, fmt.Errorf("unmarshaling JSON as YAML: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return yaml.Node{}, fmt.Errorf("unexpected YAML structure")
+	}
+	return *doc.Content[0], nil
+}
+
 // yamlNodeFromJSON marshals v to JSON, then parses as a yaml.Node. This works
 // because JSON is valid YAML, and gopkg.in/yaml.v3 handles it natively.
 func yamlNodeFromJSON(v any) (yaml.Node, error) {

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -125,3 +125,61 @@ func TestTransformsFromSync_EmptySecrets(t *testing.T) {
 	require.Len(t, transforms, 1)
 	require.Equal(t, "secrets", transforms[0].Name)
 }
+
+func TestMCPFromSync_Nil(t *testing.T) {
+	node, present, err := MCPFromSync(nil)
+	require.NoError(t, err)
+	require.False(t, present)
+	require.Equal(t, 0, int(node.Kind))
+}
+
+func TestMCPFromSync_NullJSON(t *testing.T) {
+	node, present, err := MCPFromSync(json.RawMessage("null"))
+	require.NoError(t, err)
+	require.False(t, present)
+	require.Equal(t, 0, int(node.Kind))
+}
+
+func TestMCPFromSync_EmptyObject(t *testing.T) {
+	node, present, err := MCPFromSync(json.RawMessage(`{}`))
+	require.NoError(t, err)
+	require.True(t, present)
+	require.NotEqual(t, 0, int(node.Kind))
+}
+
+func TestMCPFromSync_RoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"error":{"code":-32099,"message":"nope"},"servers":[{"name":"github","rules":[{"host":"api.github.com"}],"tools":[{"name":"list_repos"}]}]}`)
+	node, present, err := MCPFromSync(raw)
+	require.NoError(t, err)
+	require.True(t, present)
+
+	var decoded struct {
+		Error struct {
+			Code    *int    `yaml:"code"`
+			Message *string `yaml:"message"`
+		} `yaml:"error"`
+		Servers []struct {
+			Name  string `yaml:"name"`
+			Rules []struct {
+				Host string `yaml:"host"`
+			} `yaml:"rules"`
+			Tools []struct {
+				Name string `yaml:"name"`
+			} `yaml:"tools"`
+		} `yaml:"servers"`
+	}
+	require.NoError(t, node.Decode(&decoded))
+	require.NotNil(t, decoded.Error.Code)
+	require.Equal(t, -32099, *decoded.Error.Code)
+	require.NotNil(t, decoded.Error.Message)
+	require.Equal(t, "nope", *decoded.Error.Message)
+	require.Len(t, decoded.Servers, 1)
+	require.Equal(t, "github", decoded.Servers[0].Name)
+	require.Equal(t, "api.github.com", decoded.Servers[0].Rules[0].Host)
+	require.Equal(t, "list_repos", decoded.Servers[0].Tools[0].Name)
+}
+
+func TestMCPFromSync_InvalidJSON(t *testing.T) {
+	_, _, err := MCPFromSync(json.RawMessage(`{bad json`))
+	require.ErrorContains(t, err, "parsing mcp")
+}

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -23,6 +23,7 @@ type SyncResponse struct {
 	ConfigHash  string          `json:"config_hash"`
 	Rules       json.RawMessage `json:"rules"`
 	Secrets     json.RawMessage `json:"secrets"`
+	MCP         json.RawMessage `json:"mcp"`
 	IngestToken string          `json:"ingest_token"`
 }
 

--- a/internal/controlplane/poller.go
+++ b/internal/controlplane/poller.go
@@ -12,16 +12,25 @@ import (
 // PollInterval is the base interval between sync calls.
 const PollInterval = 5 * time.Second
 
+// SyncUpdate is the slice of a SyncResponse passed to the poller's update
+// callback. Fields are nil or JSON null when the control plane did not include
+// them in this sync.
+type SyncUpdate struct {
+	Rules   json.RawMessage
+	Secrets json.RawMessage
+	MCP     json.RawMessage
+}
+
 // Poller periodically calls Sync and applies config updates.
 type Poller struct {
 	client     *Client
 	configHash string
-	onUpdate   func(rules json.RawMessage, secrets json.RawMessage) error
+	onUpdate   func(SyncUpdate) error
 	logger     *slog.Logger
 }
 
 // NewPoller creates a new sync poller.
-func NewPoller(client *Client, initialConfigHash string, onUpdate func(json.RawMessage, json.RawMessage) error, logger *slog.Logger) *Poller {
+func NewPoller(client *Client, initialConfigHash string, onUpdate func(SyncUpdate) error, logger *slog.Logger) *Poller {
 	return &Poller{
 		client:     client,
 		configHash: initialConfigHash,
@@ -70,15 +79,21 @@ func (p *Poller) sync(ctx context.Context) error {
 
 	hasRules := isNonNullJSON(resp.Rules)
 	hasSecrets := isNonNullJSON(resp.Secrets)
+	hasMCP := isNonNullJSON(resp.MCP)
 
-	if hasRules || hasSecrets {
+	if hasRules || hasSecrets || hasMCP {
 		p.logger.Info("config update received from control plane",
 			slog.String("config_hash", resp.ConfigHash),
 			slog.Bool("has_rules", hasRules),
 			slog.Bool("has_secrets", hasSecrets),
+			slog.Bool("has_mcp", hasMCP),
 		)
 		if p.onUpdate != nil {
-			if err := p.onUpdate(resp.Rules, resp.Secrets); err != nil {
+			if err := p.onUpdate(SyncUpdate{
+				Rules:   resp.Rules,
+				Secrets: resp.Secrets,
+				MCP:     resp.MCP,
+			}); err != nil {
 				p.logger.Error("applying config update", slog.String("error", err.Error()))
 			}
 		}

--- a/internal/controlplane/poller_test.go
+++ b/internal/controlplane/poller_test.go
@@ -30,9 +30,9 @@ func TestPollerInitialSync(t *testing.T) {
 	client.SetCredential(&Credential{ProxyID: "irnp_test", Secret: []byte("s")})
 
 	var updateCalled atomic.Int32
-	poller := NewPoller(client, "", func(rules json.RawMessage, secrets json.RawMessage) error {
+	poller := NewPoller(client, "", func(u SyncUpdate) error {
 		updateCalled.Add(1)
-		require.NotNil(t, rules)
+		require.NotNil(t, u.Rules)
 		return nil
 	}, testLogger())
 
@@ -46,6 +46,38 @@ func TestPollerInitialSync(t *testing.T) {
 	require.GreaterOrEqual(t, updateCalled.Load(), int32(1))
 }
 
+func TestPollerInitialSyncDeliversMCP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(SyncResponse{
+			ConfigHash: "sha256:mcp",
+			MCP:        json.RawMessage(`{"servers":[]}`),
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testLogger())
+	client.SetCredential(&Credential{ProxyID: "irnp_test", Secret: []byte("s")})
+
+	var got SyncUpdate
+	var called atomic.Int32
+	poller := NewPoller(client, "", func(u SyncUpdate) error {
+		called.Add(1)
+		got = u
+		return nil
+	}, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := poller.Run(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, called.Load(), int32(1))
+	require.JSONEq(t, `{"servers":[]}`, string(got.MCP))
+	require.False(t, isNonNullJSON(got.Rules))
+	require.False(t, isNonNullJSON(got.Secrets))
+}
+
 func TestPollerNoUpdateOnNullRulesSecrets(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -57,7 +89,7 @@ func TestPollerNoUpdateOnNullRulesSecrets(t *testing.T) {
 	client.SetCredential(&Credential{ProxyID: "irnp_test", Secret: []byte("s")})
 
 	var updateCalled atomic.Int32
-	poller := NewPoller(client, "sha256:same", func(rules json.RawMessage, secrets json.RawMessage) error {
+	poller := NewPoller(client, "sha256:same", func(u SyncUpdate) error {
 		updateCalled.Add(1)
 		return nil
 	}, slog.New(slog.NewTextHandler(io.Discard, nil)))

--- a/internal/mcp/holder.go
+++ b/internal/mcp/holder.go
@@ -1,0 +1,36 @@
+package mcp
+
+import "sync/atomic"
+
+// PolicyHolder holds an atomically swappable Policy pointer. It is safe for
+// concurrent use: readers call Load to get a snapshot, and a single writer
+// calls Store to swap the policy. Policy is immutable after Compile, so no
+// per-request locking is needed.
+//
+// A nil holder, or a holder whose value is nil, both mean "no MCP policy
+// configured" — the receiver methods on *Policy already handle nil safely.
+type PolicyHolder struct {
+	p atomic.Pointer[Policy]
+}
+
+// NewPolicyHolder creates a PolicyHolder with the given initial policy.
+// Passing nil is valid and means the policy starts disabled.
+func NewPolicyHolder(initial *Policy) *PolicyHolder {
+	h := &PolicyHolder{}
+	h.p.Store(initial)
+	return h
+}
+
+// Load returns the current policy snapshot, or nil if none is configured.
+// Callers should capture the returned pointer once per request.
+func (h *PolicyHolder) Load() *Policy {
+	if h == nil {
+		return nil
+	}
+	return h.p.Load()
+}
+
+// Store atomically replaces the current policy with next.
+func (h *PolicyHolder) Store(next *Policy) {
+	h.p.Store(next)
+}

--- a/internal/mcp/holder_test.go
+++ b/internal/mcp/holder_test.go
@@ -1,0 +1,24 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyHolder_LoadStore(t *testing.T) {
+	h := NewPolicyHolder(nil)
+	require.Nil(t, h.Load())
+
+	p := &Policy{}
+	h.Store(p)
+	require.Same(t, p, h.Load())
+
+	h.Store(nil)
+	require.Nil(t, h.Load())
+}
+
+func TestPolicyHolder_NilReceiverLoadsNil(t *testing.T) {
+	var h *PolicyHolder
+	require.Nil(t, h.Load())
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -43,7 +43,7 @@ type Proxy struct {
 	transport      *http.Transport
 	resolver       *net.Resolver
 	guard          *dnsguard.Guard
-	mcpPolicy      *mcp.Policy
+	mcpPolicy      *mcp.PolicyHolder
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -67,7 +67,7 @@ type Options struct {
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
 	Guard      *dnsguard.Guard // nil is treated as an empty (no-op) guard
-	MCPPolicy  *mcp.Policy     // optional MCP-aware policy interceptor
+	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -319,14 +319,16 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	// MCP policy: evaluate the request against any matching MCP server. Runs
 	// after the transform pipeline so allowlist/secrets have already applied.
+	// Snapshot once per request so a hot-swap mid-request stays consistent.
+	mcpPolicy := p.mcpPolicy.Load()
 	var mcpServer *mcp.Server
 	var mcpTrace *mcp.Trace
-	if p.mcpPolicy != nil {
-		if s := p.mcpPolicy.MatchServer(r); s != nil {
+	if mcpPolicy != nil {
+		if s := mcpPolicy.MatchServer(r); s != nil {
 			mcpServer = s
 			mcpTrace = &mcp.Trace{Server: s.Name}
 			result.MCP = mcpTrace
-			rejectResp, err := p.mcpPolicy.EvaluateRequest(s, r, mcpTrace)
+			rejectResp, err := mcpPolicy.EvaluateRequest(s, r, mcpTrace)
 			if err != nil {
 				result.Action = transform.ActionContinue
 				result.StatusCode = http.StatusBadGateway
@@ -410,9 +412,9 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	// messages on streams from a matched MCP server. WrapResponseBody
 	// returns a *transform.BufferedBody (or the original body untouched)
 	// so the proxy's streamSSE/writeResponse paths can consume it directly.
-	if mcpServer != nil && p.mcpPolicy != nil {
+	if mcpServer != nil && mcpPolicy != nil {
 		ct := finalResp.Header.Get("Content-Type")
-		wrapped, err := p.mcpPolicy.WrapResponseBody(mcpServer, ct, finalResp.Body, mcpTrace)
+		wrapped, err := mcpPolicy.WrapResponseBody(mcpServer, ct, finalResp.Body, mcpTrace)
 		if err != nil {
 			p.logger.Warn("mcp response wrap error", slog.String("error", err.Error()))
 		} else if wrapped != nil {


### PR DESCRIPTION
Extends the control plane sync payload with a top-level `mcp` field whose JSON shape mirrors the YAML `mcp:` block, and lets managed proxies hot-swap MCP policy without restart. An atomic `mcp.PolicyHolder` (mirroring `transform.PipelineHolder`) replaces the immutable `*mcp.Policy` on the proxy struct, so each request takes a single `Load()` snapshot and stays consistent across request-side `EvaluateRequest` and response-side `WrapResponseBody`. Parse or compile errors on a sync push are logged and the prior policy is preserved, matching the existing rule for the transform pipeline. Standalone mode keeps the YAML as the source of truth, and the management `/v1/reload` endpoint now reloads MCP policy along with the pipeline.