### PR TITLE
feat(secrets): resolve lazily and add require to inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,15 +380,20 @@ Secret sources:
 
 - **`env`:** reads `var` from the proxy process environment.
 - **`aws_sm`:** reads `secret_id` from AWS Secrets Manager. Optional `region`,
-  `json_key`, and `ttl` are supported.
+  `json_key`, `ttl`, and `failure_ttl` are supported.
 - **`aws_ssm`:** reads `name` from AWS Systems Manager Parameter Store. Optional
-  `region`, `with_decryption`, `json_key`, and `ttl` are supported.
+  `region`, `with_decryption`, `json_key`, `ttl`, and `failure_ttl` are supported.
   `with_decryption` defaults to `true`, which is the expected setting for
   `SecureString` parameters.
 - **`1password`:** resolves `secret_ref` (an `op://vault/item/[section/]field`
   reference) using a 1Password service account token. The token is read from
   `OP_SERVICE_ACCOUNT_TOKEN` by default; override with `token_env`. Optional
-  `ttl` is supported.
+  `ttl` and `failure_ttl` are supported.
+
+`ttl` controls how long a successfully fetched value is cached before refresh
+(empty caches forever). `failure_ttl` controls how long a fetch error is
+cached before retrying; it defaults to 1m and is independent of `ttl`, so a
+long success TTL does not delay recovery from a transient backend outage.
 
   > **Note:** a bug in `onepassword-sdk-go` breaks builds with `CGO_ENABLED=0`,
   > so iron-proxy pins a [fork](https://github.com/ironsh/onepassword-sdk-go)

--- a/internal/transform/secrets/op_resolver.go
+++ b/internal/transform/secrets/op_resolver.go
@@ -54,7 +54,7 @@ func newOPResolver(logger *slog.Logger) *opResolver {
 	return &opResolver{clientFor: cache.get, logger: logger}
 }
 
-func (r *opResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *opResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
 	var cfg opConfig
 	if err := raw.Decode(&cfg); err != nil {
 		return ResolveResult{}, fmt.Errorf("parsing 1password source config: %w", err)
@@ -68,15 +68,17 @@ func (r *opResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult,
 	if cfg.TokenEnv == "" {
 		cfg.TokenEnv = defaultOPTokenEnv
 	}
-
-	val, err := r.fetchSecret(ctx, cfg)
+	successTTL, err := parseTTL(cfg.TTL)
 	if err != nil {
-		return ResolveResult{}, err
+		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
 	}
-
-	return resolveWithTTL(cfg.SecretRef, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+	fetch := func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
-	})
+	}
+	return ResolveResult{
+		Name:     cfg.SecretRef,
+		GetValue: newLazyValue(cfg.SecretRef, successTTL, failureTTL(successTTL), r.logger, fetch),
+	}, nil
 }
 
 func (r *opResolver) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {

--- a/internal/transform/secrets/op_resolver.go
+++ b/internal/transform/secrets/op_resolver.go
@@ -18,13 +18,13 @@ import (
 // service account tokens, matching the SDK's own examples.
 const defaultOPTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
 
-// opClient is the subset of the 1Password SDK used by opResolver, narrowed for testability.
+// opClient is the subset of the 1Password SDK used by opBuilder, narrowed for testability.
 type opClient interface {
 	Resolve(ctx context.Context, ref string) (string, error)
 }
 
-// opResolver reads secrets from 1Password using a service account token.
-type opResolver struct {
+// opBuilder reads secrets from 1Password using a service account token.
+type opBuilder struct {
 	clientFor func(ctx context.Context, tokenEnv string) (opClient, error)
 	logger    *slog.Logger
 }
@@ -37,7 +37,7 @@ type opConfig struct {
 	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
-func newOPResolver(logger *slog.Logger) *opResolver {
+func newOPBuilder(logger *slog.Logger) *opBuilder {
 	cache := &opClientCache{
 		clients: make(map[string]opClient),
 		getenv:  os.Getenv,
@@ -52,29 +52,29 @@ func newOPResolver(logger *slog.Logger) *opResolver {
 			return opSDKClient{c: c}, nil
 		},
 	}
-	return &opResolver{clientFor: cache.get, logger: logger}
+	return &opBuilder{clientFor: cache.get, logger: logger}
 }
 
-func (r *opResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *opBuilder) Build(raw yaml.Node) (secretSource, error) {
 	var cfg opConfig
 	if err := raw.Decode(&cfg); err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing 1password source config: %w", err)
+		return nil, fmt.Errorf("parsing 1password source config: %w", err)
 	}
 	if cfg.SecretRef == "" {
-		return ResolveResult{}, fmt.Errorf("1password source requires \"secret_ref\" field")
+		return nil, fmt.Errorf("1password source requires \"secret_ref\" field")
 	}
 	if !strings.HasPrefix(cfg.SecretRef, "op://") {
-		return ResolveResult{}, fmt.Errorf("1password secret_ref %q must start with \"op://\"", cfg.SecretRef)
+		return nil, fmt.Errorf("1password secret_ref %q must start with \"op://\"", cfg.SecretRef)
 	}
 	if cfg.TokenEnv == "" {
 		cfg.TokenEnv = defaultOPTokenEnv
 	}
-	return buildLazyResult(cfg.SecretRef, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
+	return buildLazySource(cfg.SecretRef, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
 	})
 }
 
-func (r *opResolver) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {
+func (r *opBuilder) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {
 	client, err := r.clientFor(ctx, cfg.TokenEnv)
 	if err != nil {
 		return "", fmt.Errorf("creating 1password client: %w", err)

--- a/internal/transform/secrets/op_resolver.go
+++ b/internal/transform/secrets/op_resolver.go
@@ -30,10 +30,11 @@ type opResolver struct {
 }
 
 type opConfig struct {
-	Type      string `yaml:"type"`
-	SecretRef string `yaml:"secret_ref"`
-	TokenEnv  string `yaml:"token_env,omitempty"`
-	TTL       string `yaml:"ttl,omitempty"`
+	Type       string `yaml:"type"`
+	SecretRef  string `yaml:"secret_ref"`
+	TokenEnv   string `yaml:"token_env,omitempty"`
+	TTL        string `yaml:"ttl,omitempty"`
+	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
 func newOPResolver(logger *slog.Logger) *opResolver {
@@ -68,17 +69,9 @@ func (r *opResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, e
 	if cfg.TokenEnv == "" {
 		cfg.TokenEnv = defaultOPTokenEnv
 	}
-	successTTL, err := parseTTL(cfg.TTL)
-	if err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
-	}
-	fetch := func(ctx context.Context) (string, error) {
+	return buildLazyResult(cfg.SecretRef, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
-	}
-	return ResolveResult{
-		Name:     cfg.SecretRef,
-		GetValue: newLazyValue(cfg.SecretRef, successTTL, failureTTL(successTTL), r.logger, fetch),
-	}, nil
+	})
 }
 
 func (r *opResolver) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {

--- a/internal/transform/secrets/op_resolver_test.go
+++ b/internal/transform/secrets/op_resolver_test.go
@@ -25,8 +25,8 @@ func staticOPClient(value string, err error) *mockOPClient {
 	}}
 }
 
-func newTestOPResolver(client opClient) *opResolver {
-	return &opResolver{
+func newTestOPBuilder(client opClient) *opBuilder {
+	return &opBuilder{
 		clientFor: func(_ context.Context, _ string) (opClient, error) {
 			return client, nil
 		},
@@ -34,9 +34,9 @@ func newTestOPResolver(client opClient) *opResolver {
 	}
 }
 
-func TestOPResolver_HappyPath_DefaultTokenEnv(t *testing.T) {
+func TestOPBuilder_HappyPath_DefaultTokenEnv(t *testing.T) {
 	var gotEnv string
-	r := &opResolver{
+	r := &opBuilder{
 		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
 			gotEnv = tokenEnv
 			return staticOPClient("real-secret", nil), nil
@@ -48,19 +48,19 @@ func TestOPResolver_HappyPath_DefaultTokenEnv(t *testing.T) {
 		"type":       "1password",
 		"secret_ref": "op://Engineering/OpenAI/credential",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, "op://Engineering/OpenAI/credential", result.Name)
+	require.Equal(t, "op://Engineering/OpenAI/credential", result.Name())
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-secret", val)
 	require.Equal(t, "OP_SERVICE_ACCOUNT_TOKEN", gotEnv)
 }
 
-func TestOPResolver_HappyPath_CustomTokenEnv(t *testing.T) {
+func TestOPBuilder_HappyPath_CustomTokenEnv(t *testing.T) {
 	var gotEnv string
-	r := &opResolver{
+	r := &opBuilder{
 		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
 			gotEnv = tokenEnv
 			return staticOPClient("custom-token-secret", nil), nil
@@ -73,49 +73,49 @@ func TestOPResolver_HappyPath_CustomTokenEnv(t *testing.T) {
 		"secret_ref": "op://Engineering/OpenAI/credential",
 		"token_env":  "CUSTOM_OP_TOKEN",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "custom-token-secret", val)
 	require.Equal(t, "CUSTOM_OP_TOKEN", gotEnv)
 }
 
-func TestOPResolver_TTLReturnsCachedValue(t *testing.T) {
-	r := newTestOPResolver(staticOPClient("value", nil))
+func TestOPBuilder_TTLReturnsCachedValue(t *testing.T) {
+	r := newTestOPBuilder(staticOPClient("value", nil))
 	node := yamlNode(t, map[string]string{
 		"type":       "1password",
 		"secret_ref": "op://Engineering/OpenAI/credential",
 		"ttl":        "15m",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "value", val)
 }
 
-func TestOPResolver_PassesSecretRefToClient(t *testing.T) {
+func TestOPBuilder_PassesSecretRefToClient(t *testing.T) {
 	var gotRef string
 	client := &mockOPClient{fn: func(_ context.Context, ref string) (string, error) {
 		gotRef = ref
 		return "v", nil
 	}}
-	r := newTestOPResolver(client)
+	r := newTestOPBuilder(client)
 	node := yamlNode(t, map[string]string{
 		"type":       "1password",
 		"secret_ref": "op://vault/item/section/field",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	_, err = result.GetValue(context.Background())
+	_, err = result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "op://vault/item/section/field", gotRef)
 }
 
-func TestOPResolver_Errors(t *testing.T) {
+func TestOPBuilder_Errors(t *testing.T) {
 	tests := []struct {
 		name   string
 		client *mockOPClient
@@ -128,21 +128,21 @@ func TestOPResolver_Errors(t *testing.T) {
 			client: staticOPClient("", nil),
 			input:  map[string]string{"type": "1password"},
 			errMsg: "\"secret_ref\" field",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "secret_ref without op:// prefix",
 			client: staticOPClient("", nil),
 			input:  map[string]string{"type": "1password", "secret_ref": "vault/item/field"},
 			errMsg: "must start with \"op://\"",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "invalid ttl",
 			client: staticOPClient("v", nil),
 			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f", "ttl": "not-a-duration"},
 			errMsg: "parsing ttl",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "sdk error",
@@ -161,16 +161,16 @@ func TestOPResolver_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newTestOPResolver(tt.client)
+			r := newTestOPBuilder(tt.client)
 			node := yamlNode(t, tt.input)
-			result, err := r.Resolve(context.Background(), node)
-			if tt.errAt == "resolve" {
+			result, err := r.Build(node)
+			if tt.errAt == "build" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMsg)
 				return
 			}
 			require.NoError(t, err)
-			_, err = result.GetValue(context.Background())
+			_, err = result.Get(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})

--- a/internal/transform/secrets/op_resolver_test.go
+++ b/internal/transform/secrets/op_resolver_test.go
@@ -51,11 +51,11 @@ func TestOPResolver_HappyPath_DefaultTokenEnv(t *testing.T) {
 	result, err := r.Resolve(context.Background(), node)
 	require.NoError(t, err)
 	require.Equal(t, "op://Engineering/OpenAI/credential", result.Name)
-	require.Equal(t, "OP_SERVICE_ACCOUNT_TOKEN", gotEnv)
 
 	val, err := result.GetValue(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-secret", val)
+	require.Equal(t, "OP_SERVICE_ACCOUNT_TOKEN", gotEnv)
 }
 
 func TestOPResolver_HappyPath_CustomTokenEnv(t *testing.T) {
@@ -75,11 +75,11 @@ func TestOPResolver_HappyPath_CustomTokenEnv(t *testing.T) {
 	})
 	result, err := r.Resolve(context.Background(), node)
 	require.NoError(t, err)
-	require.Equal(t, "CUSTOM_OP_TOKEN", gotEnv)
 
 	val, err := result.GetValue(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "custom-token-secret", val)
+	require.Equal(t, "CUSTOM_OP_TOKEN", gotEnv)
 }
 
 func TestOPResolver_TTLReturnsCachedValue(t *testing.T) {
@@ -108,7 +108,9 @@ func TestOPResolver_PassesSecretRefToClient(t *testing.T) {
 		"type":       "1password",
 		"secret_ref": "op://vault/item/section/field",
 	})
-	_, err := r.Resolve(context.Background(), node)
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	_, err = result.GetValue(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "op://vault/item/section/field", gotRef)
 }
@@ -119,43 +121,56 @@ func TestOPResolver_Errors(t *testing.T) {
 		client *mockOPClient
 		input  map[string]string
 		errMsg string
+		errAt  string
 	}{
 		{
 			name:   "missing secret_ref",
 			client: staticOPClient("", nil),
 			input:  map[string]string{"type": "1password"},
 			errMsg: "\"secret_ref\" field",
+			errAt:  "resolve",
 		},
 		{
 			name:   "secret_ref without op:// prefix",
 			client: staticOPClient("", nil),
 			input:  map[string]string{"type": "1password", "secret_ref": "vault/item/field"},
 			errMsg: "must start with \"op://\"",
-		},
-		{
-			name:   "sdk error",
-			client: staticOPClient("", fmt.Errorf("vault not found")),
-			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
-			errMsg: "vault not found",
-		},
-		{
-			name:   "empty secret value",
-			client: staticOPClient("", nil),
-			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
-			errMsg: "empty value",
+			errAt:  "resolve",
 		},
 		{
 			name:   "invalid ttl",
 			client: staticOPClient("v", nil),
 			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f", "ttl": "not-a-duration"},
 			errMsg: "parsing ttl",
+			errAt:  "resolve",
+		},
+		{
+			name:   "sdk error",
+			client: staticOPClient("", fmt.Errorf("vault not found")),
+			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
+			errMsg: "vault not found",
+			errAt:  "fetch",
+		},
+		{
+			name:   "empty secret value",
+			client: staticOPClient("", nil),
+			input:  map[string]string{"type": "1password", "secret_ref": "op://v/i/f"},
+			errMsg: "empty value",
+			errAt:  "fetch",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestOPResolver(tt.client)
 			node := yamlNode(t, tt.input)
-			_, err := r.Resolve(context.Background(), node)
+			result, err := r.Resolve(context.Background(), node)
+			if tt.errAt == "resolve" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			_, err = result.GetValue(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -16,28 +16,27 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// secretResolver resolves a real secret value from a source configuration.
-// Each implementation defines and decodes its own config from the raw YAML node.
-type secretResolver interface {
-	// Resolve validates the source config and returns a deferred GetValue
-	// that performs the network fetch lazily on first call. Resolve must
-	// not perform I/O.
-	Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error)
+// secretSource is a prepared secret. Get fetches the current value, possibly
+// from a cache; Name returns a stable display name for logging.
+type secretSource interface {
+	Name() string
+	Get(ctx context.Context) (string, error)
 }
 
-// ResolveResult holds the resolved secret and a function to get its current value.
-type ResolveResult struct {
-	Name     string                                    // display name for logging
-	GetValue func(ctx context.Context) (string, error) // returns the current secret value
+// secretSourceBuilder validates source config and returns a secretSource that
+// fetches lazily on first Get. Build must not perform I/O — only static
+// config validation.
+type secretSourceBuilder interface {
+	Build(raw yaml.Node) (secretSource, error)
 }
 
-// sourceTypeHint is used to peek at the type field before dispatching to a resolver.
+// sourceTypeHint is used to peek at the type field before dispatching to a builder.
 type sourceTypeHint struct {
 	Type string `yaml:"type"`
 }
 
-// resolverRegistry maps source type names to their resolvers.
-type resolverRegistry map[string]secretResolver
+// sourceBuilderRegistry maps source type names to their builders.
+type sourceBuilderRegistry map[string]secretSourceBuilder
 
 const defaultFailureTTL = time.Minute
 
@@ -48,8 +47,8 @@ func parseTTL(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
 }
 
-func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slog.Logger, fetch func(context.Context) (string, error)) func(context.Context) (string, error) {
-	cv := &cachedValue{
+func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slog.Logger, fetch func(context.Context) (string, error)) *cachedValue {
+	return &cachedValue{
 		name:       name,
 		logger:     logger,
 		fetch:      fetch,
@@ -57,35 +56,31 @@ func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slo
 		failureTTL: failureTTL,
 		now:        time.Now,
 	}
-	return cv.get
 }
 
-// buildLazyResult parses the TTL strings and returns a ResolveResult whose
-// GetValue lazily invokes fetch. successTTL of 0 (empty ttlStr) caches the
-// value forever after first success. An empty failureTTLStr defaults to
+// buildLazySource parses the TTL strings and returns a secretSource that
+// lazily invokes fetch. successTTL of 0 (empty ttlStr) caches the value
+// forever after first success. An empty failureTTLStr defaults to
 // defaultFailureTTL.
-func buildLazyResult(name, ttlStr, failureTTLStr string, logger *slog.Logger, fetch func(context.Context) (string, error)) (ResolveResult, error) {
+func buildLazySource(name, ttlStr, failureTTLStr string, logger *slog.Logger, fetch func(context.Context) (string, error)) (secretSource, error) {
 	successTTL, err := parseTTL(ttlStr)
 	if err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", ttlStr, err)
+		return nil, fmt.Errorf("parsing ttl %q: %w", ttlStr, err)
 	}
 	failureTTL, err := parseTTL(failureTTLStr)
 	if err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing failure_ttl %q: %w", failureTTLStr, err)
+		return nil, fmt.Errorf("parsing failure_ttl %q: %w", failureTTLStr, err)
 	}
 	if failureTTL == 0 {
 		failureTTL = defaultFailureTTL
 	}
-	return ResolveResult{
-		Name:     name,
-		GetValue: newLazyValue(name, successTTL, failureTTL, logger, fetch),
-	}, nil
+	return newLazyValue(name, successTTL, failureTTL, logger, fetch), nil
 }
 
-// --- env resolver ---
+// --- env builder ---
 
-// envResolver reads secrets from environment variables.
-type envResolver struct {
+// envBuilder reads secrets from environment variables.
+type envBuilder struct {
 	getenv func(string) string
 	logger *slog.Logger
 }
@@ -95,19 +90,19 @@ type envConfig struct {
 	Var  string `yaml:"var"`
 }
 
-func newEnvResolver(logger *slog.Logger) *envResolver {
-	return &envResolver{getenv: os.Getenv, logger: logger}
+func newEnvBuilder(logger *slog.Logger) *envBuilder {
+	return &envBuilder{getenv: os.Getenv, logger: logger}
 }
 
-func (r *envResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *envBuilder) Build(raw yaml.Node) (secretSource, error) {
 	var cfg envConfig
 	if err := raw.Decode(&cfg); err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing env source config: %w", err)
+		return nil, fmt.Errorf("parsing env source config: %w", err)
 	}
 	if cfg.Var == "" {
-		return ResolveResult{}, fmt.Errorf("env source requires \"var\" field")
+		return nil, fmt.Errorf("env source requires \"var\" field")
 	}
-	return buildLazyResult(cfg.Var, "", "", r.logger, func(context.Context) (string, error) {
+	return buildLazySource(cfg.Var, "", "", r.logger, func(context.Context) (string, error) {
 		v := r.getenv(cfg.Var)
 		if v == "" {
 			return "", fmt.Errorf("env var %q is not set or empty", cfg.Var)
@@ -145,15 +140,15 @@ func (c *awsClientCache[C]) get(ctx context.Context, region string) (C, error) {
 	return client, nil
 }
 
-// --- AWS Secrets Manager resolver ---
+// --- AWS Secrets Manager builder ---
 
-// smClient is the subset of the AWS Secrets Manager API used by awsSMResolver.
+// smClient is the subset of the AWS Secrets Manager API used by awsSMBuilder.
 type smClient interface {
 	GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 }
 
-// awsSMResolver reads secrets from AWS Secrets Manager.
-type awsSMResolver struct {
+// awsSMBuilder reads secrets from AWS Secrets Manager.
+type awsSMBuilder struct {
 	clientFor func(ctx context.Context, region string) (smClient, error)
 	logger    *slog.Logger
 }
@@ -167,28 +162,28 @@ type awsSMConfig struct {
 	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
-func newAWSSMResolver(logger *slog.Logger) *awsSMResolver {
+func newAWSSMBuilder(logger *slog.Logger) *awsSMBuilder {
 	cache := &awsClientCache[smClient]{
 		clients:   make(map[string]smClient),
 		newClient: func(cfg aws.Config) smClient { return secretsmanager.NewFromConfig(cfg) },
 	}
-	return &awsSMResolver{clientFor: cache.get, logger: logger}
+	return &awsSMBuilder{clientFor: cache.get, logger: logger}
 }
 
-func (r *awsSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *awsSMBuilder) Build(raw yaml.Node) (secretSource, error) {
 	var cfg awsSMConfig
 	if err := raw.Decode(&cfg); err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing aws_sm source config: %w", err)
+		return nil, fmt.Errorf("parsing aws_sm source config: %w", err)
 	}
 	if cfg.SecretID == "" {
-		return ResolveResult{}, fmt.Errorf("aws_sm source requires \"secret_id\" field")
+		return nil, fmt.Errorf("aws_sm source requires \"secret_id\" field")
 	}
-	return buildLazyResult(cfg.SecretID, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
+	return buildLazySource(cfg.SecretID, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
 	})
 }
 
-func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
+func (r *awsSMBuilder) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
 	client, err := r.clientFor(ctx, cfg.Region)
 	if err != nil {
 		return "", fmt.Errorf("creating AWS SM client: %w", err)
@@ -212,15 +207,15 @@ func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (strin
 	return val, nil
 }
 
-// --- AWS Systems Manager Parameter Store resolver ---
+// --- AWS Systems Manager Parameter Store builder ---
 
-// ssmClient is the subset of the AWS SSM API used by awsSSMResolver.
+// ssmClient is the subset of the AWS SSM API used by awsSSMBuilder.
 type ssmClient interface {
 	GetParameter(ctx context.Context, input *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
 }
 
-// awsSSMResolver reads secrets from AWS Systems Manager Parameter Store.
-type awsSSMResolver struct {
+// awsSSMBuilder reads secrets from AWS Systems Manager Parameter Store.
+type awsSSMBuilder struct {
 	clientFor func(ctx context.Context, region string) (ssmClient, error)
 	logger    *slog.Logger
 }
@@ -239,28 +234,28 @@ func (cfg awsSSMConfig) decryptValue() bool {
 	return cfg.WithDecryption == nil || *cfg.WithDecryption
 }
 
-func newAWSSSMResolver(logger *slog.Logger) *awsSSMResolver {
+func newAWSSSMBuilder(logger *slog.Logger) *awsSSMBuilder {
 	cache := &awsClientCache[ssmClient]{
 		clients:   make(map[string]ssmClient),
 		newClient: func(cfg aws.Config) ssmClient { return ssm.NewFromConfig(cfg) },
 	}
-	return &awsSSMResolver{clientFor: cache.get, logger: logger}
+	return &awsSSMBuilder{clientFor: cache.get, logger: logger}
 }
 
-func (r *awsSSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *awsSSMBuilder) Build(raw yaml.Node) (secretSource, error) {
 	var cfg awsSSMConfig
 	if err := raw.Decode(&cfg); err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing aws_ssm source config: %w", err)
+		return nil, fmt.Errorf("parsing aws_ssm source config: %w", err)
 	}
 	if cfg.Name == "" {
-		return ResolveResult{}, fmt.Errorf("aws_ssm source requires \"name\" field")
+		return nil, fmt.Errorf("aws_ssm source requires \"name\" field")
 	}
-	return buildLazyResult(cfg.Name, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
+	return buildLazySource(cfg.Name, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchParameter(ctx, cfg)
 	})
 }
 
-func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (string, error) {
+func (r *awsSSMBuilder) fetchParameter(ctx context.Context, cfg awsSSMConfig) (string, error) {
 	client, err := r.clientFor(ctx, cfg.Region)
 	if err != nil {
 		return "", fmt.Errorf("creating AWS SSM client: %w", err)
@@ -310,7 +305,9 @@ type cachedValue struct {
 	expiresAt   time.Time
 }
 
-func (cv *cachedValue) get(ctx context.Context) (string, error) {
+func (cv *cachedValue) Name() string { return cv.name }
+
+func (cv *cachedValue) Get(ctx context.Context) (string, error) {
 	cv.mu.Lock()
 	defer cv.mu.Unlock()
 

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -19,9 +19,9 @@ import (
 // secretResolver resolves a real secret value from a source configuration.
 // Each implementation defines and decodes its own config from the raw YAML node.
 type secretResolver interface {
-	// Resolve validates the source config and fetches the initial secret value.
-	// The returned ResolveResult includes a GetValue function that may lazily
-	// refresh the value (e.g., for sources with a TTL).
+	// Resolve validates the source config and returns a deferred GetValue
+	// that performs the network fetch lazily on first call. Resolve itself
+	// performs no I/O — only static config validation.
 	Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error)
 }
 
@@ -39,11 +39,51 @@ type sourceTypeHint struct {
 // resolverRegistry maps source type names to their resolvers.
 type resolverRegistry map[string]secretResolver
 
+// defaultFailureTTL is the duration to cache an initial-fetch error when the
+// source has no TTL configured. Picked to balance recovery latency against
+// hammering a struggling backend.
+const defaultFailureTTL = 30 * time.Second
+
+// parseTTL parses a duration string. Empty string means "no TTL configured."
+func parseTTL(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	return time.ParseDuration(s)
+}
+
+// failureTTL returns the duration to cache an initial-fetch error. If the
+// source has a successTTL configured, reuse it; otherwise fall back to a
+// 30s default.
+func failureTTL(successTTL time.Duration) time.Duration {
+	if successTTL > 0 {
+		return successTTL
+	}
+	return defaultFailureTTL
+}
+
+// newLazyValue returns a GetValue closure backed by cachedValue. successTTL
+// of 0 means "cache forever once successfully fetched" (matches the static
+// behavior of sources like env). failureTTL controls how long an initial-
+// fetch error is cached before retrying.
+func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slog.Logger, fetch func(context.Context) (string, error)) func(context.Context) (string, error) {
+	cv := &cachedValue{
+		name:       name,
+		logger:     logger,
+		fetch:      fetch,
+		successTTL: successTTL,
+		failureTTL: failureTTL,
+		now:        time.Now,
+	}
+	return cv.get
+}
+
 // --- env resolver ---
 
 // envResolver reads secrets from environment variables.
 type envResolver struct {
 	getenv func(string) string
+	logger *slog.Logger
 }
 
 type envConfig struct {
@@ -51,8 +91,8 @@ type envConfig struct {
 	Var  string `yaml:"var"`
 }
 
-func newEnvResolver() *envResolver {
-	return &envResolver{getenv: os.Getenv}
+func newEnvResolver(logger *slog.Logger) *envResolver {
+	return &envResolver{getenv: os.Getenv, logger: logger}
 }
 
 func (r *envResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
@@ -63,19 +103,17 @@ func (r *envResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, 
 	if cfg.Var == "" {
 		return ResolveResult{}, fmt.Errorf("env source requires \"var\" field")
 	}
-	val := r.getenv(cfg.Var)
-	if val == "" {
-		return ResolveResult{}, fmt.Errorf("env var %q is not set or empty", cfg.Var)
+	fetch := func(context.Context) (string, error) {
+		v := r.getenv(cfg.Var)
+		if v == "" {
+			return "", fmt.Errorf("env var %q is not set or empty", cfg.Var)
+		}
+		return v, nil
 	}
 	return ResolveResult{
 		Name:     cfg.Var,
-		GetValue: staticValue(val),
+		GetValue: newLazyValue(cfg.Var, 0, defaultFailureTTL, r.logger, fetch),
 	}, nil
-}
-
-// staticValue returns a GetValue function that always returns the same value.
-func staticValue(val string) func(context.Context) (string, error) {
-	return func(context.Context) (string, error) { return val, nil }
 }
 
 // --- shared AWS client cache ---
@@ -107,35 +145,6 @@ func (c *awsClientCache[C]) get(ctx context.Context, region string) (C, error) {
 	return client, nil
 }
 
-// resolveWithTTL builds a ResolveResult with optional TTL-based caching.
-func resolveWithTTL(name, initialValue, ttlStr string, logger *slog.Logger, refresh func(context.Context) (string, error)) (ResolveResult, error) {
-	var ttl time.Duration
-	if ttlStr != "" {
-		var err error
-		ttl, err = time.ParseDuration(ttlStr)
-		if err != nil {
-			return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", ttlStr, err)
-		}
-	}
-
-	var getValue func(context.Context) (string, error)
-	if ttl > 0 {
-		cv := &cachedValue{
-			value:     initialValue,
-			expiresAt: time.Now().Add(ttl),
-			ttl:       ttl,
-			logger:    logger,
-			name:      name,
-			refresh:   refresh,
-		}
-		getValue = cv.get
-	} else {
-		getValue = staticValue(initialValue)
-	}
-
-	return ResolveResult{Name: name, GetValue: getValue}, nil
-}
-
 // --- AWS Secrets Manager resolver ---
 
 // smClient is the subset of the AWS Secrets Manager API used by awsSMResolver.
@@ -165,7 +174,7 @@ func newAWSSMResolver(logger *slog.Logger) *awsSMResolver {
 	return &awsSMResolver{clientFor: cache.get, logger: logger}
 }
 
-func (r *awsSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *awsSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
 	var cfg awsSMConfig
 	if err := raw.Decode(&cfg); err != nil {
 		return ResolveResult{}, fmt.Errorf("parsing aws_sm source config: %w", err)
@@ -173,15 +182,17 @@ func (r *awsSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResu
 	if cfg.SecretID == "" {
 		return ResolveResult{}, fmt.Errorf("aws_sm source requires \"secret_id\" field")
 	}
-
-	val, err := r.fetchSecret(ctx, cfg)
+	successTTL, err := parseTTL(cfg.TTL)
 	if err != nil {
-		return ResolveResult{}, err
+		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
 	}
-
-	return resolveWithTTL(cfg.SecretID, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+	fetch := func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
-	})
+	}
+	return ResolveResult{
+		Name:     cfg.SecretID,
+		GetValue: newLazyValue(cfg.SecretID, successTTL, failureTTL(successTTL), r.logger, fetch),
+	}, nil
 }
 
 func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
@@ -242,7 +253,7 @@ func newAWSSSMResolver(logger *slog.Logger) *awsSSMResolver {
 	return &awsSSMResolver{clientFor: cache.get, logger: logger}
 }
 
-func (r *awsSSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error) {
+func (r *awsSSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
 	var cfg awsSSMConfig
 	if err := raw.Decode(&cfg); err != nil {
 		return ResolveResult{}, fmt.Errorf("parsing aws_ssm source config: %w", err)
@@ -250,15 +261,17 @@ func (r *awsSSMResolver) Resolve(ctx context.Context, raw yaml.Node) (ResolveRes
 	if cfg.Name == "" {
 		return ResolveResult{}, fmt.Errorf("aws_ssm source requires \"name\" field")
 	}
-
-	val, err := r.fetchParameter(ctx, cfg)
+	successTTL, err := parseTTL(cfg.TTL)
 	if err != nil {
-		return ResolveResult{}, err
+		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
 	}
-
-	return resolveWithTTL(cfg.Name, val, cfg.TTL, r.logger, func(ctx context.Context) (string, error) {
+	fetch := func(ctx context.Context) (string, error) {
 		return r.fetchParameter(ctx, cfg)
-	})
+	}
+	return ResolveResult{
+		Name:     cfg.Name,
+		GetValue: newLazyValue(cfg.Name, successTTL, failureTTL(successTTL), r.logger, fetch),
+	}, nil
 }
 
 func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (string, error) {
@@ -289,42 +302,71 @@ func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (
 	return val, nil
 }
 
-// --- cached value (lazy TTL refresh) ---
+// --- cached value (lazy fetch + TTL refresh + initial-failure caching) ---
 
-// cachedValue wraps a secret value with lazy TTL-based refresh. When get() is
-// called and the value has expired, it re-fetches inline. On refresh failure,
-// the stale value is returned and the error is logged.
+// cachedValue wraps a fetch function with TTL-based caching for both success
+// and initial-failure outcomes. The first call to get() triggers the fetch.
+// On success, the value is cached for successTTL (or forever if successTTL
+// is 0). On failure before any successful fetch, the error is cached for
+// failureTTL so a struggling backend isn't hammered. After a successful fetch,
+// later refresh failures serve the stale value (existing behavior preserved).
 type cachedValue struct {
-	mu        sync.Mutex
-	value     string
-	expiresAt time.Time
-	ttl       time.Duration
-	logger    *slog.Logger
-	name      string
-	refresh   func(ctx context.Context) (string, error)
+	mu         sync.Mutex
+	name       string
+	logger     *slog.Logger
+	fetch      func(ctx context.Context) (string, error)
+	successTTL time.Duration
+	failureTTL time.Duration
+	now        func() time.Time
+
+	initialized bool
+	value       string
+	lastErr     error
+	expiresAt   time.Time
 }
 
 func (cv *cachedValue) get(ctx context.Context) (string, error) {
 	cv.mu.Lock()
 	defer cv.mu.Unlock()
 
-	if time.Now().Before(cv.expiresAt) {
-		return cv.value, nil
+	if cv.initialized {
+		if cv.successTTL == 0 || cv.now().Before(cv.expiresAt) {
+			return cv.value, nil
+		}
+		// successTTL > 0 and expired: fall through to refresh.
+	} else if cv.now().Before(cv.expiresAt) {
+		return "", cv.lastErr
 	}
 
-	val, err := cv.refresh(ctx)
+	val, err := cv.fetch(ctx)
 	if err != nil {
-		cv.logger.Warn("failed to refresh secret, serving stale value",
-			"secret", cv.name,
-			"error", err,
-		)
-		// Retry again after half the TTL to avoid hammering on every request.
-		cv.expiresAt = time.Now().Add(cv.ttl / 2)
-		return cv.value, nil
+		if cv.initialized {
+			cv.expiresAt = cv.now().Add(cv.successTTL / 2)
+			if cv.logger != nil {
+				cv.logger.Warn("failed to refresh secret, serving stale value",
+					"secret", cv.name,
+					"error", err,
+				)
+			}
+			return cv.value, nil
+		}
+		cv.lastErr = err
+		cv.expiresAt = cv.now().Add(cv.failureTTL)
+		if cv.logger != nil {
+			cv.logger.Warn("failed to fetch secret, caching error",
+				"secret", cv.name,
+				"error", err,
+				"retry_in", cv.failureTTL,
+			)
+		}
+		return "", err
 	}
-
 	cv.value = val
-	cv.expiresAt = time.Now().Add(cv.ttl)
+	cv.initialized = true
+	cv.lastErr = nil
+	if cv.successTTL > 0 {
+		cv.expiresAt = cv.now().Add(cv.successTTL)
+	}
 	return cv.value, nil
 }
 

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -38,7 +38,10 @@ type sourceTypeHint struct {
 // sourceBuilderRegistry maps source type names to their builders.
 type sourceBuilderRegistry map[string]secretSourceBuilder
 
-const defaultFailureTTL = time.Minute
+const (
+	defaultFailureTTL = time.Minute
+	fetchTimeout      = 30 * time.Second
+)
 
 func parseTTL(s string) (time.Duration, error) {
 	if s == "" {
@@ -319,7 +322,11 @@ func (cv *cachedValue) Get(ctx context.Context) (string, error) {
 		return "", cv.lastErr
 	}
 
-	val, err := cv.fetch(ctx)
+	// Detach from the caller's context so a single client cancellation can't
+	// poison the failure cache for unrelated requests.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), fetchTimeout)
+	defer cancel()
+	val, err := cv.fetch(fetchCtx)
 	if err != nil {
 		if cv.initialized {
 			cv.expiresAt = cv.now().Add(cv.successTTL / 2)

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -20,8 +20,8 @@ import (
 // Each implementation defines and decodes its own config from the raw YAML node.
 type secretResolver interface {
 	// Resolve validates the source config and returns a deferred GetValue
-	// that performs the network fetch lazily on first call. Resolve itself
-	// performs no I/O — only static config validation.
+	// that performs the network fetch lazily on first call. Resolve must
+	// not perform I/O.
 	Resolve(ctx context.Context, raw yaml.Node) (ResolveResult, error)
 }
 
@@ -39,12 +39,8 @@ type sourceTypeHint struct {
 // resolverRegistry maps source type names to their resolvers.
 type resolverRegistry map[string]secretResolver
 
-// defaultFailureTTL is the duration to cache an initial-fetch error when the
-// source has no TTL configured. Picked to balance recovery latency against
-// hammering a struggling backend.
-const defaultFailureTTL = 30 * time.Second
+const defaultFailureTTL = time.Minute
 
-// parseTTL parses a duration string. Empty string means "no TTL configured."
 func parseTTL(s string) (time.Duration, error) {
 	if s == "" {
 		return 0, nil
@@ -52,20 +48,6 @@ func parseTTL(s string) (time.Duration, error) {
 	return time.ParseDuration(s)
 }
 
-// failureTTL returns the duration to cache an initial-fetch error. If the
-// source has a successTTL configured, reuse it; otherwise fall back to a
-// 30s default.
-func failureTTL(successTTL time.Duration) time.Duration {
-	if successTTL > 0 {
-		return successTTL
-	}
-	return defaultFailureTTL
-}
-
-// newLazyValue returns a GetValue closure backed by cachedValue. successTTL
-// of 0 means "cache forever once successfully fetched" (matches the static
-// behavior of sources like env). failureTTL controls how long an initial-
-// fetch error is cached before retrying.
 func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slog.Logger, fetch func(context.Context) (string, error)) func(context.Context) (string, error) {
 	cv := &cachedValue{
 		name:       name,
@@ -76,6 +58,28 @@ func newLazyValue(name string, successTTL, failureTTL time.Duration, logger *slo
 		now:        time.Now,
 	}
 	return cv.get
+}
+
+// buildLazyResult parses the TTL strings and returns a ResolveResult whose
+// GetValue lazily invokes fetch. successTTL of 0 (empty ttlStr) caches the
+// value forever after first success. An empty failureTTLStr defaults to
+// defaultFailureTTL.
+func buildLazyResult(name, ttlStr, failureTTLStr string, logger *slog.Logger, fetch func(context.Context) (string, error)) (ResolveResult, error) {
+	successTTL, err := parseTTL(ttlStr)
+	if err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", ttlStr, err)
+	}
+	failureTTL, err := parseTTL(failureTTLStr)
+	if err != nil {
+		return ResolveResult{}, fmt.Errorf("parsing failure_ttl %q: %w", failureTTLStr, err)
+	}
+	if failureTTL == 0 {
+		failureTTL = defaultFailureTTL
+	}
+	return ResolveResult{
+		Name:     name,
+		GetValue: newLazyValue(name, successTTL, failureTTL, logger, fetch),
+	}, nil
 }
 
 // --- env resolver ---
@@ -103,17 +107,13 @@ func (r *envResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, 
 	if cfg.Var == "" {
 		return ResolveResult{}, fmt.Errorf("env source requires \"var\" field")
 	}
-	fetch := func(context.Context) (string, error) {
+	return buildLazyResult(cfg.Var, "", "", r.logger, func(context.Context) (string, error) {
 		v := r.getenv(cfg.Var)
 		if v == "" {
 			return "", fmt.Errorf("env var %q is not set or empty", cfg.Var)
 		}
 		return v, nil
-	}
-	return ResolveResult{
-		Name:     cfg.Var,
-		GetValue: newLazyValue(cfg.Var, 0, defaultFailureTTL, r.logger, fetch),
-	}, nil
+	})
 }
 
 // --- shared AWS client cache ---
@@ -159,11 +159,12 @@ type awsSMResolver struct {
 }
 
 type awsSMConfig struct {
-	Type     string `yaml:"type"`
-	SecretID string `yaml:"secret_id"`
-	Region   string `yaml:"region,omitempty"`
-	JSONKey  string `yaml:"json_key,omitempty"`
-	TTL      string `yaml:"ttl,omitempty"`
+	Type       string `yaml:"type"`
+	SecretID   string `yaml:"secret_id"`
+	Region     string `yaml:"region,omitempty"`
+	JSONKey    string `yaml:"json_key,omitempty"`
+	TTL        string `yaml:"ttl,omitempty"`
+	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
 func newAWSSMResolver(logger *slog.Logger) *awsSMResolver {
@@ -182,17 +183,9 @@ func (r *awsSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult
 	if cfg.SecretID == "" {
 		return ResolveResult{}, fmt.Errorf("aws_sm source requires \"secret_id\" field")
 	}
-	successTTL, err := parseTTL(cfg.TTL)
-	if err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
-	}
-	fetch := func(ctx context.Context) (string, error) {
+	return buildLazyResult(cfg.SecretID, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
-	}
-	return ResolveResult{
-		Name:     cfg.SecretID,
-		GetValue: newLazyValue(cfg.SecretID, successTTL, failureTTL(successTTL), r.logger, fetch),
-	}, nil
+	})
 }
 
 func (r *awsSMResolver) fetchSecret(ctx context.Context, cfg awsSMConfig) (string, error) {
@@ -239,6 +232,7 @@ type awsSSMConfig struct {
 	WithDecryption *bool  `yaml:"with_decryption,omitempty"`
 	JSONKey        string `yaml:"json_key,omitempty"`
 	TTL            string `yaml:"ttl,omitempty"`
+	FailureTTL     string `yaml:"failure_ttl,omitempty"`
 }
 
 func (cfg awsSSMConfig) decryptValue() bool {
@@ -261,17 +255,9 @@ func (r *awsSSMResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResul
 	if cfg.Name == "" {
 		return ResolveResult{}, fmt.Errorf("aws_ssm source requires \"name\" field")
 	}
-	successTTL, err := parseTTL(cfg.TTL)
-	if err != nil {
-		return ResolveResult{}, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
-	}
-	fetch := func(ctx context.Context) (string, error) {
+	return buildLazyResult(cfg.Name, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchParameter(ctx, cfg)
-	}
-	return ResolveResult{
-		Name:     cfg.Name,
-		GetValue: newLazyValue(cfg.Name, successTTL, failureTTL(successTTL), r.logger, fetch),
-	}, nil
+	})
 }
 
 func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (string, error) {
@@ -304,12 +290,11 @@ func (r *awsSSMResolver) fetchParameter(ctx context.Context, cfg awsSSMConfig) (
 
 // --- cached value (lazy fetch + TTL refresh + initial-failure caching) ---
 
-// cachedValue wraps a fetch function with TTL-based caching for both success
-// and initial-failure outcomes. The first call to get() triggers the fetch.
-// On success, the value is cached for successTTL (or forever if successTTL
-// is 0). On failure before any successful fetch, the error is cached for
-// failureTTL so a struggling backend isn't hammered. After a successful fetch,
-// later refresh failures serve the stale value (existing behavior preserved).
+// cachedValue wraps a fetch function with TTL-based caching. The first get()
+// triggers the fetch. On success, the value is cached for successTTL (forever
+// if successTTL is 0). On failure before any successful fetch, the error is
+// cached for failureTTL so a struggling backend isn't hammered. After a
+// successful fetch, later refresh failures serve the stale value.
 type cachedValue struct {
 	mu         sync.Mutex
 	name       string
@@ -333,7 +318,6 @@ func (cv *cachedValue) get(ctx context.Context) (string, error) {
 		if cv.successTTL == 0 || cv.now().Before(cv.expiresAt) {
 			return cv.value, nil
 		}
-		// successTTL > 0 and expired: fall through to refresh.
 	} else if cv.now().Before(cv.expiresAt) {
 		return "", cv.lastErr
 	}

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -42,8 +42,8 @@ func staticSMClient(out *secretsmanager.GetSecretValueOutput, err error) *mockSM
 	}}
 }
 
-func newTestAWSSMResolver(client smClient) *awsSMResolver {
-	return &awsSMResolver{
+func newTestAWSSMBuilder(client smClient) *awsSMBuilder {
+	return &awsSMBuilder{
 		clientFor: func(_ context.Context, _ string) (smClient, error) {
 			return client, nil
 		},
@@ -67,8 +67,8 @@ func staticSSMClient(out *ssm.GetParameterOutput, err error) *mockSSMClient {
 	}}
 }
 
-func newTestAWSSSMResolver(client ssmClient) *awsSSMResolver {
-	return &awsSSMResolver{
+func newTestAWSSSMBuilder(client ssmClient) *awsSSMBuilder {
+	return &awsSSMBuilder{
 		clientFor: func(_ context.Context, _ string) (ssmClient, error) {
 			return client, nil
 		},
@@ -76,26 +76,26 @@ func newTestAWSSSMResolver(client ssmClient) *awsSSMResolver {
 	}
 }
 
-// --- envResolver tests ---
+// --- envBuilder tests ---
 
-func TestEnvResolver_HappyPath(t *testing.T) {
-	r := &envResolver{getenv: func(key string) string {
+func TestEnvBuilder_HappyPath(t *testing.T) {
+	r := &envBuilder{getenv: func(key string) string {
 		if key == "MY_SECRET" {
 			return "real-value"
 		}
 		return ""
 	}, logger: slog.Default()}
 	node := yamlNode(t, map[string]string{"type": "env", "var": "MY_SECRET"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, "MY_SECRET", result.Name)
+	require.Equal(t, "MY_SECRET", result.Name())
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-value", val)
 }
 
-func TestEnvResolver_Errors(t *testing.T) {
+func TestEnvBuilder_Errors(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  map[string]string
@@ -106,7 +106,7 @@ func TestEnvResolver_Errors(t *testing.T) {
 			name:   "missing var field",
 			input:  map[string]string{"type": "env"},
 			errMsg: "\"var\" field",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "empty value",
@@ -117,79 +117,79 @@ func TestEnvResolver_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &envResolver{getenv: func(string) string { return "" }, logger: slog.Default()}
+			r := &envBuilder{getenv: func(string) string { return "" }, logger: slog.Default()}
 			node := yamlNode(t, tt.input)
-			result, err := r.Resolve(context.Background(), node)
-			if tt.errAt == "resolve" {
+			result, err := r.Build(node)
+			if tt.errAt == "build" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMsg)
 				return
 			}
 			require.NoError(t, err)
-			_, err = result.GetValue(context.Background())
+			_, err = result.Get(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
 }
 
-// --- awsSMResolver tests ---
+// --- awsSMBuilder tests ---
 
-func TestAWSSMResolver_PlainString(t *testing.T) {
+func TestAWSSMBuilder_PlainString(t *testing.T) {
 	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String("my-secret-value"),
 	}, nil)
-	r := newTestAWSSMResolver(client)
+	r := newTestAWSSMBuilder(client)
 	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:aws:sm:us-east-1:123:secret:foo"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, "arn:aws:sm:us-east-1:123:secret:foo", result.Name)
+	require.Equal(t, "arn:aws:sm:us-east-1:123:secret:foo", result.Name())
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "my-secret-value", val)
 }
 
-func TestAWSSMResolver_JSONKey(t *testing.T) {
+func TestAWSSMBuilder_JSONKey(t *testing.T) {
 	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String(`{"api_key": "sk-abc123", "other": "val"}`),
 	}, nil)
-	r := newTestAWSSMResolver(client)
+	r := newTestAWSSMBuilder(client)
 	node := yamlNode(t, map[string]string{
 		"type":      "aws_sm",
 		"secret_id": "arn:aws:sm:us-east-1:123:secret:foo",
 		"json_key":  "api_key",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "sk-abc123", val)
 }
 
-func TestAWSSMResolver_TTLReturnsCachedValue(t *testing.T) {
+func TestAWSSMBuilder_TTLReturnsCachedValue(t *testing.T) {
 	client := staticSMClient(&secretsmanager.GetSecretValueOutput{
 		SecretString: aws.String("value"),
 	}, nil)
-	r := newTestAWSSMResolver(client)
+	r := newTestAWSSMBuilder(client)
 	node := yamlNode(t, map[string]string{
 		"type":      "aws_sm",
 		"secret_id": "arn:aws:sm:us-east-1:123:secret:foo",
 		"ttl":       "15m",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
 	// GetValue should return cached value without re-fetching.
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "value", val)
 }
 
-func TestAWSSMResolver_Errors(t *testing.T) {
-	// errAt: "resolve" for static config errors; "fetch" for network/value errors
-	// that surface lazily on first GetValue call.
+func TestAWSSMBuilder_Errors(t *testing.T) {
+	// errAt: "build" for static config errors; "fetch" for network/value errors
+	// that surface lazily on first Get call.
 	tests := []struct {
 		name   string
 		client *mockSMClient
@@ -202,14 +202,14 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 			client: staticSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_sm"},
 			errMsg: "\"secret_id\" field",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "invalid TTL",
 			client: staticSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "ttl": "not-a-duration"},
 			errMsg: "parsing ttl",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "aws error",
@@ -257,76 +257,76 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newTestAWSSMResolver(tt.client)
+			r := newTestAWSSMBuilder(tt.client)
 			node := yamlNode(t, tt.input)
-			result, err := r.Resolve(context.Background(), node)
-			if tt.errAt == "resolve" {
+			result, err := r.Build(node)
+			if tt.errAt == "build" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMsg)
 				return
 			}
 			require.NoError(t, err)
-			_, err = result.GetValue(context.Background())
+			_, err = result.Get(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
 }
 
-// --- awsSSMResolver tests ---
+// --- awsSSMBuilder tests ---
 
-func TestAWSSSMResolver_PlainString(t *testing.T) {
+func TestAWSSSMBuilder_PlainString(t *testing.T) {
 	client := staticSSMClient(&ssm.GetParameterOutput{
 		Parameter: &ssmtypes.Parameter{Value: aws.String("my-param-value")},
 	}, nil)
-	r := newTestAWSSSMResolver(client)
+	r := newTestAWSSSMBuilder(client)
 	node := yamlNode(t, map[string]string{"type": "aws_ssm", "name": "/myapp/api-key"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, "/myapp/api-key", result.Name)
+	require.Equal(t, "/myapp/api-key", result.Name())
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "my-param-value", val)
 }
 
-func TestAWSSSMResolver_JSONKey(t *testing.T) {
+func TestAWSSSMBuilder_JSONKey(t *testing.T) {
 	client := staticSSMClient(&ssm.GetParameterOutput{
 		Parameter: &ssmtypes.Parameter{Value: aws.String(`{"api_key": "sk-abc123", "other": "val"}`)},
 	}, nil)
-	r := newTestAWSSSMResolver(client)
+	r := newTestAWSSSMBuilder(client)
 	node := yamlNode(t, map[string]string{
 		"type":     "aws_ssm",
 		"name":     "/myapp/config",
 		"json_key": "api_key",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "sk-abc123", val)
 }
 
-func TestAWSSSMResolver_TTLReturnsCachedValue(t *testing.T) {
+func TestAWSSSMBuilder_TTLReturnsCachedValue(t *testing.T) {
 	client := staticSSMClient(&ssm.GetParameterOutput{
 		Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
 	}, nil)
-	r := newTestAWSSSMResolver(client)
+	r := newTestAWSSSMBuilder(client)
 	node := yamlNode(t, map[string]string{
 		"type": "aws_ssm",
 		"name": "/myapp/secret",
 		"ttl":  "15m",
 	})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 
-	val, err := result.GetValue(context.Background())
+	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "value", val)
 }
 
-func TestAWSSSMResolver_WithDecryption(t *testing.T) {
+func TestAWSSSMBuilder_WithDecryption(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  map[string]any
@@ -358,11 +358,11 @@ func TestAWSSSMResolver_WithDecryption(t *testing.T) {
 					Parameter: &ssmtypes.Parameter{Value: aws.String("decrypted-value")},
 				}, nil
 			}}
-			r := newTestAWSSSMResolver(client)
-			result, err := r.Resolve(context.Background(), yamlNode(t, tt.raw))
+			r := newTestAWSSSMBuilder(client)
+			result, err := r.Build(yamlNode(t, tt.raw))
 			require.NoError(t, err)
 
-			val, err := result.GetValue(context.Background())
+			val, err := result.Get(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, "decrypted-value", val)
 			require.Equal(t, tt.want, aws.ToBool(capturedInput.WithDecryption))
@@ -370,12 +370,12 @@ func TestAWSSSMResolver_WithDecryption(t *testing.T) {
 	}
 }
 
-func TestAWSSSMResolver_Region(t *testing.T) {
+func TestAWSSSMBuilder_Region(t *testing.T) {
 	client := staticSSMClient(&ssm.GetParameterOutput{
 		Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
 	}, nil)
 	var gotRegion string
-	r := &awsSSMResolver{
+	r := &awsSSMBuilder{
 		clientFor: func(_ context.Context, region string) (ssmClient, error) {
 			gotRegion = region
 			return client, nil
@@ -383,18 +383,18 @@ func TestAWSSSMResolver_Region(t *testing.T) {
 		logger: slog.Default(),
 	}
 
-	result, err := r.Resolve(context.Background(), yamlNode(t, map[string]string{
+	result, err := r.Build(yamlNode(t, map[string]string{
 		"type":   "aws_ssm",
 		"name":   "/myapp/secret",
 		"region": "us-east-1",
 	}))
 	require.NoError(t, err)
-	_, err = result.GetValue(context.Background())
+	_, err = result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "us-east-1", gotRegion)
 }
 
-func TestAWSSSMResolver_Errors(t *testing.T) {
+func TestAWSSSMBuilder_Errors(t *testing.T) {
 	tests := []struct {
 		name   string
 		client *mockSSMClient
@@ -407,14 +407,14 @@ func TestAWSSSMResolver_Errors(t *testing.T) {
 			client: staticSSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_ssm"},
 			errMsg: "\"name\" field",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "invalid TTL",
 			client: staticSSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "ttl": "not-a-duration"},
 			errMsg: "parsing ttl",
-			errAt:  "resolve",
+			errAt:  "build",
 		},
 		{
 			name:   "aws error",
@@ -458,16 +458,16 @@ func TestAWSSSMResolver_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := newTestAWSSSMResolver(tt.client)
+			r := newTestAWSSSMBuilder(tt.client)
 			node := yamlNode(t, tt.input)
-			result, err := r.Resolve(context.Background(), node)
-			if tt.errAt == "resolve" {
+			result, err := r.Build(node)
+			if tt.errAt == "build" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.errMsg)
 				return
 			}
 			require.NoError(t, err)
-			_, err = result.GetValue(context.Background())
+			_, err = result.Get(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -542,7 +542,7 @@ func TestCachedValue_ServesStaleOnError(t *testing.T) {
 		expiresAt:   time.Now().Add(-time.Hour), // already expired
 	}
 
-	val, err := cv.get(context.Background())
+	val, err := cv.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "initial", val)
 	require.Equal(t, 1, calls)
@@ -560,13 +560,13 @@ func TestCachedValue_LazyInitFetchOnFirstGet(t *testing.T) {
 			return "value", nil
 		},
 	}
-	val, err := cv.get(context.Background())
+	val, err := cv.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "value", val)
 	require.Equal(t, 1, calls)
 
 	// Second get within successTTL: cached, no fetch.
-	val, err = cv.get(context.Background())
+	val, err = cv.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "value", val)
 	require.Equal(t, 1, calls)
@@ -586,18 +586,18 @@ func TestCachedValue_FailureCachedForTTL(t *testing.T) {
 		},
 	}
 
-	_, err := cv.get(context.Background())
+	_, err := cv.Get(context.Background())
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
 
 	// Within failureTTL: cached error returned, no fetch.
-	_, err = cv.get(context.Background())
+	_, err = cv.Get(context.Background())
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
 
 	// Advance past failureTTL: fetch retried.
 	now = now.Add(31 * time.Second)
-	_, err = cv.get(context.Background())
+	_, err = cv.Get(context.Background())
 	require.Error(t, err)
 	require.Equal(t, 2, calls)
 }
@@ -619,17 +619,17 @@ func TestCachedValue_FailureRecovers(t *testing.T) {
 		},
 	}
 
-	_, err := cv.get(context.Background())
+	_, err := cv.Get(context.Background())
 	require.Error(t, err)
 
 	// Advance past failureTTL.
 	now = now.Add(31 * time.Second)
-	val, err := cv.get(context.Background())
+	val, err := cv.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-value", val)
 
 	// Subsequent gets: cached, no further fetches.
-	val, err = cv.get(context.Background())
+	val, err = cv.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-value", val)
 	require.Equal(t, 2, calls)
@@ -648,7 +648,7 @@ func TestCachedValue_ZeroSuccessTTLCachesForever(t *testing.T) {
 		},
 	}
 	for range 5 {
-		val, err := cv.get(context.Background())
+		val, err := cv.Get(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, "value", val)
 	}
@@ -668,16 +668,16 @@ func TestParseTTL(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestBuildLazyResult_FailureTTLDefaults(t *testing.T) {
+func TestBuildLazySource_FailureTTLDefaults(t *testing.T) {
 	// Empty failure_ttl falls back to defaultFailureTTL regardless of success TTL.
-	result, err := buildLazyResult("name", "1h", "", slog.Default(), func(context.Context) (string, error) {
+	result, err := buildLazySource("name", "1h", "", slog.Default(), func(context.Context) (string, error) {
 		return "v", nil
 	})
 	require.NoError(t, err)
-	require.NotNil(t, result.GetValue)
+	require.NotNil(t, result)
 }
 
-func TestBuildLazyResult_FailureTTLOverride(t *testing.T) {
+func TestBuildLazySource_FailureTTLOverride(t *testing.T) {
 	now := time.Now()
 	calls := 0
 	successTTL, err := parseTTL("1h")
@@ -694,78 +694,78 @@ func TestBuildLazyResult_FailureTTLOverride(t *testing.T) {
 			return "", fmt.Errorf("boom")
 		},
 	}
-	_, err = cv.get(context.Background())
+	_, err = cv.Get(context.Background())
 	require.Error(t, err)
 
 	// Within 5s the error is cached.
 	now = now.Add(4 * time.Second)
-	_, err = cv.get(context.Background())
+	_, err = cv.Get(context.Background())
 	require.Error(t, err)
 	require.Equal(t, 1, calls)
 
 	// After 5s, retry — even though successTTL is 1h.
 	now = now.Add(2 * time.Second)
-	_, err = cv.get(context.Background())
+	_, err = cv.Get(context.Background())
 	require.Error(t, err)
 	require.Equal(t, 2, calls)
 }
 
-func TestBuildLazyResult_InvalidFailureTTL(t *testing.T) {
-	_, err := buildLazyResult("name", "", "not-a-duration", slog.Default(), func(context.Context) (string, error) {
+func TestBuildLazySource_InvalidFailureTTL(t *testing.T) {
+	_, err := buildLazySource("name", "", "not-a-duration", slog.Default(), func(context.Context) (string, error) {
 		return "v", nil
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failure_ttl")
 }
 
-// Lazy-init tests: each resolver's Resolve should not call the underlying client.
+// Lazy-init tests: each builder's Build should not call the underlying client.
 
-func TestAWSSMResolver_ResolveDoesNotFetch(t *testing.T) {
+func TestAWSSMBuilder_BuildDoesNotFetch(t *testing.T) {
 	calls := 0
 	client := &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 		calls++
 		return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("v")}, nil
 	}}
-	r := newTestAWSSMResolver(client)
+	r := newTestAWSSMBuilder(client)
 	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, 0, calls, "Resolve must not call AWS")
+	require.Equal(t, 0, calls, "Build must not call AWS")
 
-	_, err = result.GetValue(context.Background())
+	_, err = result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, calls, "first GetValue triggers fetch")
 }
 
-func TestAWSSSMResolver_ResolveDoesNotFetch(t *testing.T) {
+func TestAWSSSMBuilder_BuildDoesNotFetch(t *testing.T) {
 	calls := 0
 	client := &mockSSMClient{fn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 		calls++
 		return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String("v")}}, nil
 	}}
-	r := newTestAWSSSMResolver(client)
+	r := newTestAWSSSMBuilder(client)
 	node := yamlNode(t, map[string]string{"type": "aws_ssm", "name": "/p"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
 	require.Equal(t, 0, calls)
 
-	_, err = result.GetValue(context.Background())
+	_, err = result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 }
 
-func TestEnvResolver_ResolveDoesNotReadEnv(t *testing.T) {
+func TestEnvBuilder_BuildDoesNotReadEnv(t *testing.T) {
 	calls := 0
-	r := &envResolver{getenv: func(_ string) string {
+	r := &envBuilder{getenv: func(_ string) string {
 		calls++
 		return "value"
 	}, logger: slog.Default()}
 	node := yamlNode(t, map[string]string{"type": "env", "var": "FOO"})
-	result, err := r.Resolve(context.Background(), node)
+	result, err := r.Build(node)
 	require.NoError(t, err)
-	require.Equal(t, 0, calls, "Resolve must not call getenv")
+	require.Equal(t, 0, calls, "Build must not call getenv")
 
-	_, err = result.GetValue(context.Background())
+	_, err = result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 }

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
@@ -83,7 +84,7 @@ func TestEnvResolver_HappyPath(t *testing.T) {
 			return "real-value"
 		}
 		return ""
-	}}
+	}, logger: slog.Default()}
 	node := yamlNode(t, map[string]string{"type": "env", "var": "MY_SECRET"})
 	result, err := r.Resolve(context.Background(), node)
 	require.NoError(t, err)
@@ -99,23 +100,33 @@ func TestEnvResolver_Errors(t *testing.T) {
 		name   string
 		input  map[string]string
 		errMsg string
+		errAt  string
 	}{
 		{
 			name:   "missing var field",
 			input:  map[string]string{"type": "env"},
 			errMsg: "\"var\" field",
+			errAt:  "resolve",
 		},
 		{
 			name:   "empty value",
 			input:  map[string]string{"type": "env", "var": "EMPTY_VAR"},
 			errMsg: "not set or empty",
+			errAt:  "fetch",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &envResolver{getenv: func(string) string { return "" }}
+			r := &envResolver{getenv: func(string) string { return "" }, logger: slog.Default()}
 			node := yamlNode(t, tt.input)
-			_, err := r.Resolve(context.Background(), node)
+			result, err := r.Resolve(context.Background(), node)
+			if tt.errAt == "resolve" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			_, err = result.GetValue(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -177,23 +188,35 @@ func TestAWSSMResolver_TTLReturnsCachedValue(t *testing.T) {
 }
 
 func TestAWSSMResolver_Errors(t *testing.T) {
+	// errAt: "resolve" for static config errors; "fetch" for network/value errors
+	// that surface lazily on first GetValue call.
 	tests := []struct {
 		name   string
 		client *mockSMClient
 		input  map[string]string
 		errMsg string
+		errAt  string
 	}{
 		{
 			name:   "missing secret_id",
 			client: staticSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_sm"},
 			errMsg: "\"secret_id\" field",
+			errAt:  "resolve",
+		},
+		{
+			name:   "invalid TTL",
+			client: staticSMClient(nil, nil),
+			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+			errAt:  "resolve",
 		},
 		{
 			name:   "aws error",
 			client: staticSMClient(nil, fmt.Errorf("access denied")),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo"},
 			errMsg: "access denied",
+			errAt:  "fetch",
 		},
 		{
 			name: "empty secret value",
@@ -202,14 +225,7 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo"},
 			errMsg: "empty value",
-		},
-		{
-			name: "invalid TTL",
-			client: staticSMClient(&secretsmanager.GetSecretValueOutput{
-				SecretString: aws.String("value"),
-			}, nil),
-			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "ttl": "not-a-duration"},
-			errMsg: "parsing ttl",
+			errAt:  "fetch",
 		},
 		{
 			name: "json_key with invalid JSON",
@@ -218,6 +234,7 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
 			errMsg: "not valid JSON",
+			errAt:  "fetch",
 		},
 		{
 			name: "json_key not found",
@@ -226,6 +243,7 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
 			errMsg: "not found",
+			errAt:  "fetch",
 		},
 		{
 			name: "json_key non-string value",
@@ -234,13 +252,21 @@ func TestAWSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_sm", "secret_id": "arn:foo", "json_key": "api_key"},
 			errMsg: "not a string",
+			errAt:  "fetch",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestAWSSMResolver(tt.client)
 			node := yamlNode(t, tt.input)
-			_, err := r.Resolve(context.Background(), node)
+			result, err := r.Resolve(context.Background(), node)
+			if tt.errAt == "resolve" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			_, err = result.GetValue(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -335,11 +361,11 @@ func TestAWSSSMResolver_WithDecryption(t *testing.T) {
 			r := newTestAWSSSMResolver(client)
 			result, err := r.Resolve(context.Background(), yamlNode(t, tt.raw))
 			require.NoError(t, err)
-			require.Equal(t, tt.want, aws.ToBool(capturedInput.WithDecryption))
 
 			val, err := result.GetValue(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, "decrypted-value", val)
+			require.Equal(t, tt.want, aws.ToBool(capturedInput.WithDecryption))
 		})
 	}
 }
@@ -357,11 +383,13 @@ func TestAWSSSMResolver_Region(t *testing.T) {
 		logger: slog.Default(),
 	}
 
-	_, err := r.Resolve(context.Background(), yamlNode(t, map[string]string{
+	result, err := r.Resolve(context.Background(), yamlNode(t, map[string]string{
 		"type":   "aws_ssm",
 		"name":   "/myapp/secret",
 		"region": "us-east-1",
 	}))
+	require.NoError(t, err)
+	_, err = result.GetValue(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "us-east-1", gotRegion)
 }
@@ -372,18 +400,28 @@ func TestAWSSSMResolver_Errors(t *testing.T) {
 		client *mockSSMClient
 		input  map[string]string
 		errMsg string
+		errAt  string
 	}{
 		{
 			name:   "missing name",
 			client: staticSSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_ssm"},
 			errMsg: "\"name\" field",
+			errAt:  "resolve",
+		},
+		{
+			name:   "invalid TTL",
+			client: staticSSMClient(nil, nil),
+			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+			errAt:  "resolve",
 		},
 		{
 			name:   "aws error",
 			client: staticSSMClient(nil, fmt.Errorf("parameter not found")),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/missing"},
 			errMsg: "parameter not found",
+			errAt:  "fetch",
 		},
 		{
 			name: "empty parameter value",
@@ -392,26 +430,21 @@ func TestAWSSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/empty"},
 			errMsg: "empty value",
+			errAt:  "fetch",
 		},
 		{
 			name:   "missing parameter",
 			client: staticSSMClient(&ssm.GetParameterOutput{}, nil),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/missing-value"},
 			errMsg: "without a value",
+			errAt:  "fetch",
 		},
 		{
 			name:   "nil response",
 			client: staticSSMClient(nil, nil),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/nil-response"},
 			errMsg: "without a value",
-		},
-		{
-			name: "invalid TTL",
-			client: staticSSMClient(&ssm.GetParameterOutput{
-				Parameter: &ssmtypes.Parameter{Value: aws.String("value")},
-			}, nil),
-			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "ttl": "not-a-duration"},
-			errMsg: "parsing ttl",
+			errAt:  "fetch",
 		},
 		{
 			name: "json_key with invalid JSON",
@@ -420,13 +453,21 @@ func TestAWSSSMResolver_Errors(t *testing.T) {
 			}, nil),
 			input:  map[string]string{"type": "aws_ssm", "name": "/myapp/key", "json_key": "api_key"},
 			errMsg: "not valid JSON",
+			errAt:  "fetch",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestAWSSSMResolver(tt.client)
 			node := yamlNode(t, tt.input)
-			_, err := r.Resolve(context.Background(), node)
+			result, err := r.Resolve(context.Background(), node)
+			if tt.errAt == "resolve" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			_, err = result.GetValue(context.Background())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -487,18 +528,199 @@ func TestExtractJSONKey(t *testing.T) {
 func TestCachedValue_ServesStaleOnError(t *testing.T) {
 	calls := 0
 	cv := &cachedValue{
-		value:  "initial",
-		ttl:    1, // expired immediately
-		logger: slog.Default(),
-		name:   "test",
-		refresh: func(_ context.Context) (string, error) {
+		name:       "test",
+		logger:     slog.Default(),
+		successTTL: time.Millisecond,
+		failureTTL: time.Millisecond,
+		now:        time.Now,
+		fetch: func(_ context.Context) (string, error) {
 			calls++
 			return "", fmt.Errorf("aws error")
 		},
+		initialized: true,
+		value:       "initial",
+		expiresAt:   time.Now().Add(-time.Hour), // already expired
 	}
 
 	val, err := cv.get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "initial", val)
+	require.Equal(t, 1, calls)
+}
+
+func TestCachedValue_LazyInitFetchOnFirstGet(t *testing.T) {
+	calls := 0
+	cv := &cachedValue{
+		name:       "test",
+		successTTL: time.Hour,
+		failureTTL: time.Hour,
+		now:        time.Now,
+		fetch: func(_ context.Context) (string, error) {
+			calls++
+			return "value", nil
+		},
+	}
+	val, err := cv.get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+	require.Equal(t, 1, calls)
+
+	// Second get within successTTL: cached, no fetch.
+	val, err = cv.get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+	require.Equal(t, 1, calls)
+}
+
+func TestCachedValue_FailureCachedForTTL(t *testing.T) {
+	calls := 0
+	now := time.Now()
+	cv := &cachedValue{
+		name:       "test",
+		successTTL: 0,
+		failureTTL: 30 * time.Second,
+		now:        func() time.Time { return now },
+		fetch: func(_ context.Context) (string, error) {
+			calls++
+			return "", fmt.Errorf("backend down")
+		},
+	}
+
+	_, err := cv.get(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+
+	// Within failureTTL: cached error returned, no fetch.
+	_, err = cv.get(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+
+	// Advance past failureTTL: fetch retried.
+	now = now.Add(31 * time.Second)
+	_, err = cv.get(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestCachedValue_FailureRecovers(t *testing.T) {
+	calls := 0
+	now := time.Now()
+	cv := &cachedValue{
+		name:       "test",
+		successTTL: 0, // cache forever after success
+		failureTTL: 30 * time.Second,
+		now:        func() time.Time { return now },
+		fetch: func(_ context.Context) (string, error) {
+			calls++
+			if calls == 1 {
+				return "", fmt.Errorf("transient error")
+			}
+			return "real-value", nil
+		},
+	}
+
+	_, err := cv.get(context.Background())
+	require.Error(t, err)
+
+	// Advance past failureTTL.
+	now = now.Add(31 * time.Second)
+	val, err := cv.get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "real-value", val)
+
+	// Subsequent gets: cached, no further fetches.
+	val, err = cv.get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "real-value", val)
+	require.Equal(t, 2, calls)
+}
+
+func TestCachedValue_ZeroSuccessTTLCachesForever(t *testing.T) {
+	calls := 0
+	cv := &cachedValue{
+		name:       "test",
+		successTTL: 0,
+		failureTTL: time.Second,
+		now:        time.Now,
+		fetch: func(_ context.Context) (string, error) {
+			calls++
+			return "value", nil
+		},
+	}
+	for range 5 {
+		val, err := cv.get(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "value", val)
+	}
+	require.Equal(t, 1, calls)
+}
+
+func TestParseTTL(t *testing.T) {
+	d, err := parseTTL("")
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(0), d)
+
+	d, err = parseTTL("15m")
+	require.NoError(t, err)
+	require.Equal(t, 15*time.Minute, d)
+
+	_, err = parseTTL("not-a-duration")
+	require.Error(t, err)
+}
+
+func TestFailureTTL(t *testing.T) {
+	require.Equal(t, defaultFailureTTL, failureTTL(0))
+	require.Equal(t, 5*time.Minute, failureTTL(5*time.Minute))
+}
+
+// Lazy-init tests: each resolver's Resolve should not call the underlying client.
+
+func TestAWSSMResolver_ResolveDoesNotFetch(t *testing.T) {
+	calls := 0
+	client := &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+		calls++
+		return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("v")}, nil
+	}}
+	r := newTestAWSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_sm", "secret_id": "arn:test"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, 0, calls, "Resolve must not call AWS")
+
+	_, err = result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "first GetValue triggers fetch")
+}
+
+func TestAWSSSMResolver_ResolveDoesNotFetch(t *testing.T) {
+	calls := 0
+	client := &mockSSMClient{fn: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+		calls++
+		return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String("v")}}, nil
+	}}
+	r := newTestAWSSSMResolver(client)
+	node := yamlNode(t, map[string]string{"type": "aws_ssm", "name": "/p"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, 0, calls)
+
+	_, err = result.GetValue(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestEnvResolver_ResolveDoesNotReadEnv(t *testing.T) {
+	calls := 0
+	r := &envResolver{getenv: func(_ string) string {
+		calls++
+		return "value"
+	}, logger: slog.Default()}
+	node := yamlNode(t, map[string]string{"type": "env", "var": "FOO"})
+	result, err := r.Resolve(context.Background(), node)
+	require.NoError(t, err)
+	require.Equal(t, 0, calls, "Resolve must not call getenv")
+
+	_, err = result.GetValue(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 }

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -668,9 +668,54 @@ func TestParseTTL(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFailureTTL(t *testing.T) {
-	require.Equal(t, defaultFailureTTL, failureTTL(0))
-	require.Equal(t, 5*time.Minute, failureTTL(5*time.Minute))
+func TestBuildLazyResult_FailureTTLDefaults(t *testing.T) {
+	// Empty failure_ttl falls back to defaultFailureTTL regardless of success TTL.
+	result, err := buildLazyResult("name", "1h", "", slog.Default(), func(context.Context) (string, error) {
+		return "v", nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result.GetValue)
+}
+
+func TestBuildLazyResult_FailureTTLOverride(t *testing.T) {
+	now := time.Now()
+	calls := 0
+	successTTL, err := parseTTL("1h")
+	require.NoError(t, err)
+	failTTL, err := parseTTL("5s")
+	require.NoError(t, err)
+	cv := &cachedValue{
+		name:       "name",
+		successTTL: successTTL,
+		failureTTL: failTTL,
+		now:        func() time.Time { return now },
+		fetch: func(_ context.Context) (string, error) {
+			calls++
+			return "", fmt.Errorf("boom")
+		},
+	}
+	_, err = cv.get(context.Background())
+	require.Error(t, err)
+
+	// Within 5s the error is cached.
+	now = now.Add(4 * time.Second)
+	_, err = cv.get(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+
+	// After 5s, retry — even though successTTL is 1h.
+	now = now.Add(2 * time.Second)
+	_, err = cv.get(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestBuildLazyResult_InvalidFailureTTL(t *testing.T) {
+	_, err := buildLazyResult("name", "", "not-a-duration", slog.Default(), func(context.Context) (string, error) {
+		return "v", nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failure_ttl")
 }
 
 // Lazy-init tests: each resolver's Resolve should not call the underlying client.

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -635,6 +635,22 @@ func TestCachedValue_FailureRecovers(t *testing.T) {
 	require.Equal(t, 2, calls)
 }
 
+func TestCachedValue_CallerContextCancellationDoesNotPropagate(t *testing.T) {
+	cv := newLazyValue("test", 0, time.Minute, slog.Default(), func(ctx context.Context) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return "value", nil
+	})
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	val, err := cv.Get(cancelled)
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}
+
 func TestCachedValue_ZeroSuccessTTLCachesForever(t *testing.T) {
 	calls := 0
 	cv := &cachedValue{

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -64,10 +63,9 @@ type injectConfig struct {
 
 // resolvedSecret is a secret ready for use after config parsing and source resolution.
 type resolvedSecret struct {
-	name     string // source name, for logging/metrics
-	mode     string // "replace" or "inject"
-	getValue func(ctx context.Context) (string, error)
-	rules    []hostmatch.Rule
+	source secretSource
+	mode   string // "replace" or "inject"
+	rules  []hostmatch.Rule
 
 	// replace mode fields
 	proxyValue   string
@@ -131,19 +129,17 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
-	registry := resolverRegistry{
-		"env":       newEnvResolver(logger),
-		"aws_sm":    newAWSSMResolver(logger),
-		"aws_ssm":   newAWSSSMResolver(logger),
-		"1password": newOPResolver(logger),
+	registry := sourceBuilderRegistry{
+		"env":       newEnvBuilder(logger),
+		"aws_sm":    newAWSSMBuilder(logger),
+		"aws_ssm":   newAWSSSMBuilder(logger),
+		"1password": newOPBuilder(logger),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	return newFromConfig(ctx, c, registry)
+	return newFromConfig(c, registry)
 }
 
 // newFromConfig creates a Secrets transform from a parsed config.
-func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegistry) (*Secrets, error) {
+func newFromConfig(cfg secretsConfig, registry sourceBuilderRegistry) (*Secrets, error) {
 	resolved := make([]resolvedSecret, 0, len(cfg.Secrets))
 
 	for i, entry := range cfg.Secrets {
@@ -153,7 +149,7 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 			return nil, err
 		}
 
-		// Peek at source type to dispatch to the right resolver.
+		// Peek at source type to dispatch to the right builder.
 		var hint sourceTypeHint
 		if err := entry.Source.Decode(&hint); err != nil {
 			return nil, fmt.Errorf("secrets[%d]: parsing source type: %w", i, err)
@@ -162,12 +158,12 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 			return nil, fmt.Errorf("secrets[%d]: source.type is required", i)
 		}
 
-		resolver, ok := registry[hint.Type]
+		builder, ok := registry[hint.Type]
 		if !ok {
 			return nil, fmt.Errorf("secrets[%d]: unsupported source type %q", i, hint.Type)
 		}
 
-		result, err := resolver.Resolve(ctx, entry.Source)
+		source, err := builder.Build(entry.Source)
 		if err != nil {
 			return nil, fmt.Errorf("secrets[%d]: %w", i, err)
 		}
@@ -179,9 +175,8 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 
 		if inject != nil {
 			sec := resolvedSecret{
-				name:             result.Name,
+				source:           source,
 				mode:             "inject",
-				getValue:         result.GetValue,
 				rules:            rules,
 				require:          inject.Require,
 				injectHeader:     inject.Header,
@@ -201,10 +196,9 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 				return nil, err
 			}
 			resolved = append(resolved, resolvedSecret{
-				name:         result.Name,
+				source:       source,
 				mode:         "replace",
 				proxyValue:   replace.ProxyValue,
-				getValue:     result.GetValue,
 				matchHeaders: matchers,
 				matchBody:    replace.MatchBody,
 				matchPath:    replace.MatchPath,
@@ -303,24 +297,25 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 			continue
 		}
 
-		realValue, err := sec.getValue(ctx)
+		name := sec.source.Name()
+		realValue, err := sec.source.Get(ctx)
 		if err != nil {
 			if sec.require {
-				tctx.Annotate("rejected", sec.name)
+				tctx.Annotate("rejected", name)
 				tctx.Annotate("reject_reason", "secret_unavailable")
 				return &transform.TransformResult{Action: transform.ActionReject}, nil
 			}
-			unavailable = append(unavailable, sec.name)
+			unavailable = append(unavailable, name)
 			continue
 		}
 
 		if sec.mode == "inject" {
 			locations, err := s.injectSecret(req, &sec, realValue)
 			if err != nil {
-				return nil, fmt.Errorf("injecting secret %q: %w", sec.name, err)
+				return nil, fmt.Errorf("injecting secret %q: %w", name, err)
 			}
 			if len(locations) > 0 {
-				injected = append(injected, secretRecord{Secret: sec.name, Locations: locations})
+				injected = append(injected, secretRecord{Secret: name, Locations: locations})
 			}
 			continue
 		}
@@ -342,9 +337,9 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		}
 
 		if len(locations) > 0 {
-			swapped = append(swapped, secretRecord{Secret: sec.name, Locations: locations})
+			swapped = append(swapped, secretRecord{Secret: name, Locations: locations})
 		} else if sec.require {
-			tctx.Annotate("rejected", sec.name)
+			tctx.Annotate("rejected", name)
 			return &transform.TransformResult{Action: transform.ActionReject}, nil
 		}
 	}

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -57,6 +57,10 @@ type injectConfig struct {
 	Header     string `yaml:"header,omitempty"`
 	QueryParam string `yaml:"query_param,omitempty"`
 	Formatter  string `yaml:"formatter,omitempty"`
+	// Require, when true, rejects the request if the secret can't be
+	// resolved at the time the request matches. Default false skips the
+	// secret silently on resolve failure.
+	Require bool `yaml:"require,omitempty"`
 }
 
 // resolvedSecret is a secret ready for use after config parsing and source resolution.
@@ -129,7 +133,7 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
 	registry := resolverRegistry{
-		"env":       newEnvResolver(),
+		"env":       newEnvResolver(logger),
 		"aws_sm":    newAWSSMResolver(logger),
 		"aws_ssm":   newAWSSSMResolver(logger),
 		"1password": newOPResolver(logger),
@@ -180,6 +184,7 @@ func newFromConfig(ctx context.Context, cfg secretsConfig, registry resolverRegi
 				mode:             "inject",
 				getValue:         result.GetValue,
 				rules:            rules,
+				require:          inject.Require,
 				injectHeader:     inject.Header,
 				injectQueryParam: inject.QueryParam,
 			}
@@ -292,6 +297,7 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		Locations []string `json:"locations"`
 	}
 	var swapped, injected []secretRecord
+	var unavailable []string
 
 	for _, sec := range s.secrets {
 		if !hostmatch.MatchAnyRule(sec.rules, req) {
@@ -300,7 +306,13 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 		realValue, err := sec.getValue(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("resolving secret %q: %w", sec.name, err)
+			if sec.require {
+				tctx.Annotate("rejected", sec.name)
+				tctx.Annotate("reject_reason", "secret_unavailable")
+				return &transform.TransformResult{Action: transform.ActionReject}, nil
+			}
+			unavailable = append(unavailable, sec.name)
+			continue
 		}
 
 		if sec.mode == "inject" {
@@ -343,6 +355,9 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	}
 	if len(injected) > 0 {
 		tctx.Annotate("injected", injected)
+	}
+	if len(unavailable) > 0 {
+		tctx.Annotate("secret_unavailable", unavailable)
 	}
 
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -57,9 +57,8 @@ type injectConfig struct {
 	Header     string `yaml:"header,omitempty"`
 	QueryParam string `yaml:"query_param,omitempty"`
 	Formatter  string `yaml:"formatter,omitempty"`
-	// Require, when true, rejects the request if the secret can't be
-	// resolved at the time the request matches. Default false skips the
-	// secret silently on resolve failure.
+	// Require rejects the request when the secret is unavailable. When
+	// false (default), an unavailable secret is skipped silently.
 	Require bool `yaml:"require,omitempty"`
 }
 

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -24,16 +24,16 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
-// fakeResolver is a test secretResolver. Resolve only validates that the
+// fakeBuilder is a test secretSourceBuilder. Build only validates that the
 // source has a recognizable name field; the lookup against secrets (and any
-// failure) is deferred to GetValue.
-type fakeResolver struct {
+// failure) is deferred to Get.
+type fakeBuilder struct {
 	mu         sync.Mutex
 	secrets    map[string]string
 	fetchCalls map[string]int
 }
 
-func (f *fakeResolver) extractName(raw yaml.Node) (string, error) {
+func (f *fakeBuilder) extractName(raw yaml.Node) (string, error) {
 	var env envConfig
 	if err := raw.Decode(&env); err == nil && env.Var != "" {
 		return env.Var, nil
@@ -49,12 +49,12 @@ func (f *fakeResolver) extractName(raw yaml.Node) (string, error) {
 	return "", &resolveError{"unknown"}
 }
 
-func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+func (f *fakeBuilder) Build(raw yaml.Node) (secretSource, error) {
 	name, err := f.extractName(raw)
 	if err != nil {
-		return ResolveResult{}, err
+		return nil, err
 	}
-	fetch := func(context.Context) (string, error) {
+	return newLazyValue(name, 0, defaultFailureTTL, slog.Default(), func(context.Context) (string, error) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		if f.fetchCalls == nil {
@@ -66,28 +66,24 @@ func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult,
 			return "", &resolveError{name}
 		}
 		return val, nil
-	}
-	return ResolveResult{
-		Name:     name,
-		GetValue: newLazyValue(name, 0, defaultFailureTTL, slog.Default(), fetch),
-	}, nil
+	}), nil
 }
 
 type resolveError struct{ name string }
 
 func (e *resolveError) Error() string { return e.name + " not found" }
 
-func testRegistry() resolverRegistry {
-	return resolverRegistry{
-		"env": &fakeResolver{secrets: map[string]string{
+func testRegistry() sourceBuilderRegistry {
+	return sourceBuilderRegistry{
+		"env": &fakeBuilder{secrets: map[string]string{
 			"OPENAI_API_KEY":    "sk-real-openai-key",
 			"ANTHROPIC_API_KEY": "sk-real-anthropic-key",
 			"INTERNAL_TOKEN":    "real-internal-token",
 		}},
-		"aws_sm": &fakeResolver{secrets: map[string]string{
+		"aws_sm": &fakeBuilder{secrets: map[string]string{
 			"arn:aws:sm:test": "aws-secret-value",
 		}},
-		"aws_ssm": &fakeResolver{secrets: map[string]string{
+		"aws_ssm": &fakeBuilder{secrets: map[string]string{
 			"/myapp/api-key": "ssm-secret-value",
 		}},
 	}
@@ -123,7 +119,7 @@ func defaultEntry(opts ...func(*secretEntry)) secretEntry {
 func makeSecrets(t *testing.T, entries []secretEntry) *Secrets {
 	t.Helper()
 	cfg := secretsConfig{Secrets: entries}
-	s, err := newFromConfig(context.Background(), cfg, testRegistry())
+	s, err := newFromConfig(cfg, testRegistry())
 	require.NoError(t, err)
 	return s
 }
@@ -364,7 +360,7 @@ func TestSecrets_RegexMatchHeaders_InvalidRegex(t *testing.T) {
 		MatchHeaders: []string{`/[invalid/`},
 		Rules:        []hostmatch.RuleConfig{{Host: "example.com"}},
 	}}}
-	_, err := newFromConfig(context.Background(), cfg, testRegistry())
+	_, err := newFromConfig(cfg, testRegistry())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid match_headers regex")
 }
@@ -404,7 +400,7 @@ func TestSecrets_ConfigErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := newFromConfig(context.Background(), tt.cfg, testRegistry())
+			_, err := newFromConfig(tt.cfg, testRegistry())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -693,10 +689,10 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 	require.Equal(t, "ssm-secret-value", req.Header.Get("X-SSM-Key"))
 }
 
-// --- End-to-end tests with real awsSMResolver and mock AWS client ---
+// --- End-to-end tests with real awsSMBuilder and mock AWS client ---
 
-func awsSMRegistry(client smClient) resolverRegistry {
-	return resolverRegistry{"aws_sm": &awsSMResolver{
+func awsSMRegistry(client smClient) sourceBuilderRegistry {
+	return sourceBuilderRegistry{"aws_sm": &awsSMBuilder{
 		clientFor: func(_ context.Context, _ string) (smClient, error) {
 			return client, nil
 		},
@@ -707,7 +703,7 @@ func awsSMRegistry(client smClient) resolverRegistry {
 func makeAWSSMSecrets(t *testing.T, client smClient, entries []secretEntry) *Secrets {
 	t.Helper()
 	cfg := secretsConfig{Secrets: entries}
-	s, err := newFromConfig(context.Background(), cfg, awsSMRegistry(client))
+	s, err := newFromConfig(cfg, awsSMRegistry(client))
 	require.NoError(t, err)
 	return s
 }
@@ -896,10 +892,10 @@ func TestAWSSM_EndToEnd_RequireRejectsWithoutToken(t *testing.T) {
 	require.Equal(t, transform.ActionReject, res.Action)
 }
 
-// --- End-to-end tests with real awsSSMResolver and mock AWS client ---
+// --- End-to-end tests with real awsSSMBuilder and mock AWS client ---
 
-func awsSSMRegistry(client ssmClient) resolverRegistry {
-	return resolverRegistry{"aws_ssm": &awsSSMResolver{
+func awsSSMRegistry(client ssmClient) sourceBuilderRegistry {
+	return sourceBuilderRegistry{"aws_ssm": &awsSSMBuilder{
 		clientFor: func(_ context.Context, _ string) (ssmClient, error) {
 			return client, nil
 		},
@@ -910,7 +906,7 @@ func awsSSMRegistry(client ssmClient) resolverRegistry {
 func makeAWSSSMSecrets(t *testing.T, client ssmClient, entries []secretEntry) *Secrets {
 	t.Helper()
 	cfg := secretsConfig{Secrets: entries}
-	s, err := newFromConfig(context.Background(), cfg, awsSSMRegistry(client))
+	s, err := newFromConfig(cfg, awsSSMRegistry(client))
 	require.NoError(t, err)
 	return s
 }
@@ -1145,7 +1141,7 @@ func TestInject_ConfigErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := newFromConfig(context.Background(), tt.cfg, testRegistry())
+			_, err := newFromConfig(tt.cfg, testRegistry())
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -1248,9 +1244,9 @@ func TestInject_ConcurrentSafety(t *testing.T) {
 
 // --- Lazy resolution + require-on-resolve-failure tests ---
 
-func missingSecretRegistry() resolverRegistry {
-	return resolverRegistry{
-		"env": &fakeResolver{secrets: map[string]string{}},
+func missingSecretRegistry() sourceBuilderRegistry {
+	return sourceBuilderRegistry{
+		"env": &fakeBuilder{secrets: map[string]string{}},
 	}
 }
 
@@ -1269,14 +1265,14 @@ func missingSecretEntry(opts ...func(*secretEntry)) secretEntry {
 
 func TestLazy_PipelineBuildsWhenSecretBackendUnreachable(t *testing.T) {
 	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
-	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	s, err := newFromConfig(cfg, missingSecretRegistry())
 	require.NoError(t, err, "pipeline must build even when the secret can't be fetched")
 	require.NotNil(t, s)
 }
 
 func TestLazy_RequestSkipsUnavailableSecretWhenNotRequired(t *testing.T) {
 	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
-	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	s, err := newFromConfig(cfg, missingSecretRegistry())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
@@ -1295,7 +1291,7 @@ func TestLazy_RequestRejectedWhenReplaceRequireAndSecretUnavailable(t *testing.T
 	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry(func(e *secretEntry) {
 		e.Require = true
 	})}}
-	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	s, err := newFromConfig(cfg, missingSecretRegistry())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
@@ -1313,7 +1309,7 @@ func TestLazy_RequestRejectedWhenInjectRequireAndSecretUnavailable(t *testing.T)
 		Inject: &injectConfig{Header: "Authorization", Require: true},
 		Rules:  []hostmatch.RuleConfig{{Host: "api.example.com"}},
 	}}}
-	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	s, err := newFromConfig(cfg, missingSecretRegistry())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
@@ -1330,7 +1326,7 @@ func TestLazy_InjectRequireFalseSkipsOnUnavailable(t *testing.T) {
 		Inject: &injectConfig{Header: "Authorization"},
 		Rules:  []hostmatch.RuleConfig{{Host: "api.example.com"}},
 	}}}
-	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	s, err := newFromConfig(cfg, missingSecretRegistry())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
@@ -1344,8 +1340,8 @@ func TestLazy_InjectRequireFalseSkipsOnUnavailable(t *testing.T) {
 }
 
 func TestLazy_MixedAvailableAndUnavailable(t *testing.T) {
-	registry := resolverRegistry{
-		"env": &fakeResolver{secrets: map[string]string{
+	registry := sourceBuilderRegistry{
+		"env": &fakeBuilder{secrets: map[string]string{
 			"OPENAI_API_KEY": "sk-real-openai-key",
 		}},
 	}
@@ -1363,7 +1359,7 @@ func TestLazy_MixedAvailableAndUnavailable(t *testing.T) {
 			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 		},
 	}}
-	s, err := newFromConfig(context.Background(), cfg, registry)
+	s, err := newFromConfig(cfg, registry)
 	require.NoError(t, err)
 
 	req := openaiReq("GET", "/v1/chat")
@@ -1379,11 +1375,11 @@ func TestLazy_MixedAvailableAndUnavailable(t *testing.T) {
 }
 
 func TestLazy_FailureCachedAcrossRequests(t *testing.T) {
-	fr := &fakeResolver{secrets: map[string]string{}}
-	registry := resolverRegistry{"env": fr}
+	fr := &fakeBuilder{secrets: map[string]string{}}
+	registry := sourceBuilderRegistry{"env": fr}
 
 	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
-	s, err := newFromConfig(context.Background(), cfg, registry)
+	s, err := newFromConfig(cfg, registry)
 	require.NoError(t, err)
 
 	for range 5 {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -24,38 +24,60 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
-// fakeResolver is a test secretResolver that returns preconfigured values.
+// fakeResolver is a test secretResolver. Resolve only validates that the
+// source has a recognizable name field; the actual lookup against secrets
+// (and any failure) is deferred to GetValue, mirroring lazy-init semantics.
 type fakeResolver struct {
-	secrets map[string]string // keyed by env var name or secret ID
+	mu          sync.Mutex
+	secrets     map[string]string // keyed by env var name or secret ID
+	failuresFor map[string]int    // remaining initial failures per name; decremented per fetch
+	fetchCalls  map[string]int    // per-name fetch call count for assertions
 }
 
-func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
-	// Try env config first, then AWS-backed configs.
+func (f *fakeResolver) extractName(raw yaml.Node) (string, error) {
 	var env envConfig
 	if err := raw.Decode(&env); err == nil && env.Var != "" {
-		val, ok := f.secrets[env.Var]
-		if !ok || val == "" {
-			return ResolveResult{}, &resolveError{env.Var}
-		}
-		return ResolveResult{Name: env.Var, GetValue: staticValue(val)}, nil
+		return env.Var, nil
 	}
 	var sm awsSMConfig
 	if err := raw.Decode(&sm); err == nil && sm.SecretID != "" {
-		val, ok := f.secrets[sm.SecretID]
-		if !ok || val == "" {
-			return ResolveResult{}, &resolveError{sm.SecretID}
-		}
-		return ResolveResult{Name: sm.SecretID, GetValue: staticValue(val)}, nil
+		return sm.SecretID, nil
 	}
 	var ssm awsSSMConfig
 	if err := raw.Decode(&ssm); err == nil && ssm.Name != "" {
-		val, ok := f.secrets[ssm.Name]
-		if !ok || val == "" {
-			return ResolveResult{}, &resolveError{ssm.Name}
-		}
-		return ResolveResult{Name: ssm.Name, GetValue: staticValue(val)}, nil
+		return ssm.Name, nil
 	}
-	return ResolveResult{}, &resolveError{"unknown"}
+	return "", &resolveError{"unknown"}
+}
+
+func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult, error) {
+	name, err := f.extractName(raw)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	fetch := func(context.Context) (string, error) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.fetchCalls == nil {
+			f.fetchCalls = make(map[string]int)
+		}
+		f.fetchCalls[name]++
+		if f.failuresFor != nil {
+			if left := f.failuresFor[name]; left > 0 {
+				f.failuresFor[name] = left - 1
+				return "", &resolveError{name}
+			}
+		}
+		val, ok := f.secrets[name]
+		if !ok || val == "" {
+			return "", &resolveError{name}
+		}
+		return val, nil
+	}
+	return ResolveResult{
+		Name:     name,
+		GetValue: newLazyValue(name, 0, defaultFailureTTL, slog.Default(), fetch),
+	}, nil
 }
 
 type resolveError struct{ name string }
@@ -360,15 +382,6 @@ func TestSecrets_ConfigErrors(t *testing.T) {
 		cfg    secretsConfig
 		errMsg string
 	}{
-		{
-			name: "missing env var",
-			cfg: secretsConfig{Secrets: []secretEntry{{
-				Source:     envSource("NONEXISTENT_VAR"),
-				ProxyValue: "proxy-value",
-				Rules:      []hostmatch.RuleConfig{{Host: "example.com"}},
-			}}},
-			errMsg: "NONEXISTENT_VAR",
-		},
 		{
 			name: "no mode specified",
 			cfg: secretsConfig{Secrets: []secretEntry{{
@@ -798,30 +811,30 @@ func TestAWSSM_EndToEnd_TTLRefresh(t *testing.T) {
 		MatchHeaders: []string{"Authorization"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
 	}})
-	// Initial resolve is call 1 (value-1).
+	require.Equal(t, int32(0), callCount.Load(), "lazy: no fetch before first request")
 
-	// First request: TTL=1ns is already expired, so this triggers a refresh (call 2).
+	// First request: triggers initial fetch (call 1, value-1).
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer value-1", req.Header.Get("Authorization"))
+
+	// Second request: TTL already expired, triggers refresh (call 2, value-2).
+	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
 	req.Host = "api.example.com"
 	req.Header.Set("Authorization", "Bearer proxy-tok")
 	doTransform(t, s, req)
 	require.Equal(t, "Bearer value-2", req.Header.Get("Authorization"))
 
-	// Second request: triggers another refresh (call 3).
-	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
-	req.Host = "api.example.com"
-	req.Header.Set("Authorization", "Bearer proxy-tok")
-	doTransform(t, s, req)
-	require.Equal(t, "Bearer value-3", req.Header.Get("Authorization"))
-
-	require.GreaterOrEqual(t, callCount.Load(), int32(3))
+	require.GreaterOrEqual(t, callCount.Load(), int32(2))
 }
 
 func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 	var callCount atomic.Int32
 	client := &mockSMClient{fn: func(_ context.Context, _ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
 		n := callCount.Add(1)
-		// First call (initial resolve at startup) succeeds.
+		// First fetch (lazy, on first request) succeeds.
 		if n == 1 {
 			return &secretsmanager.GetSecretValueOutput{
 				SecretString: aws.String("good-value"),
@@ -841,23 +854,30 @@ func TestAWSSM_EndToEnd_TTLServesStaleOnError(t *testing.T) {
 		MatchHeaders: []string{"Authorization"},
 		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
 	}})
-	require.Equal(t, int32(1), callCount.Load()) // initial resolve
+	require.Equal(t, int32(0), callCount.Load(), "lazy: no fetch before first request")
 
-	// First request: TTL expired, refresh fails, stale "good-value" served.
+	// First request: lazy fetch succeeds and caches "good-value".
 	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
 	req.Host = "api.example.com"
 	req.Header.Set("Authorization", "Bearer proxy-tok")
 	doTransform(t, s, req)
 	require.Equal(t, "Bearer good-value", req.Header.Get("Authorization"))
 
-	// Second request: same — refresh fails again, stale value still served.
+	// Second request: TTL expired, refresh fails, stale "good-value" served.
 	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
 	req.Host = "api.example.com"
 	req.Header.Set("Authorization", "Bearer proxy-tok")
 	doTransform(t, s, req)
 	require.Equal(t, "Bearer good-value", req.Header.Get("Authorization"))
 
-	// At least 2 refresh attempts beyond the initial resolve.
+	// Third request: same — refresh fails again, stale value still served.
+	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer good-value", req.Header.Get("Authorization"))
+
+	// At least 2 refresh attempts beyond the initial successful fetch.
 	require.GreaterOrEqual(t, callCount.Load(), int32(3))
 }
 
@@ -1231,4 +1251,207 @@ func TestInject_ConcurrentSafety(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// --- Lazy resolution + require-on-resolve-failure tests ---
+
+// missingSecretRegistry uses a fakeResolver with no secrets configured, so
+// every lazy fetch fails with "<name> not found".
+func missingSecretRegistry() resolverRegistry {
+	return resolverRegistry{
+		"env": &fakeResolver{secrets: map[string]string{}},
+	}
+}
+
+// missingSecretEntry returns a default replace entry whose source can never
+// be resolved (the fakeResolver has no value for MISSING).
+func missingSecretEntry(opts ...func(*secretEntry)) secretEntry {
+	e := secretEntry{
+		Source:       envSource("MISSING"),
+		ProxyValue:   "proxy-tok",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}
+	for _, opt := range opts {
+		opt(&e)
+	}
+	return e
+}
+
+func TestLazy_PipelineBuildsWhenSecretBackendUnreachable(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
+	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	require.NoError(t, err, "pipeline must build even when the secret can't be fetched")
+	require.NotNil(t, s)
+}
+
+func TestLazy_RequestSkipsUnavailableSecretWhenNotRequired(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
+	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+
+	tctx := &transform.TransformContext{}
+	res, err := s.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	// Secret unavailable: header is left as-is.
+	require.Equal(t, "Bearer proxy-tok", req.Header.Get("Authorization"))
+}
+
+func TestLazy_RequestRejectedWhenReplaceRequireAndSecretUnavailable(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry(func(e *secretEntry) {
+		e.Require = true
+	})}}
+	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-tok")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestLazy_RequestRejectedWhenInjectRequireAndSecretUnavailable(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source: envSource("MISSING"),
+		Inject: &injectConfig{Header: "Authorization", Require: true},
+		Rules:  []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
+func TestLazy_InjectRequireFalseSkipsOnUnavailable(t *testing.T) {
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source: envSource("MISSING"),
+		Inject: &injectConfig{Header: "Authorization"},
+		Rules:  []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+	s, err := newFromConfig(context.Background(), cfg, missingSecretRegistry())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	// Secret unavailable + require=false: header not set.
+	require.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestLazy_MixedAvailableAndUnavailable(t *testing.T) {
+	registry := resolverRegistry{
+		"env": &fakeResolver{secrets: map[string]string{
+			"OPENAI_API_KEY": "sk-real-openai-key",
+		}},
+	}
+	cfg := secretsConfig{Secrets: []secretEntry{
+		// Working secret.
+		{
+			Source:       envSource("OPENAI_API_KEY"),
+			ProxyValue:   "proxy-openai-abc123",
+			MatchHeaders: []string{"Authorization"},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		},
+		// Missing secret on a different host (so both rules can match a single req? no, they can't —
+		// use the same host so both match).
+		{
+			Source:       envSource("MISSING"),
+			ProxyValue:   "proxy-other",
+			MatchHeaders: []string{"X-Other"},
+			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		},
+	}}
+	s, err := newFromConfig(context.Background(), cfg, registry)
+	require.NoError(t, err)
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
+	req.Header.Set("X-Other", "proxy-other")
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
+	// Missing secret: X-Other untouched.
+	require.Equal(t, "proxy-other", req.Header.Get("X-Other"))
+}
+
+func TestLazy_FailureCachedAcrossRequests(t *testing.T) {
+	fr := &fakeResolver{secrets: map[string]string{}}
+	registry := resolverRegistry{"env": fr}
+
+	cfg := secretsConfig{Secrets: []secretEntry{missingSecretEntry()}}
+	s, err := newFromConfig(context.Background(), cfg, registry)
+	require.NoError(t, err)
+
+	for range 5 {
+		req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+		req.Host = "api.example.com"
+		req.Header.Set("Authorization", "Bearer proxy-tok")
+		doTransform(t, s, req)
+	}
+
+	// Lazy fetch happened only once; subsequent requests served the cached error.
+	fr.mu.Lock()
+	defer fr.mu.Unlock()
+	require.Equal(t, 1, fr.fetchCalls["MISSING"])
+}
+
+func TestLazy_FailureRecoversAfterFix(t *testing.T) {
+	fr := &fakeResolver{
+		secrets:     map[string]string{"FLAKY": "real-flaky-value"},
+		failuresFor: map[string]int{"FLAKY": 1}, // first fetch fails, then succeeds
+	}
+	registry := resolverRegistry{"env": fr}
+
+	// Use a tiny TTL so failureTTL on the cachedValue is also tiny — we can
+	// drive recovery without sleeping by inspecting the cachedValue directly.
+	cfg := secretsConfig{Secrets: []secretEntry{{
+		Source:       envSource("FLAKY"),
+		ProxyValue:   "proxy-flaky",
+		MatchHeaders: []string{"Authorization"},
+		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
+	}}}
+	s, err := newFromConfig(context.Background(), cfg, registry)
+	require.NoError(t, err)
+
+	// First request: fetch fails, header untouched.
+	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-flaky")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer proxy-flaky", req.Header.Get("Authorization"))
+
+	// Force the cachedValue to expire so the next call re-fetches.
+	require.Len(t, s.secrets, 1)
+	// Reach into the test fakeResolver call counts to confirm only 1 fetch happened.
+	fr.mu.Lock()
+	require.Equal(t, 1, fr.fetchCalls["FLAKY"])
+	fr.mu.Unlock()
+
+	// Second request right after: still within failureTTL, no new fetch.
+	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
+	req.Host = "api.example.com"
+	req.Header.Set("Authorization", "Bearer proxy-flaky")
+	doTransform(t, s, req)
+	require.Equal(t, "Bearer proxy-flaky", req.Header.Get("Authorization"))
+	fr.mu.Lock()
+	require.Equal(t, 1, fr.fetchCalls["FLAKY"], "still cached")
+	fr.mu.Unlock()
 }

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -25,13 +25,12 @@ import (
 )
 
 // fakeResolver is a test secretResolver. Resolve only validates that the
-// source has a recognizable name field; the actual lookup against secrets
-// (and any failure) is deferred to GetValue, mirroring lazy-init semantics.
+// source has a recognizable name field; the lookup against secrets (and any
+// failure) is deferred to GetValue.
 type fakeResolver struct {
-	mu          sync.Mutex
-	secrets     map[string]string // keyed by env var name or secret ID
-	failuresFor map[string]int    // remaining initial failures per name; decremented per fetch
-	fetchCalls  map[string]int    // per-name fetch call count for assertions
+	mu         sync.Mutex
+	secrets    map[string]string
+	fetchCalls map[string]int
 }
 
 func (f *fakeResolver) extractName(raw yaml.Node) (string, error) {
@@ -62,12 +61,6 @@ func (f *fakeResolver) Resolve(_ context.Context, raw yaml.Node) (ResolveResult,
 			f.fetchCalls = make(map[string]int)
 		}
 		f.fetchCalls[name]++
-		if f.failuresFor != nil {
-			if left := f.failuresFor[name]; left > 0 {
-				f.failuresFor[name] = left - 1
-				return "", &resolveError{name}
-			}
-		}
 		val, ok := f.secrets[name]
 		if !ok || val == "" {
 			return "", &resolveError{name}
@@ -1255,16 +1248,12 @@ func TestInject_ConcurrentSafety(t *testing.T) {
 
 // --- Lazy resolution + require-on-resolve-failure tests ---
 
-// missingSecretRegistry uses a fakeResolver with no secrets configured, so
-// every lazy fetch fails with "<name> not found".
 func missingSecretRegistry() resolverRegistry {
 	return resolverRegistry{
 		"env": &fakeResolver{secrets: map[string]string{}},
 	}
 }
 
-// missingSecretEntry returns a default replace entry whose source can never
-// be resolved (the fakeResolver has no value for MISSING).
 func missingSecretEntry(opts ...func(*secretEntry)) secretEntry {
 	e := secretEntry{
 		Source:       envSource("MISSING"),
@@ -1361,15 +1350,12 @@ func TestLazy_MixedAvailableAndUnavailable(t *testing.T) {
 		}},
 	}
 	cfg := secretsConfig{Secrets: []secretEntry{
-		// Working secret.
 		{
 			Source:       envSource("OPENAI_API_KEY"),
 			ProxyValue:   "proxy-openai-abc123",
 			MatchHeaders: []string{"Authorization"},
 			Rules:        []hostmatch.RuleConfig{{Host: "api.openai.com"}},
 		},
-		// Missing secret on a different host (so both rules can match a single req? no, they can't —
-		// use the same host so both match).
 		{
 			Source:       envSource("MISSING"),
 			ProxyValue:   "proxy-other",
@@ -1413,45 +1399,3 @@ func TestLazy_FailureCachedAcrossRequests(t *testing.T) {
 	require.Equal(t, 1, fr.fetchCalls["MISSING"])
 }
 
-func TestLazy_FailureRecoversAfterFix(t *testing.T) {
-	fr := &fakeResolver{
-		secrets:     map[string]string{"FLAKY": "real-flaky-value"},
-		failuresFor: map[string]int{"FLAKY": 1}, // first fetch fails, then succeeds
-	}
-	registry := resolverRegistry{"env": fr}
-
-	// Use a tiny TTL so failureTTL on the cachedValue is also tiny — we can
-	// drive recovery without sleeping by inspecting the cachedValue directly.
-	cfg := secretsConfig{Secrets: []secretEntry{{
-		Source:       envSource("FLAKY"),
-		ProxyValue:   "proxy-flaky",
-		MatchHeaders: []string{"Authorization"},
-		Rules:        []hostmatch.RuleConfig{{Host: "api.example.com"}},
-	}}}
-	s, err := newFromConfig(context.Background(), cfg, registry)
-	require.NoError(t, err)
-
-	// First request: fetch fails, header untouched.
-	req := httptest.NewRequest("GET", "http://api.example.com/v1", nil)
-	req.Host = "api.example.com"
-	req.Header.Set("Authorization", "Bearer proxy-flaky")
-	doTransform(t, s, req)
-	require.Equal(t, "Bearer proxy-flaky", req.Header.Get("Authorization"))
-
-	// Force the cachedValue to expire so the next call re-fetches.
-	require.Len(t, s.secrets, 1)
-	// Reach into the test fakeResolver call counts to confirm only 1 fetch happened.
-	fr.mu.Lock()
-	require.Equal(t, 1, fr.fetchCalls["FLAKY"])
-	fr.mu.Unlock()
-
-	// Second request right after: still within failureTTL, no new fetch.
-	req = httptest.NewRequest("GET", "http://api.example.com/v1", nil)
-	req.Host = "api.example.com"
-	req.Header.Set("Authorization", "Bearer proxy-flaky")
-	doTransform(t, s, req)
-	require.Equal(t, "Bearer proxy-flaky", req.Header.Get("Authorization"))
-	fr.mu.Lock()
-	require.Equal(t, 1, fr.fetchCalls["FLAKY"], "still cached")
-	fr.mu.Unlock()
-}


### PR DESCRIPTION
The secrets transform no longer fetches from providers at pipeline-build time. Each resolver now validates static config and returns a deferred `GetValue` that fetches on the first matching request; results are cached per the source's TTL, and initial-fetch failures are cached for the source TTL (default 30s) so a struggling backend isn't hammered. Existing serve-stale-on-refresh-error behavior is preserved.

`require` now governs resolve failures and is supported on inject as well as replace: `require=true` rejects the request when the secret can't be resolved, `require=false` silently skips it and adds a `secret_unavailable` annotation. This replaces the previous "any resolve failure → 502" with configurable per-entry behavior.