### PR TITLE
ci(release): use goreleaser pro split-merge with cgo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,6 @@ jobs:
           egress-rules: egress-rules.yaml
           disable-docker: false
 
-      - name: Allow runner access to docker socket
-        run: sudo chmod 666 /var/run/docker.sock
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ironsh/iron-proxy-action@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
-        if: matrix.goos != 'darwin'
-        with:
-          egress-rules: egress-rules.yaml
-          disable-docker: true
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"
@@ -66,9 +60,6 @@ jobs:
           path: dist/${{ matrix.goos }}_${{ matrix.goarch }}/
           retention-days: 1
           if-no-files-found: error
-
-      - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
-        if: always() && matrix.goos != 'darwin'
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Install musl toolchain
+        if: matrix.goos == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Install Docker
+        if: matrix.goos == 'darwin'
+        run: |
+          brew install --quiet docker colima
+          colima start
+
       - name: Run GoReleaser (split)
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
@@ -51,6 +61,7 @@ jobs:
         env:
           GGOOS: ${{ matrix.goos }}
           GGOARCH: ${{ matrix.goarch }}
+          CC: ${{ matrix.goos == 'linux' && 'musl-gcc' || '' }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,9 @@ jobs:
           egress-rules: egress-rules.yaml
           disable-docker: false
 
+      - name: Allow runner access to docker socket
+        run: sudo chmod 666 /var/run/docker.sock
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           fetch-depth: 0
 
       - uses: ironsh/iron-proxy-action@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
+        if: matrix.goos != 'darwin'
         with:
           egress-rules: egress-rules.yaml
           disable-docker: true
@@ -67,7 +68,7 @@ jobs:
           if-no-files-found: error
 
       - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
-        if: always()
+        if: always() && matrix.goos != 'darwin'
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,65 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            runner: ubuntu-latest
+          - goos: linux
+            goarch: arm64
+            runner: ubuntu-24.04-arm
+          - goos: darwin
+            goarch: amd64
+            runner: macos-13
+          - goos: darwin
+            goarch: arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ironsh/iron-proxy-action@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
+        with:
+          egress-rules: egress-rules.yaml
+          disable-docker: true
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+
+      - name: Run GoReleaser (split)
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            release
+            --split
+            ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
+            --clean
+        env:
+          GGOOS: ${{ matrix.goos }}
+          GGOARCH: ${{ matrix.goarch }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.goos }}_${{ matrix.goarch }}
+          path: dist/${{ matrix.goos }}_${{ matrix.goarch }}/
+          retention-days: 1
+          if-no-files-found: error
+
+      - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
+        if: always()
+
+  release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,6 +86,10 @@ jobs:
         with:
           go-version: "1.26"
 
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: dist/
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -40,15 +103,14 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (merge)
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
+          distribution: goreleaser-pro
           version: latest
-          args: >-
-            release
-            ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
-            --clean
+          args: continue --merge
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,18 +1,24 @@
 version: 2
 
+partial:
+  by: target
+
 builds:
   - main: ./cmd/iron-proxy
     binary: iron-proxy
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
       - darwin
     goarch:
       - amd64
       - arm64
+    tags:
+      - netgo
+      - osusergo
     ldflags:
-      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
+      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}} {{ if eq .Os "linux" }}-extldflags=-static{{ end }}
 
 archives:
   - formats: ["tar.gz"]


### PR DESCRIPTION
Switches the release pipeline to GoReleaser Pro and uses the split-then-merge feature so each target builds natively across a matrix of runners (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), enabling CGO. Linux binaries are statically linked via `netgo,osusergo` and `-extldflags=-static`; darwin links dynamically against system libs since Apple doesn't ship a static libSystem. Requires a new `GORELEASER_KEY` secret.