### PR TITLE
feat(mcp): include tool call arguments in audit log

### DIFF
--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -28,13 +28,17 @@ type Message struct {
 	Tool      string `json:"tool,omitempty"`
 	Decision  string `json:"decision"`
 	Reason    string `json:"reason,omitempty"`
-	// Arguments is the tools/call arguments payload. When the raw JSON is
-	// short and decodes cleanly it is the decoded value (e.g. map[string]any)
-	// so it nests naturally in audit output rather than appearing as an
-	// escaped string. When the raw JSON exceeds AuditArgumentsMaxLen bytes or
-	// cannot be decoded, this is a truncated raw-JSON string with a "..."
-	// suffix. nil for non-tools/call messages or calls without arguments.
+	// Arguments is the decoded tools/call arguments payload (e.g.
+	// map[string]any) so the value nests naturally in structured log output.
+	// Set only when the raw JSON fits under AuditArgumentsMaxLen and decodes
+	// cleanly; otherwise RawArguments carries the truncated raw string. nil
+	// for non-tools/call messages or calls without arguments.
 	Arguments any `json:"arguments,omitempty"`
+	// RawArguments is the truncated raw JSON of a tools/call arguments
+	// payload with a "..." suffix when truncation occurred. Set instead of
+	// Arguments when the payload is too large to record in full or does not
+	// decode as JSON.
+	RawArguments string `json:"raw_arguments,omitempty"`
 	// Filtered counts items removed from a tools/list response when this
 	// message represents a response-side filter event.
 	Filtered int `json:"filtered,omitempty"`
@@ -46,30 +50,31 @@ type Message struct {
 // truncated prefix with a "..." marker appended.
 const AuditArgumentsMaxLen = 64
 
-// encodeArguments produces the audit representation of a tools/call arguments
+// encodeArguments returns the audit fields for a tools/call arguments
 // payload. When raw fits under AuditArgumentsMaxLen and decodes as JSON, the
-// decoded value is returned so structured loggers nest it inline. Otherwise a
-// truncated raw-JSON string with a "..." suffix is returned. Returns nil when
-// raw is empty.
-func encodeArguments(raw []byte) any {
+// decoded value is returned as decoded so structured loggers nest it inline.
+// Otherwise rawStr carries a truncated raw-JSON string with a "..." suffix.
+// Exactly one of (decoded, rawStr) is set for a non-empty raw; both are zero
+// when raw is empty.
+func encodeArguments(raw []byte) (decoded any, rawStr string) {
 	if len(raw) == 0 {
-		return nil
+		return nil, ""
 	}
 	if len(raw) <= AuditArgumentsMaxLen {
 		var v any
 		if err := json.Unmarshal(raw, &v); err == nil {
-			return v
+			return v, ""
 		}
 	}
 	const marker = "..."
+	if len(raw) <= AuditArgumentsMaxLen {
+		return nil, string(raw)
+	}
 	cut := AuditArgumentsMaxLen - len(marker)
 	for cut > 0 && raw[cut]&0xC0 == 0x80 {
 		cut--
 	}
-	if cut >= len(raw) {
-		return string(raw)
-	}
-	return string(raw[:cut]) + marker
+	return nil, string(raw[:cut]) + marker
 }
 
 // Append records a message on the trace.
@@ -188,6 +193,9 @@ func (t *Trace) MCPMessages() []map[string]any {
 		}
 		if m.Arguments != nil {
 			entry["arguments"] = m.Arguments
+		}
+		if m.RawArguments != "" {
+			entry["raw_arguments"] = m.RawArguments
 		}
 		if m.Filtered > 0 {
 			entry["filtered"] = m.Filtered

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -28,9 +28,37 @@ type Message struct {
 	Tool      string `json:"tool,omitempty"`
 	Decision  string `json:"decision"`
 	Reason    string `json:"reason,omitempty"`
+	// Arguments is the raw JSON of a tools/call arguments payload, truncated
+	// to AuditArgumentsMaxLen bytes. Empty for non-tools/call messages or
+	// when the call carried no arguments.
+	Arguments string `json:"arguments,omitempty"`
 	// Filtered counts items removed from a tools/list response when this
 	// message represents a response-side filter event.
 	Filtered int `json:"filtered,omitempty"`
+}
+
+// AuditArgumentsMaxLen caps the recorded tools/call arguments at 64 bytes so
+// large payloads (file contents, long SQL, etc.) don't bloat audit records.
+// When the raw arguments exceed this length, the recorded value is the
+// truncated prefix with a "..." marker appended.
+const AuditArgumentsMaxLen = 64
+
+// truncateArguments returns raw, possibly with a "..." marker appended, so
+// that the returned string is no longer than AuditArgumentsMaxLen bytes.
+// Truncation is rune-aware: it never splits a multi-byte UTF-8 sequence.
+func truncateArguments(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	if len(raw) <= AuditArgumentsMaxLen {
+		return string(raw)
+	}
+	const marker = "..."
+	cut := AuditArgumentsMaxLen - len(marker)
+	for cut > 0 && raw[cut]&0xC0 == 0x80 {
+		cut--
+	}
+	return string(raw[:cut]) + marker
 }
 
 // Append records a message on the trace.
@@ -146,6 +174,9 @@ func (t *Trace) MCPMessages() []map[string]any {
 		}
 		if m.Reason != "" {
 			entry["reason"] = m.Reason
+		}
+		if m.Arguments != "" {
+			entry["arguments"] = m.Arguments
 		}
 		if m.Filtered > 0 {
 			entry["filtered"] = m.Filtered

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -28,10 +28,13 @@ type Message struct {
 	Tool      string `json:"tool,omitempty"`
 	Decision  string `json:"decision"`
 	Reason    string `json:"reason,omitempty"`
-	// Arguments is the raw JSON of a tools/call arguments payload, truncated
-	// to AuditArgumentsMaxLen bytes. Empty for non-tools/call messages or
-	// when the call carried no arguments.
-	Arguments string `json:"arguments,omitempty"`
+	// Arguments is the tools/call arguments payload. When the raw JSON is
+	// short and decodes cleanly it is the decoded value (e.g. map[string]any)
+	// so it nests naturally in audit output rather than appearing as an
+	// escaped string. When the raw JSON exceeds AuditArgumentsMaxLen bytes or
+	// cannot be decoded, this is a truncated raw-JSON string with a "..."
+	// suffix. nil for non-tools/call messages or calls without arguments.
+	Arguments any `json:"arguments,omitempty"`
 	// Filtered counts items removed from a tools/list response when this
 	// message represents a response-side filter event.
 	Filtered int `json:"filtered,omitempty"`
@@ -43,20 +46,28 @@ type Message struct {
 // truncated prefix with a "..." marker appended.
 const AuditArgumentsMaxLen = 64
 
-// truncateArguments returns raw, possibly with a "..." marker appended, so
-// that the returned string is no longer than AuditArgumentsMaxLen bytes.
-// Truncation is rune-aware: it never splits a multi-byte UTF-8 sequence.
-func truncateArguments(raw []byte) string {
+// encodeArguments produces the audit representation of a tools/call arguments
+// payload. When raw fits under AuditArgumentsMaxLen and decodes as JSON, the
+// decoded value is returned so structured loggers nest it inline. Otherwise a
+// truncated raw-JSON string with a "..." suffix is returned. Returns nil when
+// raw is empty.
+func encodeArguments(raw []byte) any {
 	if len(raw) == 0 {
-		return ""
+		return nil
 	}
 	if len(raw) <= AuditArgumentsMaxLen {
-		return string(raw)
+		var v any
+		if err := json.Unmarshal(raw, &v); err == nil {
+			return v
+		}
 	}
 	const marker = "..."
 	cut := AuditArgumentsMaxLen - len(marker)
 	for cut > 0 && raw[cut]&0xC0 == 0x80 {
 		cut--
+	}
+	if cut >= len(raw) {
+		return string(raw)
 	}
 	return string(raw[:cut]) + marker
 }
@@ -175,7 +186,7 @@ func (t *Trace) MCPMessages() []map[string]any {
 		if m.Reason != "" {
 			entry["reason"] = m.Reason
 		}
-		if m.Arguments != "" {
+		if m.Arguments != nil {
 			entry["arguments"] = m.Arguments
 		}
 		if m.Filtered > 0 {

--- a/internal/mcp/intercept.go
+++ b/internal/mcp/intercept.go
@@ -101,7 +101,7 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 		case MethodToolsCall:
 			name, args, rawArgs, ok := extractToolCallName(m.Params)
 			entry.Tool = name
-			entry.Arguments = encodeArguments(rawArgs)
+			entry.Arguments, entry.RawArguments = encodeArguments(rawArgs)
 			if !ok {
 				entry.Decision = DecisionDeny
 				entry.Reason = ReasonMalformedJSONRPC

--- a/internal/mcp/intercept.go
+++ b/internal/mcp/intercept.go
@@ -101,7 +101,7 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 		case MethodToolsCall:
 			name, args, rawArgs, ok := extractToolCallName(m.Params)
 			entry.Tool = name
-			entry.Arguments = truncateArguments(rawArgs)
+			entry.Arguments = encodeArguments(rawArgs)
 			if !ok {
 				entry.Decision = DecisionDeny
 				entry.Reason = ReasonMalformedJSONRPC

--- a/internal/mcp/intercept.go
+++ b/internal/mcp/intercept.go
@@ -99,8 +99,9 @@ func (p *Policy) EvaluateRequest(server *Server, req *http.Request, trace *Trace
 		}
 		switch m.Method {
 		case MethodToolsCall:
-			name, args, ok := extractToolCallName(m.Params)
+			name, args, rawArgs, ok := extractToolCallName(m.Params)
 			entry.Tool = name
+			entry.Arguments = truncateArguments(rawArgs)
 			if !ok {
 				entry.Decision = DecisionDeny
 				entry.Reason = ReasonMalformedJSONRPC

--- a/internal/mcp/intercept_test.go
+++ b/internal/mcp/intercept_test.go
@@ -61,6 +61,7 @@ func TestEvaluateRequestAllow(t *testing.T) {
 	require.Equal(t, DecisionAllow, tr.Messages[0].Decision)
 	require.Equal(t, "search_repositories", tr.Messages[0].Tool)
 	require.Equal(t, map[string]any{"q": "foo"}, tr.Messages[0].Arguments)
+	require.Empty(t, tr.Messages[0].RawArguments)
 }
 
 func TestEvaluateRequestArgumentsTruncated(t *testing.T) {
@@ -74,10 +75,9 @@ func TestEvaluateRequestArgumentsTruncated(t *testing.T) {
 	_, err := p.EvaluateRequest(s, req, tr)
 	require.NoError(t, err)
 	require.Len(t, tr.Messages, 1)
-	got, ok := tr.Messages[0].Arguments.(string)
-	require.True(t, ok, "oversize arguments must fall back to a truncated string")
-	require.Len(t, got, AuditArgumentsMaxLen)
-	require.True(t, strings.HasSuffix(got, "..."))
+	require.Nil(t, tr.Messages[0].Arguments)
+	require.Len(t, tr.Messages[0].RawArguments, AuditArgumentsMaxLen)
+	require.True(t, strings.HasSuffix(tr.Messages[0].RawArguments, "..."))
 }
 
 func TestEvaluateRequestDenyToolNotAllowed(t *testing.T) {

--- a/internal/mcp/intercept_test.go
+++ b/internal/mcp/intercept_test.go
@@ -60,7 +60,7 @@ func TestEvaluateRequestAllow(t *testing.T) {
 	require.Len(t, tr.Messages, 1)
 	require.Equal(t, DecisionAllow, tr.Messages[0].Decision)
 	require.Equal(t, "search_repositories", tr.Messages[0].Tool)
-	require.Equal(t, `{"q":"foo"}`, tr.Messages[0].Arguments)
+	require.Equal(t, map[string]any{"q": "foo"}, tr.Messages[0].Arguments)
 }
 
 func TestEvaluateRequestArgumentsTruncated(t *testing.T) {
@@ -74,8 +74,10 @@ func TestEvaluateRequestArgumentsTruncated(t *testing.T) {
 	_, err := p.EvaluateRequest(s, req, tr)
 	require.NoError(t, err)
 	require.Len(t, tr.Messages, 1)
-	require.Len(t, tr.Messages[0].Arguments, AuditArgumentsMaxLen)
-	require.True(t, strings.HasSuffix(tr.Messages[0].Arguments, "..."))
+	got, ok := tr.Messages[0].Arguments.(string)
+	require.True(t, ok, "oversize arguments must fall back to a truncated string")
+	require.Len(t, got, AuditArgumentsMaxLen)
+	require.True(t, strings.HasSuffix(got, "..."))
 }
 
 func TestEvaluateRequestDenyToolNotAllowed(t *testing.T) {

--- a/internal/mcp/intercept_test.go
+++ b/internal/mcp/intercept_test.go
@@ -60,6 +60,22 @@ func TestEvaluateRequestAllow(t *testing.T) {
 	require.Len(t, tr.Messages, 1)
 	require.Equal(t, DecisionAllow, tr.Messages[0].Decision)
 	require.Equal(t, "search_repositories", tr.Messages[0].Tool)
+	require.Equal(t, `{"q":"foo"}`, tr.Messages[0].Arguments)
+}
+
+func TestEvaluateRequestArgumentsTruncated(t *testing.T) {
+	p := newTestPolicy(t)
+	s := p.MatchServer(newJSONRequest(t, "{}"))
+
+	huge := strings.Repeat("x", 1000)
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories","arguments":{"q":"` + huge + `"}}}`
+	req := newJSONRequest(t, body)
+	tr := &Trace{Server: s.Name}
+	_, err := p.EvaluateRequest(s, req, tr)
+	require.NoError(t, err)
+	require.Len(t, tr.Messages, 1)
+	require.Len(t, tr.Messages[0].Arguments, AuditArgumentsMaxLen)
+	require.True(t, strings.HasSuffix(tr.Messages[0].Arguments, "..."))
 }
 
 func TestEvaluateRequestDenyToolNotAllowed(t *testing.T) {

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -98,31 +98,33 @@ func batchErrorResponseBody(ids []json.RawMessage, code int, message string) ([]
 	return json.Marshal(resps)
 }
 
-// extractToolCallName pulls the tool name and decoded arguments from a
-// tools/call params payload. Returns ("", nil, false) when the params do not
-// carry a recognizable tool name (caller treats this as malformed).
-func extractToolCallName(params json.RawMessage) (string, any, bool) {
+// extractToolCallName pulls the tool name, decoded arguments, and the raw
+// arguments JSON from a tools/call params payload. Returns ("", nil, nil,
+// false) when the params do not carry a recognizable tool name (caller treats
+// this as malformed). rawArgs may be non-nil even when args is nil (e.g. the
+// arguments field is present but not a JSON object the policy can evaluate).
+func extractToolCallName(params json.RawMessage) (string, any, json.RawMessage, bool) {
 	if len(params) == 0 {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 	var p struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
 	}
 	if err := json.Unmarshal(params, &p); err != nil {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 	if p.Name == "" {
-		return "", nil, false
+		return "", nil, nil, false
 	}
 	if len(p.Arguments) == 0 {
-		return p.Name, nil, true
+		return p.Name, nil, nil, true
 	}
 	var args any
 	if err := json.Unmarshal(p.Arguments, &args); err != nil {
-		return p.Name, nil, true
+		return p.Name, nil, p.Arguments, true
 	}
-	return p.Name, args, true
+	return p.Name, args, p.Arguments, true
 }
 
 // filterToolsListResult takes a tools/list result payload and returns a new

--- a/internal/mcp/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc_test.go
@@ -40,17 +40,18 @@ func TestDecodeJSONRPCMalformed(t *testing.T) {
 
 func TestExtractToolCallName(t *testing.T) {
 	params := json.RawMessage(`{"name":"create_issue","arguments":{"owner":"ironsh"}}`)
-	name, args, ok := extractToolCallName(params)
+	name, args, rawArgs, ok := extractToolCallName(params)
 	require.True(t, ok)
 	require.Equal(t, "create_issue", name)
 	m, ok := args.(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "ironsh", m["owner"])
+	require.Equal(t, `{"owner":"ironsh"}`, string(rawArgs))
 
-	_, _, ok = extractToolCallName(json.RawMessage(`{}`))
+	_, _, _, ok = extractToolCallName(json.RawMessage(`{}`))
 	require.False(t, ok)
 
-	_, _, ok = extractToolCallName(nil)
+	_, _, _, ok = extractToolCallName(nil)
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
Tools/call audit entries now carry the raw JSON of the call's arguments, truncated to 64 bytes with a `...` suffix when over the cap so large payloads (file contents, long SQL, etc.) don't bloat audit records.