### PR TITLE
feat(proxy): detect client-cancelled requests and log as 200

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -305,10 +305,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	// Run request transforms
 	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &result.RequestTransforms); err != nil {
-		if isClientCancel(r, err) {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusOK
-			result.ClientCanceled = true
+		if markIfClientCancel(r, err, result) {
 			return
 		}
 		result.Action = transform.ActionContinue // error, not reject
@@ -336,10 +333,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 			result.MCP = mcpTrace
 			rejectResp, err := mcpPolicy.EvaluateRequest(s, r, mcpTrace)
 			if err != nil {
-				if isClientCancel(r, err) {
-					result.Action = transform.ActionContinue
-					result.StatusCode = http.StatusOK
-					result.ClientCanceled = true
+				if markIfClientCancel(r, err, result) {
 					return
 				}
 				result.Action = transform.ActionContinue
@@ -396,10 +390,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	resp, err := p.doUpstream(upstreamReq)
 	if err != nil {
-		if isClientCancel(r, err) {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusOK
-			result.ClientCanceled = true
+		if markIfClientCancel(r, err, result) {
 			return
 		}
 		result.Action = transform.ActionContinue
@@ -416,10 +407,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	// Run response transforms
 	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &result.ResponseTransforms)
 	if err != nil {
-		if isClientCancel(r, err) {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusOK
-			result.ClientCanceled = true
+		if markIfClientCancel(r, err, result) {
 			return
 		}
 		result.Action = transform.ActionContinue
@@ -659,16 +647,18 @@ func (p *Proxy) doUpstream(req *http.Request) (*http.Response, error) {
 	return p.transport.RoundTrip(req)
 }
 
-// isClientCancel reports whether err arose because the client closed its
-// connection (request context cancelled), rather than a real upstream or
-// transform failure. The canonical signal is the request context being
-// cancelled; we also accept errors.Is(err, context.Canceled) so a wrapped
-// sentinel from a transform that doesn't observe r.Context() still gets caught.
-func isClientCancel(r *http.Request, err error) bool {
-	if errors.Is(r.Context().Err(), context.Canceled) {
-		return true
+// markIfClientCancel records a client-initiated cancellation on result and
+// returns true; callers should then return without writing a 502. The wrapped
+// errors.Is on err catches transforms that report context.Canceled without
+// observing r.Context() directly.
+func markIfClientCancel(r *http.Request, err error, result *transform.PipelineResult) bool {
+	if !errors.Is(r.Context().Err(), context.Canceled) && !errors.Is(err, context.Canceled) {
+		return false
 	}
-	return errors.Is(err, context.Canceled)
+	result.Action = transform.ActionContinue
+	result.StatusCode = http.StatusOK
+	result.ClientCanceled = true
+	return true
 }
 
 func copyHeaders(dst, src http.Header) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -305,6 +305,12 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	// Run request transforms
 	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &result.RequestTransforms); err != nil {
+		if isClientCancel(r, err) {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusOK
+			result.ClientCanceled = true
+			return
+		}
 		result.Action = transform.ActionContinue // error, not reject
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
@@ -330,6 +336,12 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 			result.MCP = mcpTrace
 			rejectResp, err := mcpPolicy.EvaluateRequest(s, r, mcpTrace)
 			if err != nil {
+				if isClientCancel(r, err) {
+					result.Action = transform.ActionContinue
+					result.StatusCode = http.StatusOK
+					result.ClientCanceled = true
+					return
+				}
 				result.Action = transform.ActionContinue
 				result.StatusCode = http.StatusBadGateway
 				result.Err = err
@@ -384,6 +396,12 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	resp, err := p.doUpstream(upstreamReq)
 	if err != nil {
+		if isClientCancel(r, err) {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusOK
+			result.ClientCanceled = true
+			return
+		}
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
@@ -398,6 +416,12 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	// Run response transforms
 	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &result.ResponseTransforms)
 	if err != nil {
+		if isClientCancel(r, err) {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusOK
+			result.ClientCanceled = true
+			return
+		}
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
@@ -633,6 +657,18 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 
 func (p *Proxy) doUpstream(req *http.Request) (*http.Response, error) {
 	return p.transport.RoundTrip(req)
+}
+
+// isClientCancel reports whether err arose because the client closed its
+// connection (request context cancelled), rather than a real upstream or
+// transform failure. The canonical signal is the request context being
+// cancelled; we also accept errors.Is(err, context.Canceled) so a wrapped
+// sentinel from a transform that doesn't observe r.Context() still gets caught.
+func isClientCancel(r *http.Request, err error) bool {
+	if errors.Is(r.Context().Err(), context.Canceled) {
+		return true
+	}
+	return errors.Is(err, context.Canceled)
 }
 
 func copyHeaders(dst, src http.Header) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -15,8 +15,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -263,6 +265,92 @@ func TestHTTPSProxy_SNIHostMismatch(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestHTTPProxy_ClientCancel(t *testing.T) {
+	// Upstream that blocks on a release channel so the client has a window to
+	// cancel its context while the proxy is mid-RoundTrip.
+	release := make(chan struct{})
+	reached := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(reached)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	defer close(release)
+
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
+
+	var mu sync.Mutex
+	var results []transform.PipelineResult
+	done := make(chan struct{})
+	pipeline.SetAuditFunc(func(r *transform.PipelineResult) {
+		mu.Lock()
+		results = append(results, *r)
+		mu.Unlock()
+		close(done)
+	})
+
+	p := New(Options{
+		HTTPAddr: "127.0.0.1:0",
+		Pipeline: transform.NewPipelineHolder(pipeline),
+		Logger:   testLogger(),
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = p.httpServer.Serve(ln) }()
+	t.Cleanup(func() { _ = p.httpServer.Close() })
+	proxyAddr := ln.Addr().String()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: proxyAddr}),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, "GET", upstream.URL+"/slow", nil)
+	require.NoError(t, err)
+
+	reqErr := make(chan error, 1)
+	go func() {
+		resp, err := client.Do(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		reqErr <- err
+	}()
+
+	// Wait for the proxy to reach upstream, then cancel.
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream never reached")
+	}
+	cancel()
+
+	select {
+	case err := <-reqErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("client Do never returned")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("audit never fired")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, results, 1)
+	r := results[0]
+	require.True(t, r.ClientCanceled)
+	require.Equal(t, http.StatusOK, r.StatusCode)
+	require.NoError(t, r.Err)
+	require.Equal(t, transform.ActionContinue, r.Action)
 }
 
 func TestHTTPProxy_UpstreamError(t *testing.T) {

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -22,6 +22,9 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 		if result.Err != nil {
 			action = "error"
 		}
+		if result.ClientCanceled {
+			action = "client_cancel"
+		}
 
 		attrs := []any{
 			slog.Group("audit",
@@ -79,6 +82,8 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 		switch {
 		case result.Err != nil:
 			logger.Error("request", attrs...)
+		case result.ClientCanceled:
+			logger.Info("request", attrs...)
 		case result.Action == ActionReject:
 			logger.Warn("request", attrs...)
 		default:

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -152,6 +152,31 @@ func TestAudit_ErroredRequest(t *testing.T) {
 	require.Equal(t, float64(502), audit["status_code"])
 }
 
+func TestAudit_ClientCanceled(t *testing.T) {
+	result := &PipelineResult{
+		Host:           "api.openai.com",
+		Method:         "POST",
+		Path:           "/v1/chat/completions",
+		RemoteAddr:     "10.16.0.5:43215",
+		SNI:            "api.openai.com",
+		StartedAt:      time.Now(),
+		Duration:       3200 * time.Microsecond,
+		Action:         ActionContinue,
+		StatusCode:     200,
+		ClientCanceled: true,
+	}
+
+	parsed, raw := captureAuditLog(result)
+
+	require.Equal(t, "INFO", parsed["level"])
+	require.Equal(t, "request", parsed["msg"])
+	require.NotContains(t, raw, "\"error\"")
+
+	audit := parsed["audit"].(map[string]any)
+	require.Equal(t, "client_cancel", audit["action"])
+	require.Equal(t, float64(200), audit["status_code"])
+}
+
 func TestAudit_TransformTraceOrder(t *testing.T) {
 	result := &PipelineResult{
 		Host:       "example.com",

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -119,9 +119,8 @@ type PipelineResult struct {
 
 	Err error
 
-	// ClientCanceled is set when the request ended because the client closed
-	// its connection (request context cancelled). Distinguishes "client went
-	// away" from real upstream/transform errors so dashboards stay clean.
+	// ClientCanceled distinguishes client-initiated disconnect from a real
+	// failure so audit dashboards don't see phantom upstream errors.
 	ClientCanceled bool
 }
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -118,6 +118,11 @@ type PipelineResult struct {
 	MCP MCPAudit
 
 	Err error
+
+	// ClientCanceled is set when the request ended because the client closed
+	// its connection (request context cancelled). Distinguishes "client went
+	// away" from real upstream/transform errors so dashboards stay clean.
+	ClientCanceled bool
 }
 
 // MCPAudit is the read-only view of the MCP interceptor's per-request audit


### PR DESCRIPTION
When a client closes its connection mid-request, the request context is cancelled and upstream RoundTrip returns context.Canceled, which previously surfaced as a 502 error in audit logs. Detect this in handleHTTP, set status 200, record a new PipelineResult.ClientCanceled flag, and emit the audit record at INFO with action=client_cancel so dashboards stop seeing phantom upstream failures.