### PR TITLE
feat(gcpauth): inject GCP service account OAuth2 tokens via MITM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_CONNECT_HOST: http://localhost:8080
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
-          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
+          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64 }}
         run: |
           if [ -n "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" ]; then
             keyfile="$RUNNER_TEMP/gcp-bq-sa-key.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,26 @@ jobs:
           docker compose logs
           exit 1
 
+      # The BigQuery service account key is stored base64-encoded in
+      # secrets so GitHub Actions' substring-based secret redaction doesn't
+      # mangle unrelated job output that happens to share fragments with the
+      # JSON keyfile (project id, common phrases, etc.). Decode it here and
+      # expose the JSON to the test step as a normal env var.
+      - name: Decode BigQuery service account key
+        env:
+          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64 }}
+        run: |
+          if [ -z "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" ]; then
+            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64 not set; BigQuery test will skip"
+            exit 0
+          fi
+          {
+            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY<<__IRON_EOF__"
+            printf '%s' "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" | base64 -d
+            echo
+            echo "__IRON_EOF__"
+          } >> "$GITHUB_ENV"
+
       - name: Run integration tests
         run: go test -v -race -count=1 ./integration_test/ -integration
         env:
@@ -85,7 +105,6 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_CONNECT_HOST: http://localhost:8080
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
-          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
 
       - name: Dump 1Password Connect logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,15 @@ jobs:
       # expose the JSON to the test step as a normal env var.
       - name: Decode BigQuery service account key
         env:
-          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64 }}
+          BQ_SA_KEY_ENCODED: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
         run: |
-          if [ -z "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" ]; then
-            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64 not set; BigQuery test will skip"
+          if [ -z "$BQ_SA_KEY_ENCODED" ]; then
+            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY not set; BigQuery test will skip"
             exit 0
           fi
           {
             echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY<<__IRON_EOF__"
-            printf '%s' "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" | base64 -d
+            printf '%s' "$BQ_SA_KEY_ENCODED" | base64 -d
             echo
             echo "__IRON_EOF__"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_CONNECT_HOST: http://localhost:8080
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
+          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
 
       - name: Dump 1Password Connect logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,28 +74,13 @@ jobs:
           docker compose logs
           exit 1
 
-      # The BigQuery service account key is stored base64-encoded in
-      # secrets so GitHub Actions' substring-based secret redaction doesn't
-      # mangle unrelated job output that happens to share fragments with the
-      # JSON keyfile (project id, common phrases, etc.). Decode it here and
-      # expose the JSON to the test step as a normal env var.
-      - name: Decode BigQuery service account key
-        env:
-          BQ_SA_KEY_ENCODED: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
-        run: |
-          if [ -z "$BQ_SA_KEY_ENCODED" ]; then
-            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY not set; BigQuery test will skip"
-            exit 0
-          fi
-          {
-            echo "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY<<__IRON_EOF__"
-            printf '%s' "$BQ_SA_KEY_ENCODED" | base64 -d
-            echo
-            echo "__IRON_EOF__"
-          } >> "$GITHUB_ENV"
-
       - name: Run integration tests
-        run: go test -v -race -count=1 ./integration_test/ -integration
+        # The BigQuery service account key is stored base64-encoded in
+        # secrets so GitHub Actions' substring-based redaction can't mangle
+        # unrelated job output that happens to share fragments with the JSON
+        # keyfile. We decode it inline to a temp file and export only the
+        # path — the decoded JSON never appears in the env block GitHub
+        # prints at step start.
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -105,6 +90,15 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_CONNECT_HOST: http://localhost:8080
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
+          GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64: ${{ secrets.GCP_BIGQUERY_SERVICE_ACCOUNT_KEY }}
+        run: |
+          if [ -n "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" ]; then
+            keyfile="$RUNNER_TEMP/gcp-bq-sa-key.json"
+            printf '%s' "$GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_B64" | base64 -d > "$keyfile"
+            chmod 600 "$keyfile"
+            export GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE="$keyfile"
+          fi
+          go test -v -race -count=1 ./integration_test/ -integration
 
       - name: Dump 1Password Connect logs
         if: failure()

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -32,6 +32,7 @@ import (
 	// Register built-in transforms.
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
+	_ "github.com/ironsh/iron-proxy/internal/transform/gcpauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -43,5 +43,4 @@ domains:
   - "ironsh.1password.com"
 
   # GCP (for gcp_auth integration tests: oauth2 token exchange + BigQuery API)
-  - "oauth2.googleapis.com"
-  - "bigquery.googleapis.com"
+  - "*.googleapis.com"

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -41,3 +41,7 @@ domains:
 
   # 1Password (for 1password secret source integration tests)
   - "ironsh.1password.com"
+
+  # GCP (for gcp_auth integration tests: oauth2 token exchange + BigQuery API)
+  - "oauth2.googleapis.com"
+  - "bigquery.googleapis.com"

--- a/go.mod
+++ b/go.mod
@@ -25,12 +25,14 @@ require (
 	go.opentelemetry.io/otel/log v0.19.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
+	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/1Password/connect-sdk-go v1.5.3 h1:KyjJ+kCKj6BwB2Y8tPM1Ixg5uIS6HsB0uWA8U38p/Uk=
@@ -234,6 +236,8 @@ golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/integration_test/gcp_auth_bigquery_test.go
+++ b/integration_test/gcp_auth_bigquery_test.go
@@ -108,7 +108,5 @@ func TestGCPAuthBigQuery(t *testing.T) {
 	require.True(t, qr.JobComplete, "BigQuery job not complete in synchronous response: %s", string(body))
 	require.NotEmpty(t, qr.Rows, "no rows returned from test_dataset.test_table")
 	require.NotEmpty(t, qr.Rows[0].F, "first row has no fields")
-	require.NotNil(t, qr.Rows[0].F[0].V, "first cell of first row is nil")
-
-	t.Logf("test_dataset.test_table.test_field first value: %v", qr.Rows[0].F[0].V)
+	require.Equal(t, "foo", qr.Rows[0].F[0].V, "test_dataset.test_table.test_field first value")
 }

--- a/integration_test/gcp_auth_bigquery_test.go
+++ b/integration_test/gcp_auth_bigquery_test.go
@@ -1,0 +1,105 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCPAuthBigQuery boots the proxy with the gcp_auth transform configured
+// to mint OAuth2 access tokens from the service account JSON in
+// GCP_BIGQUERY_SERVICE_ACCOUNT_KEY, then runs a BigQuery query through the
+// proxy and asserts the first cell of the first row is returned. The client
+// sends no Authorization header — the proxy injects one after minting a token
+// from the keyfile.
+//
+// Requires a BigQuery table at test_dataset.test_table with a test_field
+// column readable by the configured service account.
+func TestGCPAuthBigQuery(t *testing.T) {
+	keyJSON := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY")
+	if keyJSON == "" {
+		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY not set")
+	}
+
+	var meta struct {
+		ProjectID string `json:"project_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(keyJSON), &meta))
+	require.NotEmpty(t, meta.ProjectID, "service account JSON missing project_id")
+
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+	cfgPath := renderConfig(t, tmpDir, "gcp_auth_bigquery.yaml", nil)
+
+	proxy := startProxy(t, binary, cfgPath, []string{
+		"GCP_BIGQUERY_SERVICE_ACCOUNT_KEY=" + keyJSON,
+	})
+
+	// Trust the proxy's CA so the client accepts the MITM cert it presents
+	// for bigquery.googleapis.com.
+	caPath := filepath.Join(repoRoot(t), "tmp", "ca.crt")
+	caPEM, err := os.ReadFile(caPath)
+	require.NoError(t, err, "expected proxy CA at %s — generate it with: ./iron-proxy generate-ca -outdir tmp -alg ed25519", caPath)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+
+	proxyURL, err := url.Parse("http://" + proxy.HTTPAddr)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+
+	queryBody, err := json.Marshal(map[string]any{
+		"query":        "SELECT test_field FROM test_dataset.test_table LIMIT 1",
+		"useLegacySql": false,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	endpoint := "https://bigquery.googleapis.com/bigquery/v2/projects/" + meta.ProjectID + "/queries"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(queryBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "BigQuery response: %s", string(body))
+
+	var qr struct {
+		JobComplete bool `json:"jobComplete"`
+		Rows        []struct {
+			F []struct {
+				V any `json:"v"`
+			} `json:"f"`
+		} `json:"rows"`
+	}
+	require.NoError(t, json.Unmarshal(body, &qr))
+	require.True(t, qr.JobComplete, "BigQuery job not complete in synchronous response: %s", string(body))
+	require.NotEmpty(t, qr.Rows, "no rows returned from test_dataset.test_table")
+	require.NotEmpty(t, qr.Rows[0].F, "first row has no fields")
+	require.NotNil(t, qr.Rows[0].F[0].V, "first cell of first row is nil")
+
+	t.Logf("test_dataset.test_table.test_field first value: %v", qr.Rows[0].F[0].V)
+}

--- a/integration_test/gcp_auth_bigquery_test.go
+++ b/integration_test/gcp_auth_bigquery_test.go
@@ -54,7 +54,10 @@ func TestGCPAuthBigQuery(t *testing.T) {
 	pool := x509.NewCertPool()
 	require.True(t, pool.AppendCertsFromPEM(caPEM))
 
-	proxyURL, err := url.Parse("http://" + proxy.HTTPAddr)
+	// CONNECT requests for HTTPS upstreams go to the tunnel listener, not the
+	// HTTP proxy listener.
+	tunnelAddr := proxy.AddrFor(t, "tunnel proxy starting")
+	proxyURL, err := url.Parse("http://" + tunnelAddr)
 	require.NoError(t, err)
 
 	client := &http.Client{

--- a/integration_test/gcp_auth_bigquery_test.go
+++ b/integration_test/gcp_auth_bigquery_test.go
@@ -18,33 +18,39 @@ import (
 )
 
 // TestGCPAuthBigQuery boots the proxy with the gcp_auth transform configured
-// to mint OAuth2 access tokens from the service account JSON in
-// GCP_BIGQUERY_SERVICE_ACCOUNT_KEY, then runs a BigQuery query through the
-// proxy and asserts the first cell of the first row is returned. The client
-// sends no Authorization header — the proxy injects one after minting a token
-// from the keyfile.
+// to mint OAuth2 access tokens from the service account JSON keyfile at
+// GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE, then runs a BigQuery query through
+// the proxy and asserts the first cell of the first row is returned. The
+// client sends no Authorization header — the proxy injects one after minting
+// a token from the keyfile.
+//
+// The keyfile is passed as a file path rather than an env var so the decoded
+// JSON doesn't leak into GitHub Actions' env block, which is printed at the
+// start of every step.
 //
 // Requires a BigQuery table at test_dataset.test_table with a test_field
 // column readable by the configured service account.
 func TestGCPAuthBigQuery(t *testing.T) {
-	keyJSON := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY")
-	if keyJSON == "" {
-		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY not set")
+	keyfilePath := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
+	if keyfilePath == "" {
+		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE not set")
 	}
+	keyJSON, err := os.ReadFile(keyfilePath)
+	require.NoError(t, err, "reading GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
 
 	var meta struct {
 		ProjectID string `json:"project_id"`
 	}
-	require.NoError(t, json.Unmarshal([]byte(keyJSON), &meta))
+	require.NoError(t, json.Unmarshal(keyJSON, &meta))
 	require.NotEmpty(t, meta.ProjectID, "service account JSON missing project_id")
 
 	tmpDir := t.TempDir()
 	binary := proxyBinary(t)
-	cfgPath := renderConfig(t, tmpDir, "gcp_auth_bigquery.yaml", nil)
+	cfgPath := renderConfig(t, tmpDir, "gcp_auth_bigquery.yaml", struct {
+		KeyfilePath string
+	}{KeyfilePath: keyfilePath})
 
-	proxy := startProxy(t, binary, cfgPath, []string{
-		"GCP_BIGQUERY_SERVICE_ACCOUNT_KEY=" + keyJSON,
-	})
+	proxy := startProxy(t, binary, cfgPath, nil)
 
 	// Trust the proxy's CA so the client accepts the MITM cert it presents
 	// for bigquery.googleapis.com.

--- a/integration_test/testdata/gcp_auth_bigquery.yaml
+++ b/integration_test/testdata/gcp_auth_bigquery.yaml
@@ -1,0 +1,35 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "bigquery.googleapis.com"
+
+  - name: gcp_auth
+    config:
+      keyfile:
+        type: env
+        var: GCP_BIGQUERY_SERVICE_ACCOUNT_KEY
+      scopes:
+        - "https://www.googleapis.com/auth/bigquery"
+      rules:
+        - host: "bigquery.googleapis.com"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/integration_test/testdata/gcp_auth_bigquery.yaml
+++ b/integration_test/testdata/gcp_auth_bigquery.yaml
@@ -5,6 +5,7 @@ dns:
 proxy:
   http_listen: "127.0.0.1:0"
   https_listen: "127.0.0.1:0"
+  tunnel_listen: "127.0.0.1:0"
   max_request_body_bytes: 1048576
   upstream_deny_cidrs: []
 

--- a/integration_test/testdata/gcp_auth_bigquery.yaml
+++ b/integration_test/testdata/gcp_auth_bigquery.yaml
@@ -21,9 +21,7 @@ transforms:
 
   - name: gcp_auth
     config:
-      keyfile:
-        type: env
-        var: GCP_BIGQUERY_SERVICE_ACCOUNT_KEY
+      keyfile_path: "{{ .KeyfilePath }}"
       scopes:
         - "https://www.googleapis.com/auth/bigquery"
       rules:

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -33,28 +33,19 @@ func init() {
 	transform.Register("gcp_auth", factory)
 }
 
-type fallbackMode int
-
-const (
-	fallbackDeny fallbackMode = iota
-	fallbackSkip
-)
-
 type config struct {
 	KeyfilePath string                 `yaml:"keyfile_path,omitempty"`
 	Keyfile     yaml.Node              `yaml:"keyfile,omitempty"`
 	Scopes      []string               `yaml:"scopes"`
 	Rules       []hostmatch.RuleConfig `yaml:"rules"`
-	Fallback    string                 `yaml:"fallback,omitempty"`
 }
 
 // GCPAuth is the transform.
 type GCPAuth struct {
-	scopes   []string
-	rules    []hostmatch.Rule // empty = apply to all requests
-	loadKey  func(ctx context.Context) ([]byte, error)
-	fallback fallbackMode
-	logger   *slog.Logger
+	scopes  []string
+	rules   []hostmatch.Rule // empty = apply to all requests
+	loadKey func(ctx context.Context) ([]byte, error)
+	logger  *slog.Logger
 
 	mu    sync.Mutex
 	creds *google.Credentials
@@ -81,10 +72,6 @@ func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte,
 	}
 	if len(c.Scopes) == 0 {
 		return nil, fmt.Errorf("gcp_auth: at least one entry in \"scopes\" is required")
-	}
-	fb, err := parseFallback(c.Fallback)
-	if err != nil {
-		return nil, fmt.Errorf("gcp_auth: %w", err)
 	}
 	rules, err := hostmatch.CompileRules(c.Rules, "gcp_auth")
 	if err != nil {
@@ -116,22 +103,11 @@ func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte,
 	}
 
 	return &GCPAuth{
-		scopes:   c.Scopes,
-		rules:    rules,
-		loadKey:  load,
-		fallback: fb,
-		logger:   logger,
+		scopes:  c.Scopes,
+		rules:   rules,
+		loadKey: load,
+		logger:  logger,
 	}, nil
-}
-
-func parseFallback(s string) (fallbackMode, error) {
-	switch s {
-	case "", "deny":
-		return fallbackDeny, nil
-	case "skip":
-		return fallbackSkip, nil
-	}
-	return 0, fmt.Errorf("invalid fallback %q: must be \"deny\" or \"skip\"", s)
 }
 
 func (g *GCPAuth) Name() string { return "gcp_auth" }
@@ -144,10 +120,6 @@ func (g *GCPAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	tok, err := g.mintToken(ctx)
 	if err != nil {
 		tctx.Annotate("error", err.Error())
-		if g.fallback == fallbackSkip {
-			tctx.Annotate("fallback", "skip")
-			return &transform.TransformResult{Action: transform.ActionContinue}, nil
-		}
 		tctx.Annotate("rejected", "token_unavailable")
 		return &transform.TransformResult{Action: transform.ActionReject}, nil
 	}

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sync"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"gopkg.in/yaml.v3"
 
@@ -47,9 +48,9 @@ type GCPAuth struct {
 	loadKey func(ctx context.Context) ([]byte, error)
 	logger  *slog.Logger
 
-	mu    sync.Mutex
-	creds *google.Credentials
-	email string
+	mu          sync.Mutex
+	tokenSource oauth2.TokenSource
+	email       string
 }
 
 // sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
@@ -137,11 +138,11 @@ func (g *GCPAuth) TransformResponse(context.Context, *transform.TransformContext
 }
 
 func (g *GCPAuth) mintToken(ctx context.Context) (string, error) {
-	creds, err := g.loadCreds(ctx)
+	ts, err := g.loadTokenSource(ctx)
 	if err != nil {
 		return "", err
 	}
-	tok, err := creds.TokenSource.Token()
+	tok, err := ts.Token()
 	if err != nil {
 		return "", fmt.Errorf("minting GCP access token: %w", err)
 	}
@@ -151,17 +152,22 @@ func (g *GCPAuth) mintToken(ctx context.Context) (string, error) {
 	return tok.AccessToken, nil
 }
 
-func (g *GCPAuth) loadCreds(ctx context.Context) (*google.Credentials, error) {
+func (g *GCPAuth) loadTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.creds != nil {
-		return g.creds, nil
+	if g.tokenSource != nil {
+		return g.tokenSource, nil
 	}
 	keyJSON, err := g.loadKey(ctx)
 	if err != nil {
 		return nil, err
 	}
-	creds, err := google.CredentialsFromJSON(ctx, keyJSON, g.scopes...)
+	// JWTConfigFromJSON is the narrowed, non-deprecated form of credential
+	// loading. It only accepts service-account JSON keyfiles, which is what
+	// gcp_auth is designed for; we don't want to silently accept the broader
+	// set of credential configurations (workload identity federation,
+	// external_account, etc.) that CredentialsFromJSON allows.
+	cfg, err := google.JWTConfigFromJSON(keyJSON, g.scopes...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing GCP service account keyfile: %w", err)
 	}
@@ -171,6 +177,6 @@ func (g *GCPAuth) loadCreds(ctx context.Context) (*google.Credentials, error) {
 	if err := json.Unmarshal(keyJSON, &meta); err == nil {
 		g.email = meta.ClientEmail
 	}
-	g.creds = creds
-	return g.creds, nil
+	g.tokenSource = cfg.TokenSource(ctx)
+	return g.tokenSource, nil
 }

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -1,0 +1,204 @@
+// Package gcpauth implements a transform that mints short-lived GCP OAuth2
+// access tokens from a service account keyfile and injects them as
+// Authorization: Bearer headers on matching requests.
+//
+// The keyfile can be loaded from disk (keyfile_path) or from any secret
+// source registered with the secrets package (env, aws_sm, aws_ssm,
+// 1password, 1password_connect) via a nested keyfile block. Token minting,
+// caching, and refresh are delegated to golang.org/x/oauth2/google — the same
+// code path the official GCP SDKs use.
+//
+// Like all header-injecting transforms, this requires MITM mode; sni-only
+// mode has no way to rewrite headers.
+package gcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+
+	"golang.org/x/oauth2/google"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+func init() {
+	transform.Register("gcp_auth", factory)
+}
+
+type fallbackMode int
+
+const (
+	fallbackDeny fallbackMode = iota
+	fallbackSkip
+)
+
+type config struct {
+	KeyfilePath string                 `yaml:"keyfile_path,omitempty"`
+	Keyfile     yaml.Node              `yaml:"keyfile,omitempty"`
+	Scopes      []string               `yaml:"scopes"`
+	Rules       []hostmatch.RuleConfig `yaml:"rules"`
+	Fallback    string                 `yaml:"fallback,omitempty"`
+}
+
+// GCPAuth is the transform.
+type GCPAuth struct {
+	scopes   []string
+	rules    []hostmatch.Rule // empty = apply to all requests
+	loadKey  func(ctx context.Context) ([]byte, error)
+	fallback fallbackMode
+	logger   *slog.Logger
+
+	mu    sync.Mutex
+	creds *google.Credentials
+	email string
+}
+
+// sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
+// can inject a stub instead of constructing real source backends.
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing gcp_auth config: %w", err)
+	}
+	return newFromConfig(c, logger, os.ReadFile, secrets.BuildSource)
+}
+
+func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte, error), buildSource sourceBuilder) (*GCPAuth, error) {
+	hasPath := c.KeyfilePath != ""
+	hasNested := c.Keyfile.Kind != 0
+	if hasPath == hasNested {
+		return nil, fmt.Errorf("gcp_auth: requires exactly one of \"keyfile_path\" or \"keyfile\"")
+	}
+	if len(c.Scopes) == 0 {
+		return nil, fmt.Errorf("gcp_auth: at least one entry in \"scopes\" is required")
+	}
+	fb, err := parseFallback(c.Fallback)
+	if err != nil {
+		return nil, fmt.Errorf("gcp_auth: %w", err)
+	}
+	rules, err := hostmatch.CompileRules(c.Rules, "gcp_auth")
+	if err != nil {
+		return nil, err
+	}
+
+	var load func(context.Context) ([]byte, error)
+	if hasPath {
+		path := c.KeyfilePath
+		load = func(context.Context) ([]byte, error) {
+			data, err := readFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("reading GCP keyfile %q: %w", path, err)
+			}
+			return data, nil
+		}
+	} else {
+		nested, err := buildSource(c.Keyfile, logger)
+		if err != nil {
+			return nil, fmt.Errorf("gcp_auth: building keyfile source: %w", err)
+		}
+		load = func(ctx context.Context) ([]byte, error) {
+			v, err := nested.Get(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("loading GCP keyfile from %q: %w", nested.Name(), err)
+			}
+			return []byte(v), nil
+		}
+	}
+
+	return &GCPAuth{
+		scopes:   c.Scopes,
+		rules:    rules,
+		loadKey:  load,
+		fallback: fb,
+		logger:   logger,
+	}, nil
+}
+
+func parseFallback(s string) (fallbackMode, error) {
+	switch s {
+	case "", "deny":
+		return fallbackDeny, nil
+	case "skip":
+		return fallbackSkip, nil
+	}
+	return 0, fmt.Errorf("invalid fallback %q: must be \"deny\" or \"skip\"", s)
+}
+
+func (g *GCPAuth) Name() string { return "gcp_auth" }
+
+func (g *GCPAuth) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(g.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	tok, err := g.mintToken(ctx)
+	if err != nil {
+		tctx.Annotate("error", err.Error())
+		if g.fallback == fallbackSkip {
+			tctx.Annotate("fallback", "skip")
+			return &transform.TransformResult{Action: transform.ActionContinue}, nil
+		}
+		tctx.Annotate("rejected", "token_unavailable")
+		return &transform.TransformResult{Action: transform.ActionReject}, nil
+	}
+
+	req.Header.Set("Authorization", "Bearer "+tok)
+	if g.email != "" {
+		tctx.Annotate("service_account", g.email)
+	}
+	tctx.Annotate("injected", []string{"header:Authorization"})
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (g *GCPAuth) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (g *GCPAuth) mintToken(ctx context.Context) (string, error) {
+	creds, err := g.loadCreds(ctx)
+	if err != nil {
+		return "", err
+	}
+	tok, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("minting GCP access token: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return "", fmt.Errorf("GCP token source returned empty access token")
+	}
+	return tok.AccessToken, nil
+}
+
+func (g *GCPAuth) loadCreds(ctx context.Context) (*google.Credentials, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.creds != nil {
+		return g.creds, nil
+	}
+	keyJSON, err := g.loadKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	creds, err := google.CredentialsFromJSON(ctx, keyJSON, g.scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing GCP service account keyfile: %w", err)
+	}
+	var meta struct {
+		ClientEmail string `json:"client_email"`
+	}
+	if err := json.Unmarshal(keyJSON, &meta); err == nil {
+		g.email = meta.ClientEmail
+	}
+	g.creds = creds
+	return g.creds, nil
+}

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -141,17 +141,6 @@ rules:
 `,
 			wantError: "scopes",
 		},
-		{
-			name: "invalid fallback",
-			yaml: `
-keyfile_path: /tmp/k.json
-scopes: [a]
-fallback: panic
-rules:
-  - host: "*.googleapis.com"
-`,
-			wantError: "invalid fallback",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -262,7 +251,7 @@ func TestGCPAuth_CachesTokenAcrossRequests(t *testing.T) {
 	require.Equal(t, int64(1), calls.Load())
 }
 
-func TestGCPAuth_KeyfileMissing_DefaultDenies(t *testing.T) {
+func TestGCPAuth_KeyfileMissing_Rejects(t *testing.T) {
 	cfg := config{
 		KeyfilePath: "/does/not/exist.json",
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
@@ -274,22 +263,6 @@ func TestGCPAuth_KeyfileMissing_DefaultDenies(t *testing.T) {
 	res, err := g.TransformRequest(context.Background(), newContext(), req)
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
-	require.Empty(t, req.Header.Get("Authorization"))
-}
-
-func TestGCPAuth_KeyfileMissing_FallbackSkip(t *testing.T) {
-	cfg := config{
-		KeyfilePath: "/does/not/exist.json",
-		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
-		Fallback:    "skip",
-	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
-	require.NoError(t, err)
-
-	req := newRequest(t, "storage.googleapis.com")
-	res, err := g.TransformRequest(context.Background(), newContext(), req)
-	require.NoError(t, err)
-	require.Equal(t, transform.ActionContinue, res.Action)
 	require.Empty(t, req.Header.Get("Authorization"))
 }
 

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -1,0 +1,332 @@
+package gcpauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+// staticSource implements secrets.Source with a fixed value or error.
+type staticSource struct {
+	name  string
+	value string
+	err   error
+	calls atomic.Int64
+}
+
+func (s *staticSource) Name() string { return s.name }
+func (s *staticSource) Get(context.Context) (string, error) {
+	s.calls.Add(1)
+	return s.value, s.err
+}
+
+func staticBuilder(src secrets.Source) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return src, nil }
+}
+
+func failingBuilder(err error) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return nil, err }
+}
+
+// testKeyfileJSON generates a service-account JSON keyfile pointing token
+// exchange at tokenURL.
+func testKeyfileJSON(t *testing.T, tokenURL, email string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	keyfile := map[string]string{
+		"type":         "service_account",
+		"project_id":   "test-project",
+		"private_key":  string(pemBytes),
+		"client_email": email,
+		"token_uri":    tokenURL,
+	}
+	data, err := json.Marshal(keyfile)
+	require.NoError(t, err)
+	return data
+}
+
+// fakeTokenServer mimics Google's oauth2 token endpoint and counts requests.
+func fakeTokenServer(t *testing.T, accessToken string, expiresIn int) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"access_token": accessToken,
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func yamlFromString(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	return *node.Content[0]
+}
+
+func newRequest(t *testing.T, host string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, "https://"+host+"/v1/projects", nil)
+	require.NoError(t, err)
+	return r
+}
+
+func newContext() *transform.TransformContext {
+	return &transform.TransformContext{Mode: transform.ModeMITM}
+}
+
+func TestGCPAuth_Validation(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantError string
+	}{
+		{
+			name: "missing both keyfile sources",
+			yaml: `
+scopes: [a]
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "exactly one of",
+		},
+		{
+			name: "both keyfile sources set",
+			yaml: `
+keyfile_path: /tmp/k.json
+keyfile:
+  type: env
+  var: X
+scopes: [a]
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "exactly one of",
+		},
+		{
+			name: "missing scopes",
+			yaml: `
+keyfile_path: /tmp/k.json
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "scopes",
+		},
+		{
+			name: "invalid fallback",
+			yaml: `
+keyfile_path: /tmp/k.json
+scopes: [a]
+fallback: panic
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "invalid fallback",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c config
+			node := yamlFromString(t, tc.yaml)
+			require.NoError(t, node.Decode(&c))
+			_, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+			require.ErrorContains(t, err, tc.wantError)
+		})
+	}
+}
+
+func TestGCPAuth_InjectsBearerFromKeyfilePath(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+	require.Equal(t, int64(1), calls.Load())
+}
+
+func TestGCPAuth_InjectsBearerFromNestedSource(t *testing.T) {
+	srv, _ := fakeTokenServer(t, "nested-token", 3600)
+	keyJSON := testKeyfileJSON(t, srv.URL, "nested-sa@p.iam.gserviceaccount.com")
+	nested := &staticSource{name: "op://vault/gcp-sa/credential", value: string(keyJSON)}
+
+	cfg := config{
+		Keyfile: yamlFromString(t, `
+type: 1password_connect
+secret_ref: "op://vault/gcp-sa/credential"
+`),
+		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(nested))
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer nested-token", req.Header.Get("Authorization"))
+	require.Equal(t, int64(1), nested.calls.Load())
+}
+
+func TestGCPAuth_HostRulesRestrictInjection(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "scoped-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfgYAML := `
+keyfile_path: ` + path + `
+scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+rules:
+  - host: "*.googleapis.com"
+`
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	// Matching host gets the header.
+	req := newRequest(t, "storage.googleapis.com")
+	_, err = g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer scoped-token", req.Header.Get("Authorization"))
+
+	// Non-matching host is passed through untouched.
+	other := newRequest(t, "api.openai.com")
+	_, err = g.TransformRequest(context.Background(), newContext(), other)
+	require.NoError(t, err)
+	require.Empty(t, other.Header.Get("Authorization"))
+	require.Equal(t, int64(1), calls.Load(), "token endpoint should only be hit for matching hosts")
+}
+
+func TestGCPAuth_CachesTokenAcrossRequests(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "shared-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		req := newRequest(t, "storage.googleapis.com")
+		_, err := g.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, "Bearer shared-token", req.Header.Get("Authorization"))
+	}
+	require.Equal(t, int64(1), calls.Load())
+}
+
+func TestGCPAuth_KeyfileMissing_DefaultDenies(t *testing.T) {
+	cfg := config{
+		KeyfilePath: "/does/not/exist.json",
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestGCPAuth_KeyfileMissing_FallbackSkip(t *testing.T) {
+	cfg := config{
+		KeyfilePath: "/does/not/exist.json",
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+		Fallback:    "skip",
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
+}
+
+func TestGCPAuth_NestedSourceBuildError(t *testing.T) {
+	cfg := config{
+		Keyfile: yamlFromString(t, `
+type: 1password_connect
+secret_ref: "op://vault/missing"
+`),
+		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	_, err := newFromConfig(cfg, slog.Default(), os.ReadFile, failingBuilder(fmt.Errorf("not configured")))
+	require.ErrorContains(t, err, "building keyfile source")
+	require.ErrorContains(t, err, "not configured")
+}
+
+// End-to-end through the registered transform factory and the real secrets
+// package: keyfile loaded via the env source.
+func TestGCPAuth_Factory_EndToEnd(t *testing.T) {
+	srv, _ := fakeTokenServer(t, "factory-token", 3600)
+	keyJSON := testKeyfileJSON(t, srv.URL, "factory-sa@p.iam.gserviceaccount.com")
+	t.Setenv("GCP_SA_JSON", string(keyJSON))
+
+	cfgYAML := `
+keyfile:
+  type: env
+  var: GCP_SA_JSON
+scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+rules:
+  - host: "*.googleapis.com"
+`
+	tr, err := factory(yamlFromString(t, cfgYAML), slog.Default())
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	res, err := tr.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer factory-token", req.Header.Get("Authorization"))
+}

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -16,12 +16,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// secretSource is a prepared secret. Get fetches the current value, possibly
+// Source is a prepared secret. Get fetches the current value, possibly
 // from a cache; Name returns a stable display name for logging.
-type secretSource interface {
+type Source interface {
 	Name() string
 	Get(ctx context.Context) (string, error)
 }
+
+// secretSource is the package-internal alias for Source. Kept so existing
+// internal call sites stay terse.
+type secretSource = Source
 
 // secretSourceBuilder validates source config and returns a secretSource that
 // fetches lazily on first Get. Build must not perform I/O — only static

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -129,14 +129,44 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing secrets config: %w", err)
 	}
-	registry := sourceBuilderRegistry{
+	return newFromConfig(c, defaultRegistry(logger))
+}
+
+// defaultRegistry returns the standard set of secret source builders. It is
+// used by both the secrets transform's factory and by BuildSource so other
+// transforms can compose the same sources.
+func defaultRegistry(logger *slog.Logger) sourceBuilderRegistry {
+	return sourceBuilderRegistry{
 		"env":               newEnvBuilder(logger),
 		"aws_sm":            newAWSSMBuilder(logger),
 		"aws_ssm":           newAWSSSMBuilder(logger),
 		"1password":         newOPBuilder(logger),
 		"1password_connect": newOPConnectBuilder(logger),
 	}
-	return newFromConfig(c, registry)
+}
+
+// BuildSource constructs a secret Source from a yaml node shaped like a
+// top-level "source:" block (e.g. {type: env, var: FOO}). It is intended for
+// other transforms that want to load their inputs from any registered
+// secrets backend (1Password, AWS SM, etc.).
+func BuildSource(node yaml.Node, logger *slog.Logger) (Source, error) {
+	return resolveSource(defaultRegistry(logger), node)
+}
+
+// resolveSource dispatches a source config through the registry.
+func resolveSource(registry sourceBuilderRegistry, node yaml.Node) (secretSource, error) {
+	var hint sourceTypeHint
+	if err := node.Decode(&hint); err != nil {
+		return nil, fmt.Errorf("parsing source type: %w", err)
+	}
+	if hint.Type == "" {
+		return nil, fmt.Errorf("source.type is required")
+	}
+	builder, ok := registry[hint.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported source type %q", hint.Type)
+	}
+	return builder.Build(node)
 }
 
 // newFromConfig creates a Secrets transform from a parsed config.

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -232,8 +232,7 @@ transforms:
   # are cached and refreshed automatically before expiry. Scopes are baked
   # into the minted token; widen them if one configured transform serves
   # multiple GCP APIs. Requires MITM mode (sni-only mode cannot rewrite
-  # headers). On token-minting failure the request is rejected (403); set
-  # fallback: skip to pass through unauthenticated instead.
+  # headers). On token-minting failure the request is rejected (403).
   #
   # The keyfile JSON can come from disk via keyfile_path, or from any other
   # configured secret source (env, aws_sm, aws_ssm, 1password,

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -226,6 +226,37 @@ transforms:
         #   rules:
         #     - host: "api.openai.com"
 
+  # GCP service account authentication. Signs a JWT with the configured
+  # keyfile, exchanges it at Google's token endpoint for a short-lived OAuth2
+  # access token, and sets Authorization: Bearer on matching requests. Tokens
+  # are cached and refreshed automatically before expiry. Scopes are baked
+  # into the minted token; widen them if one configured transform serves
+  # multiple GCP APIs. Requires MITM mode (sni-only mode cannot rewrite
+  # headers). On token-minting failure the request is rejected (403); set
+  # fallback: skip to pass through unauthenticated instead.
+  #
+  # The keyfile JSON can come from disk via keyfile_path, or from any other
+  # configured secret source (env, aws_sm, aws_ssm, 1password,
+  # 1password_connect) via a nested keyfile block. Use exactly one.
+  # - name: gcp_auth
+  #   config:
+  #     keyfile_path: "/etc/iron-proxy/gcp-sa.json"
+  #     scopes:
+  #       - "https://www.googleapis.com/auth/cloud-platform"
+  #     rules:
+  #       - host: "*.googleapis.com"
+  #
+  # Same thing, keyfile sourced from 1Password Connect:
+  # - name: gcp_auth
+  #   config:
+  #     keyfile:
+  #       type: 1password_connect
+  #       secret_ref: "op://Engineering/GCP-SA/credential"
+  #     scopes:
+  #       - "https://www.googleapis.com/auth/cloud-platform"
+  #     rules:
+  #       - host: "*.googleapis.com"
+
   # Header allowlist: strips any request header not listed below before the
   # request goes upstream. Default-deny — every header must either match a
   # literal name (case-insensitive) or a /regex/ pattern. Place this AFTER


### PR DESCRIPTION
Adds a `gcp_auth` transform that signs a JWT with a service account keyfile, exchanges it for a short-lived access token, and injects `Authorization: Bearer` on matching requests. The keyfile can be loaded from disk via `keyfile_path` or from any registered secret source (env, aws_sm, aws_ssm, 1password, 1password_connect) via a nested `keyfile:` block — `secrets.Source` and `secrets.BuildSource` are exported for that composition. Token caching and refresh are delegated to `golang.org/x/oauth2/google`. On token-mint failure the request is rejected with 403; set `fallback: skip` to pass through unauthenticated instead. Adds an integration test that runs a real BigQuery query through the proxy when `GCP_BIGQUERY_SERVICE_ACCOUNT_KEY` is set, wired into CI alongside the existing AWS / OpenAI / 1Password integration tests.