### PR TITLE
feat(management): reload postgres listeners on /v1/reload

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -206,10 +206,7 @@ func main() {
 		logger.Error("loading postgres config", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	pgServers := make([]*postgres.Server, 0, len(pgPolicies))
-	for _, p := range pgPolicies {
-		pgServers = append(pgServers, postgres.NewServer(p, logger))
-	}
+	pgManager := postgres.NewManager(logger)
 
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
@@ -235,8 +232,9 @@ func main() {
 		mgmtServer = management.New(management.Options{
 			Addr:   cfg.Management.Listen,
 			APIKey: os.Getenv(cfg.Management.APIKeyEnv),
-			Reload: newReloadFunc(*configPath, holder, mcpHolder, bodyLimits, logger),
+			Reload: newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger),
 			Logger: logger,
+			Ctx:    ctx,
 		})
 	}
 
@@ -247,10 +245,7 @@ func main() {
 	if mgmtServer != nil {
 		go func() { errc <- fmt.Errorf("management: %w", mgmtServer.ListenAndServe()) }()
 	}
-	for _, pg := range pgServers {
-		pg := pg
-		go func() { errc <- fmt.Errorf("postgres[%s]: %w", pg.Name(), pg.ListenAndServe()) }()
-	}
+	pgManager.Start(pgPolicies, errc)
 
 	startAttrs := []any{
 		slog.String("dns_listen", cfg.DNS.Listen),
@@ -302,13 +297,8 @@ func main() {
 			logger.Error("management server shutdown error", slog.String("error", err.Error()))
 		}
 	}
-	for _, pg := range pgServers {
-		if err := pg.Shutdown(shutdownCtx); err != nil {
-			logger.Error("postgres server shutdown error",
-				slog.String("name", pg.Name()),
-				slog.String("error", err.Error()),
-			)
-		}
+	if err := pgManager.Shutdown(shutdownCtx); err != nil {
+		logger.Error("postgres server shutdown error", slog.String("error", err.Error()))
 	}
 
 	logger.Info("iron-proxy stopped")
@@ -533,12 +523,13 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 }
 
 // newReloadFunc returns a management.ReloadFunc that re-reads the YAML config
-// from configPath, rebuilds the pipeline and MCP policy, and atomically swaps
-// them in. Parse, validation, and build errors are wrapped in
-// *management.ValidationError so the management server returns 422; the
-// existing pipeline and policy are preserved.
-func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolder *mcp.PolicyHolder, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
-	return func() error {
+// from configPath, rebuilds the pipeline, MCP policy, and postgres listeners,
+// and atomically swaps them in. Parse, validation, and build errors are
+// wrapped in *management.ValidationError so the management server returns
+// 422 and the existing state is left untouched. Validation runs for every
+// component before any state is mutated.
+func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolder *mcp.PolicyHolder, pgManager *postgres.Manager, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
+	return func(ctx context.Context) error {
 		newCfg, err := config.LoadConfig(configPath)
 		if err != nil {
 			return &management.ValidationError{Err: err}
@@ -554,10 +545,18 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolde
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
+		newPgPolicies, err := postgres.LoadFromNode(newCfg.Postgres, logger)
+		if err != nil {
+			return &management.ValidationError{Err: err}
+		}
 		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 		holder.Store(newPipeline)
 		mcpHolder.Store(newPolicy)
-		logger.Info("pipeline reloaded via management API", slog.String("transforms", newPipeline.Names()))
+		pgManager.Reload(ctx, newPgPolicies)
+		logger.Info("pipeline reloaded via management API",
+			slog.String("transforms", newPipeline.Names()),
+			slog.Int("postgres_servers", len(newPgPolicies)),
+		)
 		return nil
 	}
 }

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -12,10 +12,14 @@ import (
 	"strings"
 )
 
-// ReloadFunc rebuilds the running pipeline from the on-disk config. Returning
-// a *ValidationError signals that the supplied config could not be parsed or
-// built into a pipeline; the server maps that to HTTP 422.
-type ReloadFunc func() error
+// ReloadFunc rebuilds the running pipeline from the on-disk config. ctx is
+// the server's process-scoped context (configured via Options.Ctx) so a
+// reload survives an HTTP client disconnect: a partially-applied swap of
+// pipeline, MCP, and postgres listeners would leave the proxy in a
+// half-reloaded state. Returning a *ValidationError signals that the
+// supplied config could not be parsed or built; the server maps that to
+// HTTP 422.
+type ReloadFunc func(context.Context) error
 
 // ValidationError marks an error as the result of bad on-disk configuration
 // rather than an internal failure. Reload handlers translate this to a 422.
@@ -43,6 +47,12 @@ type Options struct {
 	APIKey string
 	Reload ReloadFunc
 	Logger *slog.Logger
+
+	// Ctx is the process-scoped context passed to Reload. It must outlive
+	// individual HTTP requests so a client disconnect cannot abort a reload
+	// after pipeline/MCP have been swapped but before postgres listeners
+	// have been recycled. If nil, context.Background() is used.
+	Ctx context.Context
 }
 
 // Server serves the management API.
@@ -51,16 +61,22 @@ type Server struct {
 	apiKey string
 	reload ReloadFunc
 	logger *slog.Logger
+	ctx    context.Context
 }
 
 // New creates a Server bound to opts.Addr. The caller starts it with
 // ListenAndServe and stops it with Shutdown.
 func New(opts Options) *Server {
 	mux := http.NewServeMux()
+	ctx := opts.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	s := &Server{
 		apiKey: opts.APIKey,
 		reload: opts.Reload,
 		logger: opts.Logger,
+		ctx:    ctx,
 	}
 	mux.HandleFunc("/v1/reload", s.handleReload)
 	s.server = &http.Server{
@@ -96,7 +112,9 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.reload()
+	// Use the server-scoped context, not r.Context(): reload mutates
+	// process-wide state and must not be cut short by a client disconnect.
+	err := s.reload(s.ctx)
 	if err == nil {
 		s.logger.Info("management reload succeeded")
 		writeJSON(w, http.StatusOK, statusResponse{Status: "ok"})

--- a/internal/management/server_test.go
+++ b/internal/management/server_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -42,26 +43,26 @@ func decodeError(t *testing.T, body io.Reader) string {
 }
 
 func TestReload_MissingAuth(t *testing.T) {
-	s := newTestServer(t, "secret", func() error { return nil })
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
 	rec := do(t, s, http.MethodPost, "/v1/reload", "")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 	require.Equal(t, "unauthorized", decodeError(t, rec.Body))
 }
 
 func TestReload_WrongAuth(t *testing.T) {
-	s := newTestServer(t, "secret", func() error { return nil })
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
 	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer nope")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestReload_NonBearerAuth(t *testing.T) {
-	s := newTestServer(t, "secret", func() error { return nil })
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
 	rec := do(t, s, http.MethodPost, "/v1/reload", "Basic c2VjcmV0")
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestReload_WrongMethod(t *testing.T) {
-	s := newTestServer(t, "secret", func() error {
+	s := newTestServer(t, "secret", func(context.Context) error {
 		t.Fatal("reload should not run on GET")
 		return nil
 	})
@@ -72,7 +73,7 @@ func TestReload_WrongMethod(t *testing.T) {
 
 func TestReload_Success(t *testing.T) {
 	called := 0
-	s := newTestServer(t, "secret", func() error {
+	s := newTestServer(t, "secret", func(context.Context) error {
 		called++
 		return nil
 	})
@@ -86,7 +87,7 @@ func TestReload_Success(t *testing.T) {
 }
 
 func TestReload_ValidationError(t *testing.T) {
-	s := newTestServer(t, "secret", func() error {
+	s := newTestServer(t, "secret", func(context.Context) error {
 		return &ValidationError{Err: errors.New("bad transform: missing field")}
 	})
 	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
@@ -97,7 +98,7 @@ func TestReload_ValidationError(t *testing.T) {
 
 func TestReload_WrappedValidationError(t *testing.T) {
 	// A ValidationError wrapped further down the chain still maps to 422.
-	s := newTestServer(t, "secret", func() error {
+	s := newTestServer(t, "secret", func(context.Context) error {
 		inner := &ValidationError{Err: errors.New("parse failure")}
 		return errors.Join(errors.New("wrapper"), inner)
 	})
@@ -106,7 +107,7 @@ func TestReload_WrappedValidationError(t *testing.T) {
 }
 
 func TestReload_InternalError(t *testing.T) {
-	s := newTestServer(t, "secret", func() error {
+	s := newTestServer(t, "secret", func(context.Context) error {
 		return errors.New("disk on fire")
 	})
 	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
@@ -116,7 +117,7 @@ func TestReload_InternalError(t *testing.T) {
 }
 
 func TestUnknownPath(t *testing.T) {
-	s := newTestServer(t, "secret", func() error { return nil })
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
 	rec := do(t, s, http.MethodPost, "/anything-else", "Bearer secret")
 	require.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/internal/postgres/manager.go
+++ b/internal/postgres/manager.go
@@ -1,0 +1,103 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// Manager owns the running set of postgres listener servers and supports
+// hot reload by closing the old set and starting a new one from updated
+// policies. Safe for concurrent use.
+type Manager struct {
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	servers []*Server
+}
+
+// NewManager returns a Manager with no running servers.
+func NewManager(logger *slog.Logger) *Manager {
+	return &Manager{logger: logger}
+}
+
+// Start launches a listener for each policy. A listener that exits with a
+// non-nil error sends it to errc so the calling process can treat it as
+// fatal; bind failures during a subsequent Reload are logged instead.
+func (m *Manager) Start(policies []*Policy, errc chan<- error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, p := range policies {
+		srv := NewServer(p, m.logger)
+		m.servers = append(m.servers, srv)
+		go m.run(srv, errc)
+	}
+}
+
+// Reload closes all running listeners and starts a new set from policies.
+// In-flight client sessions on the closed listeners are not interrupted, but
+// no new connections will be accepted on the old addresses. ctx bounds the
+// shutdown of the old listeners. Listener failures during reload (e.g.
+// address already in use) are logged, not fatal: the management /v1/reload
+// caller has already received a 200.
+func (m *Manager) Reload(ctx context.Context, policies []*Policy) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, s := range m.servers {
+		if err := s.Shutdown(ctx); err != nil {
+			m.logger.Error("postgres listener shutdown during reload",
+				slog.String("name", s.Name()),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+
+	m.servers = make([]*Server, 0, len(policies))
+	for _, p := range policies {
+		srv := NewServer(p, m.logger)
+		m.servers = append(m.servers, srv)
+		go m.run(srv, nil)
+	}
+}
+
+// Shutdown closes all running listeners. The first error from any server is
+// returned; remaining listeners are still asked to shut down.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var firstErr error
+	for _, s := range m.servers {
+		if err := s.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// Names returns the names of the currently running servers. Test-only.
+func (m *Manager) Names() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.servers))
+	for _, s := range m.servers {
+		out = append(out, s.Name())
+	}
+	return out
+}
+
+func (m *Manager) run(s *Server, errc chan<- error) {
+	err := s.ListenAndServe()
+	if err == nil {
+		return
+	}
+	if errc != nil {
+		errc <- fmt.Errorf("postgres[%s]: %w", s.Name(), err)
+		return
+	}
+	m.logger.Error("postgres listener stopped",
+		slog.String("name", s.Name()),
+		slog.String("error", err.Error()),
+	)
+}

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -1,0 +1,106 @@
+package postgres
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// staticDSN is a no-op secrets.Source used to build test policies. The
+// manager tests never complete a postgres handshake; they only verify that
+// the listener is accepting TCP connections, so the DSN value is never read.
+type staticDSN struct{ name, value string }
+
+func (s staticDSN) Name() string                       { return s.name }
+func (s staticDSN) Get(context.Context) (string, error) { return s.value, nil }
+
+func testPolicy(name, listen string) *Policy {
+	return &Policy{
+		name:           name,
+		listen:         listen,
+		upstreamDSN:    staticDSN{name: "test", value: "host=127.0.0.1"},
+		clientUser:     "u",
+		clientPassword: "p",
+	}
+}
+
+// waitForListener returns the bound address once the first server in m is
+// listening. Fails the test if the bind never completes in time.
+func waitForListener(t *testing.T, m *Manager) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		if len(m.servers) > 0 {
+			addr := m.servers[0].Addr()
+			m.mu.Unlock()
+			if addr != "" {
+				return addr
+			}
+		} else {
+			m.mu.Unlock()
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("listener never bound")
+	return ""
+}
+
+func TestManagerReload(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(logger)
+	errc := make(chan error, 2)
+
+	m.Start([]*Policy{testPolicy("initial", "127.0.0.1:0")}, errc)
+	oldAddr := waitForListener(t, m)
+
+	// Old listener is accepting connections.
+	c, err := net.DialTimeout("tcp", oldAddr, time.Second)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	// Reload swaps in a new policy. The old listener closes; a new one binds.
+	m.Reload(context.Background(), []*Policy{testPolicy("reloaded", "127.0.0.1:0")})
+	newAddr := waitForListener(t, m)
+	require.NotEqual(t, oldAddr, newAddr)
+	require.Equal(t, []string{"reloaded"}, m.Names())
+
+	// New listener accepts.
+	c, err = net.DialTimeout("tcp", newAddr, time.Second)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	// Old address is no longer accepting connections.
+	_, err = net.DialTimeout("tcp", oldAddr, 200*time.Millisecond)
+	require.Error(t, err)
+
+	require.NoError(t, m.Shutdown(context.Background()))
+
+	select {
+	case err := <-errc:
+		t.Fatalf("unexpected fatal error from initial Start: %v", err)
+	default:
+	}
+}
+
+func TestManagerReloadToEmpty(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(logger)
+	errc := make(chan error, 1)
+
+	m.Start([]*Policy{testPolicy("initial", "127.0.0.1:0")}, errc)
+	oldAddr := waitForListener(t, m)
+
+	m.Reload(context.Background(), nil)
+	require.Empty(t, m.Names())
+
+	_, err := net.DialTimeout("tcp", oldAddr, 200*time.Millisecond)
+	require.Error(t, err)
+
+	require.NoError(t, m.Shutdown(context.Background()))
+}


### PR DESCRIPTION
The pipeline reload endpoint now also rebuilds postgres listeners from the new config. A new `postgres.Manager` owns the running set of servers and supports close+rebind reload, with errors logged rather than fatal. Validation runs for pipeline, MCP, and postgres before any state is mutated, so a 422 leaves the proxy untouched.

`ReloadFunc` now takes a `context.Context`, and the management server passes its own process-scoped context (not the request's) so a client disconnect mid-reload cannot leave pipeline/MCP swapped while postgres is half-reloaded.

In-flight postgres sessions on closed listeners are not drained, by design.