### PR TITLE
feat(gcpauth): stub GCP OAuth2 token endpoints with a synthetic token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Install the gcloud SDK (gcloud + bq) before the egress proxy locks
+      # down outbound traffic, so the SDK download isn't blocked. The bq CLI
+      # is exercised by TestGCPAuthBigQueryGcloudCLI.
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
       - uses: ironsh/iron-proxy-action@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
         with:
           egress-rules: egress-rules.yaml

--- a/integration_test/gcp_auth_bigquery_cli_test.go
+++ b/integration_test/gcp_auth_bigquery_cli_test.go
@@ -1,0 +1,187 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCPAuthBigQueryGcloudCLI drives the real bq CLI (shipped with the Google
+// Cloud SDK) through the proxy to prove the gcp_auth OAuth2 stub works against
+// an off-the-shelf client.
+//
+// The CLI is activated with a *dummy* service account keyfile: the private key
+// is freshly generated and corresponds to no real Google identity. When bq
+// mints a token it signs a JWT with that dummy key and POSTs it to
+// oauth2.googleapis.com/token — the proxy intercepts that request and returns a
+// stubbed access token, so the bogus signature is never seen by Google. bq then
+// calls bigquery.googleapis.com with the stub bearer, and gcp_auth swaps in a
+// real token minted from the genuine keyfile the proxy holds
+// (GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE).
+//
+// The query succeeding therefore depends on both halves of the feature: the
+// token endpoint being stubbed and the real token being injected.
+//
+// Requires the gcloud SDK (gcloud + bq) on PATH and a BigQuery table at
+// test_dataset.test_table with a test_field column readable by the configured
+// service account.
+func TestGCPAuthBigQueryGcloudCLI(t *testing.T) {
+	keyfilePath := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
+	if keyfilePath == "" {
+		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE not set")
+	}
+	gcloudBin, err := exec.LookPath("gcloud")
+	if err != nil {
+		t.Skip("gcloud CLI not found on PATH")
+	}
+	bqBin, err := exec.LookPath("bq")
+	if err != nil {
+		t.Skip("bq CLI not found on PATH")
+	}
+
+	keyJSON, err := os.ReadFile(keyfilePath)
+	require.NoError(t, err, "reading GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
+	var meta struct {
+		ProjectID string `json:"project_id"`
+	}
+	require.NoError(t, json.Unmarshal(keyJSON, &meta))
+	require.NotEmpty(t, meta.ProjectID, "service account JSON missing project_id")
+
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+	cfgPath := renderConfig(t, tmpDir, "gcp_auth_bigquery_cli.yaml", struct {
+		KeyfilePath string
+	}{KeyfilePath: keyfilePath})
+
+	proxy := startProxy(t, binary, cfgPath, nil)
+	// CONNECT requests for HTTPS upstreams go to the tunnel listener.
+	tunnelAddr := proxy.AddrFor(t, "tunnel proxy starting")
+
+	caPath := filepath.Join(repoRoot(t), "tmp", "ca.crt")
+	_, err = os.Stat(caPath)
+	require.NoError(t, err, "expected proxy CA at %s — generate it with: ./iron-proxy generate-ca -outdir tmp -alg ed25519", caPath)
+
+	dummyKey := writeDummyServiceAccountKeyfile(t, tmpDir)
+
+	// Point gcloud/bq at this test's proxy and CA, fully overriding any
+	// ambient proxy configuration the CI runner may have set. CLOUDSDK_CONFIG
+	// and BIGQUERYRC keep the CLI state inside the temp dir so the test is
+	// hermetic.
+	cliEnv := envWith(map[string]string{
+		"CLOUDSDK_CONFIG":                    filepath.Join(tmpDir, "cloudsdk"),
+		"BIGQUERYRC":                         filepath.Join(tmpDir, "bigqueryrc"),
+		"CLOUDSDK_CORE_DISABLE_PROMPTS":      "1",
+		"HTTP_PROXY":                         "http://" + tunnelAddr,
+		"HTTPS_PROXY":                        "http://" + tunnelAddr,
+		"http_proxy":                         "http://" + tunnelAddr,
+		"https_proxy":                        "http://" + tunnelAddr,
+		"NO_PROXY":                           "",
+		"no_proxy":                           "",
+		"CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE": caPath,
+		"REQUESTS_CA_BUNDLE":                 caPath,
+		"SSL_CERT_FILE":                      caPath,
+	})
+
+	// activate-service-account is offline: gcloud just stores the keyfile. The
+	// dummy key is never validated against Google.
+	runCLI(t, cliEnv, 30*time.Second, gcloudBin,
+		"auth", "activate-service-account", "--key-file="+dummyKey)
+
+	out := runCLI(t, cliEnv, 90*time.Second, bqBin, "query",
+		"--project_id="+meta.ProjectID,
+		"--headless",
+		"--quiet",
+		"--format=json",
+		"--use_legacy_sql=false",
+		"SELECT test_field FROM test_dataset.test_table LIMIT 1",
+	)
+
+	// bq --format=json emits a JSON array of row objects keyed by column name.
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &rows), "parsing bq output: %s", out)
+	require.NotEmpty(t, rows, "no rows returned from test_dataset.test_table")
+	require.Equal(t, "foo", rows[0]["test_field"], "test_dataset.test_table.test_field first value")
+}
+
+// writeDummyServiceAccountKeyfile generates a syntactically valid service
+// account JSON keyfile with a freshly minted RSA private key. It is accepted by
+// gcloud auth activate-service-account but corresponds to no real identity.
+func writeDummyServiceAccountKeyfile(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	keyfile := map[string]string{
+		"type":                        "service_account",
+		"project_id":                  "iron-proxy-stub",
+		"private_key_id":              "stub-private-key-id",
+		"private_key":                 string(pemBytes),
+		"client_email":                "stub@iron-proxy-stub.iam.gserviceaccount.com",
+		"client_id":                   "000000000000000000000",
+		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",
+		"token_uri":                   "https://oauth2.googleapis.com/token",
+		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+		"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/stub%40iron-proxy-stub.iam.gserviceaccount.com",
+	}
+	data, err := json.MarshalIndent(keyfile, "", "  ")
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "dummy-sa.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+// runCLI runs an external command with the given environment and timeout,
+// failing the test with full stdout/stderr if it exits non-zero.
+func runCLI(t *testing.T, env []string, timeout time.Duration, name string, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	require.NoError(t, err, "%s %s failed\nstdout:\n%s\nstderr:\n%s",
+		name, strings.Join(args, " "), stdout.String(), stderr.String())
+	return stdout.String()
+}
+
+// envWith returns os.Environ() with the given keys overridden. Existing entries
+// for an overridden key are dropped so the new value is the only one the child
+// process sees (libc getenv returns the first match).
+func envWith(overrides map[string]string) []string {
+	out := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		if _, ok := overrides[kv[:eq]]; ok {
+			continue
+		}
+		out = append(out, kv)
+	}
+	for k, v := range overrides {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/integration_test/testdata/gcp_auth_bigquery_cli.yaml
+++ b/integration_test/testdata/gcp_auth_bigquery_cli.yaml
@@ -1,0 +1,41 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  tunnel_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  # oauth2.googleapis.com must be allowlisted so the gcloud/bq token request
+  # reaches gcp_auth, which stubs it. Without this the allowlist transform
+  # would reject the CONNECT before gcp_auth ever runs.
+  - name: allowlist
+    config:
+      domains:
+        - "oauth2.googleapis.com"
+        - "bigquery.googleapis.com"
+        - "www.googleapis.com"
+
+  - name: gcp_auth
+    config:
+      keyfile_path: "{{ .KeyfilePath }}"
+      scopes:
+        - "https://www.googleapis.com/auth/bigquery"
+        - "https://www.googleapis.com/auth/cloud-platform"
+      rules:
+        - host: "bigquery.googleapis.com"
+        - host: "www.googleapis.com"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -314,7 +314,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	} else if rejectResp != nil {
-		result.Action = transform.ActionReject
+		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
 		p.writeResponse(w, rejectResp)
 		return
@@ -417,7 +417,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 
-	result.Action = transform.ActionContinue
+	result.Action = transform.ShortCircuitAction(result.ResponseTransforms)
 	result.StatusCode = finalResp.StatusCode
 
 	// MCP response wrapping: filter tools/list payloads and other JSON-RPC

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -88,9 +88,9 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 		return fmt.Errorf("pipeline error for %q: %w", sni, pipelineErr)
 	}
 	if rejectResp != nil {
-		result.Action = transform.ActionReject
+		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
-		p.logger.Info("sni passthrough rejected by transform",
+		p.logger.Info("sni passthrough short-circuited by transform",
 			slog.String("sni", sni),
 			slog.Int("status", rejectResp.StatusCode),
 		)

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -298,9 +298,9 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string, connectHeaders h
 		return false, nil, nil
 	}
 	if rejectResp != nil {
-		result.Action = transform.ActionReject
+		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
-		p.logger.Info("tunnel rejected by transform",
+		p.logger.Info("tunnel short-circuited by transform",
 			slog.String("target", target),
 			slog.Int("status", rejectResp.StatusCode),
 		)

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -14,8 +14,8 @@ type traceEntry struct {
 }
 
 // NewAuditLogger returns an AuditFunc that writes structured JSON log lines
-// for every request. Log level is INFO for allowed, WARN for rejected,
-// ERROR for errored requests.
+// for every request. Log level is INFO for allowed and stubbed, WARN for
+// rejected, ERROR for errored requests.
 func NewAuditLogger(logger *slog.Logger) AuditFunc {
 	return func(result *PipelineResult) {
 		action := actionString(result.Action)
@@ -49,11 +49,19 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 			attrs = append(attrs, slog.Group("tunnel", tunnelAttrs...))
 		}
 
-		// Add rejected_by for reject actions
+		// Add rejected_by / stubbed_by for short-circuit actions
 		if result.Action == ActionReject {
 			for _, tr := range result.RequestTransforms {
 				if tr.Action == ActionReject {
 					attrs = append(attrs, slog.String("rejected_by", tr.Name))
+					break
+				}
+			}
+		}
+		if result.Action == ActionStub {
+			for _, tr := range result.RequestTransforms {
+				if tr.Action == ActionStub {
+					attrs = append(attrs, slog.String("stubbed_by", tr.Name))
 					break
 				}
 			}
@@ -114,6 +122,8 @@ func actionString(a TransformAction) string {
 		return "allow"
 	case ActionReject:
 		return "reject"
+	case ActionStub:
+		return "stub"
 	default:
 		return "unknown"
 	}

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -85,6 +85,34 @@ func TestAudit_RejectedRequest(t *testing.T) {
 	require.Equal(t, float64(403), audit["status_code"])
 }
 
+func TestAudit_StubbedRequest(t *testing.T) {
+	result := &PipelineResult{
+		Host:       "oauth2.googleapis.com",
+		Method:     "POST",
+		Path:       "/token",
+		RemoteAddr: "10.16.0.5:43216",
+		SNI:        "oauth2.googleapis.com",
+		StartedAt:  time.Now(),
+		Duration:   80 * time.Microsecond,
+		Action:     ActionStub,
+		StatusCode: 200,
+		RequestTransforms: []TransformTrace{
+			{Name: "gcp_auth", Action: ActionStub, Duration: 80 * time.Microsecond,
+				Annotations: map[string]any{"stubbed": "oauth2_token_endpoint"}},
+		},
+	}
+
+	parsed, _ := captureAuditLog(result)
+
+	require.Equal(t, "INFO", parsed["level"])
+	require.Equal(t, "request", parsed["msg"])
+	require.Equal(t, "gcp_auth", parsed["stubbed_by"])
+
+	audit := parsed["audit"].(map[string]any)
+	require.Equal(t, "stub", audit["action"])
+	require.Equal(t, float64(200), audit["status_code"])
+}
+
 func TestAudit_TunnelInfo(t *testing.T) {
 	result := &PipelineResult{
 		Host:       "example.com",

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"golang.org/x/oauth2"
@@ -29,6 +30,15 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
+
+// stubAccessToken is the placeholder bearer returned to clients that fetch a
+// token from a GCP OAuth2 endpoint through the proxy. The real token is minted
+// by gcp_auth and swapped in just before the request leaves the proxy, so the
+// value here is never sent to Google: it just has to look like an opaque token
+// to the client SDK.
+const stubAccessToken = "iron-proxy-stub-token"
+
+var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","expires_in":3600,"token_type":"Bearer"}`)
 
 func init() {
 	transform.Register("gcp_auth", factory)
@@ -114,6 +124,18 @@ func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte,
 func (g *GCPAuth) Name() string { return "gcp_auth" }
 
 func (g *GCPAuth) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	// Stubbing the well-known OAuth2 token endpoints runs before host rules
+	// so client SDKs always complete their token dance against the proxy,
+	// even when the user's rules only target API hosts like
+	// bigquery.googleapis.com. gcp_auth itself mints the real token.
+	if isTokenEndpoint(req) {
+		tctx.Annotate("stubbed", "oauth2_token_endpoint")
+		return &transform.TransformResult{
+			Action:   transform.ActionStub,
+			Response: stubTokenResponse(req),
+		}, nil
+	}
+
 	if len(g.rules) > 0 && !hostmatch.MatchAnyRule(g.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
@@ -179,4 +201,39 @@ func (g *GCPAuth) loadTokenSource(ctx context.Context) (oauth2.TokenSource, erro
 	}
 	g.tokenSource = cfg.TokenSource(ctx)
 	return g.tokenSource, nil
+}
+
+// isTokenEndpoint reports whether req targets a well-known GCP OAuth2 token
+// endpoint. Covers the JWT bearer grant endpoint used by service account
+// keyfiles (oauth2.googleapis.com/token) and the GCE/GKE metadata server
+// endpoints clients hit when they believe they are running on GCP.
+func isTokenEndpoint(req *http.Request) bool {
+	host := hostmatch.StripPort(req.Host)
+	var path string
+	if req.URL != nil {
+		path = req.URL.Path
+	}
+	switch host {
+	case "oauth2.googleapis.com":
+		return path == "/token"
+	case "metadata.google.internal", "169.254.169.254":
+		return strings.HasPrefix(path, "/computeMetadata/v1/instance/service-accounts/") &&
+			strings.HasSuffix(path, "/token")
+	}
+	return false
+}
+
+func stubTokenResponse(req *http.Request) *http.Response {
+	body := transform.NewBufferedBodyFromBytes(stubTokenJSON)
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        "200 OK",
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          body,
+		ContentLength: int64(len(stubTokenJSON)),
+		Request:       req,
+	}
 }

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -279,6 +279,131 @@ secret_ref: "op://vault/missing"
 	require.ErrorContains(t, err, "not configured")
 }
 
+type stubTokenResp struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func decodeStubResponse(t *testing.T, resp *http.Response) stubTokenResp {
+	t.Helper()
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var out stubTokenResp
+	require.NoError(t, json.Unmarshal(body, &out))
+	return out
+}
+
+// TestGCPAuth_StubsOAuth2TokenEndpoint exercises the always-on stub for the
+// JWT bearer grant endpoint used by service-account keyfile flows. The rules
+// here target a different host on purpose: stubbing must not depend on the
+// configured rules matching the token endpoint.
+func TestGCPAuth_StubsOAuth2TokenEndpoint(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfgYAML := `
+keyfile_path: ` + path + `
+scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+rules:
+  - host: "bigquery.googleapis.com"
+`
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", nil)
+	require.NoError(t, err)
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionStub, res.Action)
+
+	decoded := decodeStubResponse(t, res.Response)
+	require.Equal(t, stubAccessToken, decoded.AccessToken)
+	require.Equal(t, "Bearer", decoded.TokenType)
+	require.Equal(t, 3600, decoded.ExpiresIn)
+
+	annotations := tctx.DrainAnnotations()
+	require.Equal(t, "oauth2_token_endpoint", annotations["stubbed"])
+
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, int64(0), calls.Load(), "real GCP token endpoint must not be hit when stubbing")
+}
+
+func TestGCPAuth_StubsMetadataServerToken(t *testing.T) {
+	srv, _ := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	urls := []string{
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/sa@p.iam.gserviceaccount.com/token",
+		"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token",
+	}
+	for _, u := range urls {
+		t.Run(u, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, u, nil)
+			require.NoError(t, err)
+			tctx := newContext()
+			res, err := g.TransformRequest(context.Background(), tctx, req)
+			require.NoError(t, err)
+			require.Equal(t, transform.ActionStub, res.Action)
+
+			decoded := decodeStubResponse(t, res.Response)
+			require.Equal(t, stubAccessToken, decoded.AccessToken)
+			require.Equal(t, "oauth2_token_endpoint", tctx.DrainAnnotations()["stubbed"])
+		})
+	}
+}
+
+// Paths on the same hosts that aren't the token endpoint should not be stubbed
+// — they fall through to the normal injection path so the matching upstream
+// keeps working.
+func TestGCPAuth_DoesNotStubNonTokenPaths(t *testing.T) {
+	srv, _ := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	cases := []string{
+		"https://oauth2.googleapis.com/revoke",
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email",
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, u, nil)
+			require.NoError(t, err)
+			res, err := g.TransformRequest(context.Background(), newContext(), req)
+			require.NoError(t, err)
+			require.Equal(t, transform.ActionContinue, res.Action)
+			require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+		})
+	}
+}
+
 // End-to-end through the registered transform factory and the real secrets
 // package: keyfile loaded via the env source.
 func TestGCPAuth_Factory_EndToEnd(t *testing.T) {

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -61,6 +61,14 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 				}
 			}
 		}
+		if result.Action == ActionStub {
+			for _, tr := range result.RequestTransforms {
+				if tr.Action == ActionStub {
+					attrs = append(attrs, log.String("stubbed_by", tr.Name))
+					break
+				}
+			}
+		}
 
 		if result.Err != nil {
 			attrs = append(attrs, log.String("error", result.Err.Error()))

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -155,6 +155,38 @@ func TestOTELAuditFunc_RejectedRequest(t *testing.T) {
 	assert.Equal(t, "allowlist", attrs["rejected_by"].AsString())
 }
 
+func TestOTELAuditFunc_StubbedRequest(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:       "oauth2.googleapis.com",
+		Method:     "POST",
+		Path:       "/token",
+		Action:     ActionStub,
+		StatusCode: 200,
+		Duration:   1 * time.Millisecond,
+		RequestTransforms: []TransformTrace{
+			{
+				Name:   "gcp_auth",
+				Action: ActionStub,
+			},
+		},
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	rec := records[0]
+	assert.Equal(t, log.SeverityInfo1, rec.Severity())
+	assert.Equal(t, "INFO", rec.SeverityText())
+
+	attrs := recordAttrs(rec)
+	assert.Equal(t, "stub", attrs["action"].AsString())
+	assert.Equal(t, "gcp_auth", attrs["stubbed_by"].AsString())
+}
+
 func TestOTELAuditFunc_ErroredRequest(t *testing.T) {
 	proc := &recordProcessor{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))

--- a/internal/transform/pipeline.go
+++ b/internal/transform/pipeline.go
@@ -42,7 +42,8 @@ func (p *Pipeline) SetAuditFunc(f AuditFunc) {
 }
 
 // ProcessRequest runs all request transforms in order. Returns a non-nil
-// *http.Response if the pipeline rejects the request (short-circuit).
+// *http.Response if the pipeline short-circuits the request (ActionReject or
+// ActionStub). Callers can use ShortCircuitAction(traces) to tell which.
 // Returns an error if any transform fails, which the caller should treat as 502.
 // The traces slice is appended to with each transform's result.
 func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, req *http.Request, traces *[]TransformTrace) (*http.Response, error) {
@@ -69,7 +70,7 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 		trace.Action = result.Action
 		*traces = append(*traces, trace)
 
-		if result.Action == ActionReject {
+		if result.Action == ActionReject || result.Action == ActionStub {
 			if result.Response != nil {
 				return result.Response, nil
 			}
@@ -80,8 +81,8 @@ func (p *Pipeline) ProcessRequest(ctx context.Context, tctx *TransformContext, r
 }
 
 // ProcessResponse runs all response transforms in order (same order as request).
-// Returns a replacement *http.Response if any transform rejects.
-// Returns an error if any transform fails.
+// Returns a replacement *http.Response if any transform short-circuits
+// (ActionReject or ActionStub). Returns an error if any transform fails.
 func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, req *http.Request, resp *http.Response, traces *[]TransformTrace) (*http.Response, error) {
 	for _, t := range p.transforms {
 		start := time.Now()
@@ -107,7 +108,7 @@ func (p *Pipeline) ProcessResponse(ctx context.Context, tctx *TransformContext, 
 		trace.Action = result.Action
 		*traces = append(*traces, trace)
 
-		if result.Action == ActionReject {
+		if result.Action == ActionReject || result.Action == ActionStub {
 			if result.Response != nil {
 				return result.Response, nil
 			}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -19,8 +19,33 @@ const (
 
 	// ActionReject stops the pipeline and returns TransformResult.Response to the client.
 	// If Response is nil, the proxy returns a default 403 Forbidden.
+	// Use this when the proxy is denying the request on the client's behalf.
 	ActionReject
+
+	// ActionStub stops the pipeline and returns TransformResult.Response to
+	// the client, the same way ActionReject does. Unlike ActionReject, it
+	// signals that the proxy is intentionally serving a synthetic response
+	// (e.g. a stubbed OAuth2 token endpoint) rather than denying the request.
+	// Audit logs render this as "stub" and log at INFO so operators can find
+	// proxy-served responses without conflating them with rejections.
+	// If Response is nil, the proxy falls back to a default 403 Forbidden,
+	// the same as ActionReject.
+	ActionStub
 )
+
+// ShortCircuitAction returns the action of the trace that short-circuited the
+// pipeline (ActionReject or ActionStub), or ActionContinue if none did. The
+// short-circuiting transform is always the last appended trace because the
+// pipeline returns immediately after appending it.
+func ShortCircuitAction(traces []TransformTrace) TransformAction {
+	if n := len(traces); n > 0 {
+		switch traces[n-1].Action {
+		case ActionReject, ActionStub:
+			return traces[n-1].Action
+		}
+	}
+	return ActionContinue
+}
 
 // Mode identifies how the proxy obtained the request being transformed.
 type Mode int
@@ -159,11 +184,11 @@ type Transformer interface {
 
 	// TransformRequest is called before the request is sent upstream.
 	// The transform may modify the request in place.
-	// Returning ActionReject stops the pipeline.
+	// Returning ActionReject or ActionStub stops the pipeline.
 	TransformRequest(ctx context.Context, tctx *TransformContext, req *http.Request) (*TransformResult, error)
 
 	// TransformResponse is called after the response is received from upstream.
 	// The transform may modify the response in place.
-	// Returning ActionReject replaces the upstream response with TransformResult.Response.
+	// Returning ActionReject or ActionStub replaces the upstream response with TransformResult.Response.
 	TransformResponse(ctx context.Context, tctx *TransformContext, req *http.Request, resp *http.Response) (*TransformResult, error)
 }


### PR DESCRIPTION
When the gcp_auth transform is active, requests to GCP OAuth2 token endpoints (`oauth2.googleapis.com/token` and the GCE/GKE metadata server token endpoints) are now intercepted and answered with a stubbed access token. Clients complete their OAuth2 dance against the proxy and never need real credentials, while gcp_auth mints the real token from the keyfile it holds and injects it on the upstream API call. Stubbing is always-on whenever gcp_auth is configured, independent of the transform's host rules.

This adds a new `ActionStub` transform action. It short-circuits the pipeline the same way `ActionReject` does, but renders as `"stub"` at INFO level in audit logs (with a `stubbed_by` field) so operators can find proxy-served responses without conflating them with rejections. The proxy now records the real short-circuit outcome in `PipelineResult.Action` instead of hardcoding `ActionReject`.

Includes an integration test that drives the real `bq` CLI through the proxy using a dummy service account, proving both the stub and the token injection work against an off-the-shelf client. CI installs the gcloud SDK before the egress proxy locks down outbound traffic.