### PR TITLE
feat(oauth): add oauth_token transform for OAuth2 token injection

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
+	_ "github.com/ironsh/iron-proxy/internal/transform/oauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 

--- a/integration_test/oauth_token_bigquery_test.go
+++ b/integration_test/oauth_token_bigquery_test.go
@@ -1,0 +1,106 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOAuthTokenBigQuery boots the proxy with the oauth_token transform
+// configured for the jwt_bearer grant, minting OAuth2 access tokens from the
+// service account keyfile at GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE. It runs a
+// BigQuery query through the proxy and asserts the first cell of the first
+// row. The client sends no Authorization header — the proxy injects one after
+// minting a token.
+//
+// The keyfile JSON is handed to the proxy through its own process environment
+// (not the workflow env block, which is printed at the start of every CI
+// step), via the env source the oauth_token credential references.
+func TestOAuthTokenBigQuery(t *testing.T) {
+	keyfilePath := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
+	if keyfilePath == "" {
+		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE not set")
+	}
+	keyJSON, err := os.ReadFile(keyfilePath)
+	require.NoError(t, err, "reading GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
+
+	var meta struct {
+		ProjectID string `json:"project_id"`
+	}
+	require.NoError(t, json.Unmarshal(keyJSON, &meta))
+	require.NotEmpty(t, meta.ProjectID, "service account JSON missing project_id")
+
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+	cfgPath := renderConfig(t, tmpDir, "oauth_token_bigquery.yaml", nil)
+
+	proxy := startProxy(t, binary, cfgPath, []string{"GCP_BIGQUERY_KEYFILE_JSON=" + string(keyJSON)})
+
+	// Trust the proxy's CA so the client accepts the MITM cert it presents
+	// for bigquery.googleapis.com.
+	caPath := filepath.Join(repoRoot(t), "tmp", "ca.crt")
+	caPEM, err := os.ReadFile(caPath)
+	require.NoError(t, err, "expected proxy CA at %s — generate it with: ./iron-proxy generate-ca -outdir tmp -alg ed25519", caPath)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+
+	// CONNECT requests for HTTPS upstreams go to the tunnel listener.
+	tunnelAddr := proxy.AddrFor(t, "tunnel proxy starting")
+	proxyURL, err := url.Parse("http://" + tunnelAddr)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+
+	queryBody, err := json.Marshal(map[string]any{
+		"query":        "SELECT test_field FROM test_dataset.test_table LIMIT 1",
+		"useLegacySql": false,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	endpoint := "https://bigquery.googleapis.com/bigquery/v2/projects/" + meta.ProjectID + "/queries"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(queryBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "BigQuery response: %s", string(body))
+
+	var qr struct {
+		JobComplete bool `json:"jobComplete"`
+		Rows        []struct {
+			F []struct {
+				V any `json:"v"`
+			} `json:"f"`
+		} `json:"rows"`
+	}
+	require.NoError(t, json.Unmarshal(body, &qr))
+	require.True(t, qr.JobComplete, "BigQuery job not complete in synchronous response: %s", string(body))
+	require.NotEmpty(t, qr.Rows, "no rows returned from test_dataset.test_table")
+	require.NotEmpty(t, qr.Rows[0].F, "first row has no fields")
+	require.Equal(t, "foo", qr.Rows[0].F[0].V, "test_dataset.test_table.test_field first value")
+}

--- a/integration_test/testdata/oauth_token_bigquery.yaml
+++ b/integration_test/testdata/oauth_token_bigquery.yaml
@@ -1,0 +1,38 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  tunnel_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "bigquery.googleapis.com"
+
+  - name: oauth_token
+    config:
+      tokens:
+        - grant: jwt_bearer
+          credential:
+            type: env
+            var: GCP_BIGQUERY_KEYFILE_JSON
+          scopes:
+            - "https://www.googleapis.com/auth/bigquery"
+          rules:
+            - host: "bigquery.googleapis.com"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -1,0 +1,205 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"golang.org/x/oauth2/google"
+)
+
+// mint returns a cached or freshly minted access token for the entry.
+func (e *tokenEntry) mint(ctx context.Context) (string, error) {
+	ts, err := e.tokenSourceFor(ctx)
+	if err != nil {
+		return "", err
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return "", fmt.Errorf("minting %s access token: %w", e.grant, err)
+	}
+	if tok.AccessToken == "" {
+		return "", fmt.Errorf("%s token endpoint returned an empty access_token", e.grant)
+	}
+	return tok.AccessToken, nil
+}
+
+// tokenSourceFor returns the entry's oauth2.TokenSource, rebuilding it when the
+// credential blob has changed since it was last built. The returned source
+// caches the access token and single-flights concurrent refreshes.
+func (e *tokenEntry) tokenSourceFor(ctx context.Context) (oauth2.TokenSource, error) {
+	// Get is read outside the lock: the secrets source has its own ttl cache,
+	// so this is cheap and returns a stable value within the ttl window.
+	blob, err := e.credential.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading credential from %q: %w", e.credential.Name(), err)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.tokenSource != nil && blob == e.blob {
+		return e.tokenSource, nil
+	}
+	ts, err := buildTokenSource(ctx, e.grant, blob, e.scopes, e.subject, e.cfgEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	e.tokenSource = ts
+	e.blob = blob
+	return ts, nil
+}
+
+// buildTokenSource constructs an oauth2.TokenSource for one grant from its
+// credential blob. It performs no I/O: the token is exchanged lazily on the
+// first Token() call.
+func buildTokenSource(ctx context.Context, grant, blob string, scopes []string, subject, cfgEndpoint string) (oauth2.TokenSource, error) {
+	switch grant {
+	case grantJWTBearer:
+		return jwtBearerTokenSource(ctx, blob, scopes, subject)
+	case grantRefreshToken:
+		return refreshTokenTokenSource(ctx, blob, scopes, cfgEndpoint)
+	case grantClientCredentials:
+		return clientCredentialsTokenSource(ctx, blob, scopes, cfgEndpoint)
+	default:
+		return nil, fmt.Errorf("unknown grant %q", grant)
+	}
+}
+
+// jwtBearerTokenSource builds a token source for the RFC 7523 JWT-bearer grant
+// from a GCP service-account keyfile. A non-empty subject impersonates that
+// Workspace user via domain-wide delegation.
+func jwtBearerTokenSource(ctx context.Context, blob string, scopes []string, subject string) (oauth2.TokenSource, error) {
+	// JWTConfigFromJSON only accepts service-account keyfiles and validates
+	// that client_email, private_key, and token_uri are present.
+	cfg, err := google.JWTConfigFromJSON([]byte(blob), scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("parsing jwt_bearer service account keyfile: %w", err)
+	}
+	cfg.Subject = subject
+	return cfg.TokenSource(ctx), nil
+}
+
+// authorizedUser is the refresh_token credential blob. Google's
+// Credentials.to_json() authorized-user output satisfies it directly.
+type authorizedUser struct {
+	Token        string `json:"token"`
+	RefreshToken string `json:"refresh_token"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	TokenURI     string `json:"token_uri"`
+	Expiry       string `json:"expiry"`
+}
+
+// refreshTokenTokenSource builds a token source for the RFC 6749 refresh_token
+// grant. The token endpoint is the blob's token_uri when present, otherwise
+// the configured token_endpoint.
+func refreshTokenTokenSource(ctx context.Context, blob string, scopes []string, cfgEndpoint string) (oauth2.TokenSource, error) {
+	var au authorizedUser
+	if err := json.Unmarshal([]byte(blob), &au); err != nil {
+		return nil, fmt.Errorf("parsing refresh_token credential: %w", err)
+	}
+	if au.RefreshToken == "" {
+		return nil, fmt.Errorf("refresh_token credential is missing \"refresh_token\"")
+	}
+	if au.ClientID == "" {
+		return nil, fmt.Errorf("refresh_token credential is missing \"client_id\"")
+	}
+	tokenURL := au.TokenURI
+	if tokenURL == "" {
+		tokenURL = cfgEndpoint
+	}
+	if tokenURL == "" {
+		return nil, fmt.Errorf("refresh_token grant needs a token endpoint: set \"token_endpoint\" or include \"token_uri\" in the credential")
+	}
+
+	cfg := &oauth2.Config{
+		ClientID:     au.ClientID,
+		ClientSecret: au.ClientSecret,
+		Scopes:       scopes,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: tokenURL,
+			// Send client_id/client_secret in the form body, never as HTTP
+			// Basic. Every provider in scope accepts body auth.
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	// Seed the cache from the blob's token/expiry to skip the first refresh.
+	// The expiry format is provider-specific; if it does not parse, the seed
+	// is dropped and the token source refreshes on first use.
+	seed := &oauth2.Token{RefreshToken: au.RefreshToken}
+	if au.Token != "" && au.Expiry != "" {
+		if exp, err := time.Parse(time.RFC3339, au.Expiry); err == nil && exp.After(time.Now()) {
+			seed.AccessToken = au.Token
+			seed.Expiry = exp
+		}
+	}
+	return cfg.TokenSource(ctx, seed), nil
+}
+
+// clientCredentials is the client_credentials credential blob.
+type clientCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// clientCredentialsTokenSource builds a token source for the RFC 6749 4.4
+// client_credentials grant.
+func clientCredentialsTokenSource(ctx context.Context, blob string, scopes []string, tokenURL string) (oauth2.TokenSource, error) {
+	var cc clientCredentials
+	if err := json.Unmarshal([]byte(blob), &cc); err != nil {
+		return nil, fmt.Errorf("parsing client_credentials credential: %w", err)
+	}
+	if cc.ClientID == "" || cc.ClientSecret == "" {
+		return nil, fmt.Errorf("client_credentials credential needs \"client_id\" and \"client_secret\"")
+	}
+	cfg := &clientcredentials.Config{
+		ClientID:     cc.ClientID,
+		ClientSecret: cc.ClientSecret,
+		TokenURL:     tokenURL,
+		Scopes:       scopes,
+		AuthStyle:    oauth2.AuthStyleInParams,
+	}
+	return cfg.TokenSource(ctx), nil
+}
+
+// logMintFailure classifies and logs a mint error and returns a short reason
+// string for the audit annotation. An invalid_grant (revoked or expired
+// refresh token) is unrecoverable and needs a human, so it logs at error
+// level; everything else is potentially transient and logs at warn.
+func (e *tokenEntry) logMintFailure(err error) string {
+	reason, unrecoverable := classifyMintError(err)
+	level := slog.LevelWarn
+	if unrecoverable {
+		level = slog.LevelError
+	}
+	if e.logger != nil {
+		// err may carry the token endpoint's error response, which is the
+		// standard OAuth2 error JSON and contains no credential material.
+		e.logger.Log(context.Background(), level, "oauth_token mint failed",
+			"grant", e.grant, "reason", reason, "error", err)
+	}
+	return reason
+}
+
+func classifyMintError(err error) (reason string, unrecoverable bool) {
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		switch {
+		case re.ErrorCode == "invalid_grant":
+			return "invalid_grant", true
+		case re.ErrorCode != "":
+			return re.ErrorCode, false
+		case re.Response != nil:
+			return fmt.Sprintf("token_endpoint_http_%d", re.Response.StatusCode), false
+		default:
+			return "token_endpoint_error", false
+		}
+	}
+	return "mint_failed", false
+}

--- a/internal/transform/oauth/oauth.go
+++ b/internal/transform/oauth/oauth.go
@@ -1,0 +1,305 @@
+// Package oauth implements a transform that mints OAuth2 access tokens and
+// injects them as Authorization: Bearer headers on matching requests.
+//
+// One oauth_token transform carries a list of token entries. Each entry
+// names an OAuth2 grant (refresh_token, jwt_bearer, or client_credentials), a
+// credential resolved from any secrets-package source (env, 1password,
+// 1password_connect, aws_sm, aws_ssm), and host rules selecting the requests
+// it applies to. Token exchange, caching, refresh, and single-flight are
+// delegated to golang.org/x/oauth2 — the same code path the official SDKs use.
+//
+// jwt_bearer is a strict superset of the older gcp_auth transform: same
+// JWT-bearer exchange, plus a subject field for Workspace domain-wide
+// delegation.
+//
+// Like all header-injecting transforms, this requires MITM mode; sni-only
+// mode has no way to rewrite headers.
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"golang.org/x/oauth2"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+const (
+	grantRefreshToken      = "refresh_token"
+	grantJWTBearer         = "jwt_bearer"
+	grantClientCredentials = "client_credentials"
+)
+
+// stubAccessToken is the placeholder bearer returned to clients that fetch a
+// token from a configured token endpoint through the proxy. The real token is
+// minted by oauth_token and swapped in just before the request leaves the
+// proxy, so the value here never reaches the upstream: it only has to look
+// like an opaque token to the client SDK.
+const stubAccessToken = "iron-proxy-stub-token"
+
+var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","expires_in":3600,"token_type":"Bearer"}`)
+
+func init() {
+	transform.Register("oauth_token", factory)
+}
+
+type config struct {
+	Tokens []tokenEntryConfig `yaml:"tokens"`
+}
+
+type tokenEntryConfig struct {
+	Grant         string                 `yaml:"grant"`
+	Credential    yaml.Node              `yaml:"credential"`
+	TokenEndpoint string                 `yaml:"token_endpoint,omitempty"`
+	Scopes        []string               `yaml:"scopes,omitempty"`
+	Subject       string                 `yaml:"subject,omitempty"`
+	Rules         []hostmatch.RuleConfig `yaml:"rules"`
+	Header        string                 `yaml:"header,omitempty"`
+	ValuePrefix   string                 `yaml:"value_prefix,omitempty"`
+}
+
+// sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
+// can inject a stub instead of constructing real source backends.
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+
+// OAuth is the transform.
+type OAuth struct {
+	entries       []*tokenEntry
+	stubEndpoints []tokenEndpoint
+}
+
+// tokenEntry is one resolved entry from config.tokens.
+type tokenEntry struct {
+	grant       string
+	scopes      []string
+	subject     string // jwt_bearer only
+	rules       []hostmatch.Rule
+	header      string
+	valuePrefix string
+	cfgEndpoint string // config token_endpoint, "" if unset
+	credential  secrets.Source
+	logger      *slog.Logger
+
+	// mu guards the lazily built token source and the credential blob it was
+	// built from. The token source is rebuilt when the blob changes (e.g. the
+	// credential's ttl expired and the secret store returned a new value).
+	mu          sync.Mutex
+	blob        string
+	tokenSource oauth2.TokenSource
+}
+
+// tokenEndpoint is a host+path pair that, when matched by an inbound request,
+// is served a synthetic token response instead of being forwarded.
+type tokenEndpoint struct {
+	host string
+	path string
+}
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing oauth_token config: %w", err)
+	}
+	return newFromConfig(c, logger, secrets.BuildSource)
+}
+
+func newFromConfig(c config, logger *slog.Logger, buildSource sourceBuilder) (*OAuth, error) {
+	if len(c.Tokens) == 0 {
+		return nil, fmt.Errorf("oauth_token: at least one entry in \"tokens\" is required")
+	}
+	o := &OAuth{}
+	for i, tc := range c.Tokens {
+		entry, stub, err := buildEntry(tc, logger, buildSource)
+		if err != nil {
+			return nil, fmt.Errorf("oauth_token: tokens[%d]: %w", i, err)
+		}
+		o.entries = append(o.entries, entry)
+		if stub != nil {
+			o.stubEndpoints = append(o.stubEndpoints, *stub)
+		}
+	}
+	return o, nil
+}
+
+func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuilder) (*tokenEntry, *tokenEndpoint, error) {
+	switch tc.Grant {
+	case grantRefreshToken, grantJWTBearer, grantClientCredentials:
+	default:
+		return nil, nil, fmt.Errorf("\"grant\" must be one of refresh_token, jwt_bearer, client_credentials (got %q)", tc.Grant)
+	}
+	if tc.Credential.Kind == 0 {
+		return nil, nil, fmt.Errorf("\"credential\" is required")
+	}
+	if tc.Subject != "" && tc.Grant != grantJWTBearer {
+		return nil, nil, fmt.Errorf("\"subject\" is only valid for the jwt_bearer grant")
+	}
+	if tc.Grant == grantClientCredentials && tc.TokenEndpoint == "" {
+		return nil, nil, fmt.Errorf("client_credentials grant requires \"token_endpoint\"")
+	}
+
+	rules, err := hostmatch.CompileRules(tc.Rules, "rules")
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(rules) == 0 {
+		return nil, nil, fmt.Errorf("at least one entry in \"rules\" is required")
+	}
+
+	src, err := buildSource(tc.Credential, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("building credential source: %w", err)
+	}
+
+	var stub *tokenEndpoint
+	if tc.TokenEndpoint != "" {
+		stub, err = parseTokenEndpoint(tc.TokenEndpoint)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid token_endpoint: %w", err)
+		}
+	}
+
+	header := tc.Header
+	if header == "" {
+		header = "Authorization"
+	}
+	valuePrefix := tc.ValuePrefix
+	if valuePrefix == "" {
+		valuePrefix = "Bearer "
+	}
+
+	return &tokenEntry{
+		grant:       tc.Grant,
+		scopes:      tc.Scopes,
+		subject:     tc.Subject,
+		rules:       rules,
+		header:      header,
+		valuePrefix: valuePrefix,
+		cfgEndpoint: tc.TokenEndpoint,
+		credential:  src,
+		logger:      logger,
+	}, stub, nil
+}
+
+// parseTokenEndpoint splits a configured token endpoint URL into the host and
+// path used to recognize a client's token request for stubbing.
+func parseTokenEndpoint(raw string) (*tokenEndpoint, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("%q has no host", raw)
+	}
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	return &tokenEndpoint{host: hostmatch.StripPort(u.Host), path: path}, nil
+}
+
+func (o *OAuth) Name() string { return "oauth_token" }
+
+func (o *OAuth) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	// Stubbing a configured token endpoint runs before host rules so a
+	// sandboxed SDK can always complete its own token dance against the proxy
+	// with a placeholder token. oauth_token mints the real token separately
+	// and injects it on the API request.
+	if o.matchesTokenEndpoint(req) {
+		tctx.Annotate("stubbed", "oauth2_token_endpoint")
+		return &transform.TransformResult{
+			Action:   transform.ActionStub,
+			Response: stubTokenResponse(req),
+		}, nil
+	}
+
+	// First entry whose rules host-match wins; config order is the tie-breaker.
+	entry := o.matchEntry(req)
+	if entry == nil {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	tok, err := entry.mint(ctx)
+	if err != nil {
+		reason := entry.logMintFailure(err)
+		tctx.Annotate("grant", entry.grant)
+		tctx.Annotate("error", reason)
+		tctx.Annotate("rejected", "token_unavailable")
+		// Fail closed with a 502: forwarding an unauthenticated request would
+		// surface as a confusing upstream 401.
+		return &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: mintFailureResponse(req, entry.grant),
+		}, nil
+	}
+
+	req.Header.Set(entry.header, entry.valuePrefix+tok)
+	tctx.Annotate("grant", entry.grant)
+	if entry.subject != "" {
+		tctx.Annotate("subject", entry.subject)
+	}
+	tctx.Annotate("injected", []string{"header:" + http.CanonicalHeaderKey(entry.header)})
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (o *OAuth) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+// matchEntry returns the first entry whose host rules match req, or nil.
+func (o *OAuth) matchEntry(req *http.Request) *tokenEntry {
+	for _, e := range o.entries {
+		if hostmatch.MatchAnyRule(e.rules, req) {
+			return e
+		}
+	}
+	return nil
+}
+
+// matchesTokenEndpoint reports whether req targets one of the configured token
+// endpoints, which the proxy serves with a synthetic token instead of
+// forwarding.
+func (o *OAuth) matchesTokenEndpoint(req *http.Request) bool {
+	host := hostmatch.StripPort(req.Host)
+	var path string
+	if req.URL != nil {
+		path = req.URL.Path
+	}
+	for _, te := range o.stubEndpoints {
+		if te.host == host && te.path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func stubTokenResponse(req *http.Request) *http.Response {
+	return jsonResponse(req, http.StatusOK, "200 OK", stubTokenJSON)
+}
+
+func mintFailureResponse(req *http.Request, grant string) *http.Response {
+	// grant is a config-validated enum, so it is safe to interpolate.
+	body := []byte(`{"error":"oauth_token failed to mint an access token","grant":"` + grant + `"}`)
+	return jsonResponse(req, http.StatusBadGateway, "502 Bad Gateway", body)
+}
+
+func jsonResponse(req *http.Request, status int, statusText string, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode:    status,
+		Status:        statusText,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          transform.NewBufferedBodyFromBytes(body),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}

--- a/internal/transform/oauth/oauth_test.go
+++ b/internal/transform/oauth/oauth_test.go
@@ -1,0 +1,672 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+// --- test doubles ---
+
+// staticSource implements secrets.Source with a fixed value or error.
+type staticSource struct {
+	name  string
+	value string
+	err   error
+	calls atomic.Int64
+}
+
+func (s *staticSource) Name() string { return s.name }
+func (s *staticSource) Get(context.Context) (string, error) {
+	s.calls.Add(1)
+	return s.value, s.err
+}
+
+func staticBuilder(src secrets.Source) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return src, nil }
+}
+
+// tokenServer is a fake OAuth2 token endpoint. It counts requests and records
+// each request's form so tests can assert on the exchange.
+type tokenServer struct {
+	*httptest.Server
+	mu    sync.Mutex
+	calls int
+	forms []url.Values
+}
+
+func (ts *tokenServer) Calls() int {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.calls
+}
+
+func (ts *tokenServer) LastForm() url.Values {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.forms[len(ts.forms)-1]
+}
+
+// newTokenServer serves the OAuth2 token endpoint. respond decides the HTTP
+// status and JSON body per request; pass nil for the default success
+// response that mints "minted-token".
+func newTokenServer(t *testing.T, respond func(form url.Values) (int, map[string]any)) *tokenServer {
+	t.Helper()
+	if respond == nil {
+		respond = func(url.Values) (int, map[string]any) {
+			return http.StatusOK, map[string]any{
+				"access_token": "minted-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+		}
+	}
+	ts := &tokenServer{}
+	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		ts.mu.Lock()
+		ts.calls++
+		ts.forms = append(ts.forms, r.PostForm)
+		ts.mu.Unlock()
+		status, body := respond(r.PostForm)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// --- credential blob builders ---
+
+// keyfileJSON generates a GCP service-account keyfile whose JWT-bearer
+// exchange targets tokenURL.
+func keyfileJSON(t *testing.T, tokenURL string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	data, err := json.Marshal(map[string]string{
+		"type":           "service_account",
+		"project_id":     "test-project",
+		"private_key_id": "test-key-id",
+		"private_key":    string(pemBytes),
+		"client_email":   "sa@test-project.iam.gserviceaccount.com",
+		"token_uri":      tokenURL,
+	})
+	require.NoError(t, err)
+	return data
+}
+
+func refreshTokenJSON(t *testing.T, tokenURI string) []byte {
+	t.Helper()
+	blob := map[string]any{
+		"refresh_token": "test-refresh-token",
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+	}
+	if tokenURI != "" {
+		blob["token_uri"] = tokenURI
+	}
+	data, err := json.Marshal(blob)
+	require.NoError(t, err)
+	return data
+}
+
+func clientCredentialsJSON(t *testing.T) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]string{
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+	})
+	require.NoError(t, err)
+	return data
+}
+
+// --- generic helpers ---
+
+func yamlFromString(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	return *node.Content[0]
+}
+
+func newRequest(t *testing.T, method, rawURL string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(method, rawURL, nil)
+	require.NoError(t, err)
+	return r
+}
+
+func newContext() *transform.TransformContext {
+	return &transform.TransformContext{Mode: transform.ModeMITM}
+}
+
+// buildTransform decodes cfgYAML and builds the transform with a static
+// credential source, so tests never reach a real secret backend.
+func buildTransform(t *testing.T, cfgYAML string, src secrets.Source) *OAuth {
+	t.Helper()
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+	o, err := newFromConfig(c, slog.Default(), staticBuilder(src))
+	require.NoError(t, err)
+	return o
+}
+
+type tokenJSON struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func decodeBody(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+	require.NotNil(t, resp)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return body
+}
+
+func decodeJWTClaims(t *testing.T, assertion string) map[string]any {
+	t.Helper()
+	parts := strings.Split(assertion, ".")
+	require.Len(t, parts, 3, "assertion is not a JWT")
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(raw, &claims))
+	return claims
+}
+
+// --- validation ---
+
+func TestValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantError string
+	}{
+		{
+			name:      "empty tokens",
+			yaml:      `tokens: []`,
+			wantError: "at least one entry in \"tokens\"",
+		},
+		{
+			name: "unknown grant",
+			yaml: `
+tokens:
+  - grant: password
+    credential: {type: env, var: X}
+    rules:
+      - host: "example.com"
+`,
+			wantError: "\"grant\" must be one of",
+		},
+		{
+			name: "missing credential",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    rules:
+      - host: "example.com"
+`,
+			wantError: "\"credential\" is required",
+		},
+		{
+			name: "subject on non-jwt grant",
+			yaml: `
+tokens:
+  - grant: refresh_token
+    credential: {type: env, var: X}
+    subject: user@example.com
+    rules:
+      - host: "example.com"
+`,
+			wantError: "\"subject\" is only valid for the jwt_bearer grant",
+		},
+		{
+			name: "client_credentials without token_endpoint",
+			yaml: `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    rules:
+      - host: "example.com"
+`,
+			wantError: "client_credentials grant requires \"token_endpoint\"",
+		},
+		{
+			name: "missing rules",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    credential: {type: env, var: X}
+`,
+			wantError: "at least one entry in \"rules\"",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c config
+			node := yamlFromString(t, tc.yaml)
+			require.NoError(t, node.Decode(&c))
+			_, err := newFromConfig(c, slog.Default(), staticBuilder(&staticSource{}))
+			require.ErrorContains(t, err, tc.wantError)
+		})
+	}
+}
+
+// --- refresh_token grant ---
+
+func TestRefreshTokenGrant_InjectsBearer(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	tokenURL := srv.URL + "/token"
+	src := &staticSource{name: "op://ai-agents/GSUITE", value: string(refreshTokenJSON(t, tokenURL))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: refresh_token
+    credential: {type: env, var: X}
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
+    rules:
+      - host: "gmail.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/gmail/v1/users/me/messages")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+
+	form := srv.LastForm()
+	require.Equal(t, "refresh_token", form.Get("grant_type"))
+	require.Equal(t, "test-refresh-token", form.Get("refresh_token"))
+	require.Equal(t, "test-client-id", form.Get("client_id"))
+	require.Equal(t, "test-client-secret", form.Get("client_secret"), "client auth must be in the form body")
+}
+
+// The token endpoint comes from the credential blob's token_uri when no
+// token_endpoint is configured.
+func TestRefreshTokenGrant_TokenURIFromBlobOnly(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "blob", value: string(refreshTokenJSON(t, srv.URL+"/token"))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: refresh_token
+    credential: {type: env, var: X}
+    rules:
+      - host: "gmail.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+	require.Equal(t, 1, srv.Calls())
+}
+
+// --- jwt_bearer grant ---
+
+func TestJWTBearerGrant_WithoutSubject(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "keyfile", value: string(keyfileJSON(t, srv.URL+"/token"))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: jwt_bearer
+    credential: {type: env, var: X}
+    scopes: ["https://www.googleapis.com/auth/bigquery.readonly"]
+    rules:
+      - host: "bigquery.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://bigquery.googleapis.com/bigquery/v2/projects/p/queries")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+
+	form := srv.LastForm()
+	require.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", form.Get("grant_type"))
+	claims := decodeJWTClaims(t, form.Get("assertion"))
+	require.Equal(t, "sa@test-project.iam.gserviceaccount.com", claims["iss"])
+	require.NotContains(t, claims, "sub", "no subject configured: assertion must not impersonate")
+}
+
+func TestJWTBearerGrant_WithSubject(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "keyfile", value: string(keyfileJSON(t, srv.URL+"/token"))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: jwt_bearer
+    credential: {type: env, var: X}
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
+    subject: "user@workspace.example.com"
+    rules:
+      - host: "gmail.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	tctx := newContext()
+	res, err := o.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	claims := decodeJWTClaims(t, srv.LastForm().Get("assertion"))
+	require.Equal(t, "user@workspace.example.com", claims["sub"], "subject must impersonate the configured user")
+	require.Equal(t, "user@workspace.example.com", tctx.DrainAnnotations()["subject"])
+}
+
+// --- client_credentials grant ---
+
+func TestClientCredentialsGrant_InjectsBearer(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["api.read"]
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/things")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+
+	form := srv.LastForm()
+	require.Equal(t, "client_credentials", form.Get("grant_type"))
+	require.Equal(t, "test-client-id", form.Get("client_id"))
+	require.Equal(t, "test-client-secret", form.Get("client_secret"))
+	require.Equal(t, "api.read", form.Get("scope"))
+}
+
+// --- caching, matching, injection behavior ---
+
+func TestCachesTokenAcrossRequests(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	for i := 0; i < 5; i++ {
+		req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+		_, err := o.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+	}
+	require.Equal(t, 1, srv.Calls(), "token should be minted once and cached")
+}
+
+func TestConcurrentRequestsTriggerSingleRefresh(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+			_, err := o.TransformRequest(context.Background(), newContext(), req)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 1, srv.Calls(), "concurrent requests must single-flight the exchange")
+}
+
+func TestNoMatchingEntryPassesThrough(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://other.example.org/v1/x")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, 0, srv.Calls())
+}
+
+func TestOverwritesExistingAuthorizationHeader(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+	req.Header.Set("Authorization", "Bearer client-supplied-token")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+}
+
+// The first entry whose rules match wins, in config order.
+func TestFirstMatchingEntryWins(t *testing.T) {
+	srv := newTokenServer(t, func(form url.Values) (int, map[string]any) {
+		return http.StatusOK, map[string]any{
+			"access_token": "token-for-" + form.Get("scope"),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+	})
+	src := &staticSource{name: "creds", value: string(clientCredentialsJSON(t))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["first"]
+    rules:
+      - host: "*.example.com"
+  - grant: client_credentials
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["second"]
+    rules:
+      - host: "api.example.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer token-for-first", req.Header.Get("Authorization"))
+}
+
+// --- token endpoint stubbing ---
+
+func TestStubsConfiguredTokenEndpoint(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	tokenURL := srv.URL + "/token"
+	src := &staticSource{name: "keyfile", value: string(keyfileJSON(t, tokenURL))}
+
+	// rules target the API host on purpose: stubbing must not depend on the
+	// rules matching the token endpoint.
+	o := buildTransform(t, `
+tokens:
+  - grant: jwt_bearer
+    credential: {type: env, var: X}
+    token_endpoint: "`+tokenURL+`"
+    scopes: ["https://www.googleapis.com/auth/bigquery"]
+    rules:
+      - host: "bigquery.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodPost, tokenURL)
+	tctx := newContext()
+	res, err := o.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionStub, res.Action)
+
+	var decoded tokenJSON
+	require.NoError(t, json.Unmarshal(decodeBody(t, res.Response), &decoded))
+	require.Equal(t, stubAccessToken, decoded.AccessToken)
+	require.Equal(t, "Bearer", decoded.TokenType)
+	require.Equal(t, 3600, decoded.ExpiresIn)
+	require.Equal(t, "oauth2_token_endpoint", tctx.DrainAnnotations()["stubbed"])
+	require.Equal(t, 0, srv.Calls(), "the real token endpoint must not be hit when stubbing")
+}
+
+// A non-token path on the token endpoint host is not stubbed.
+func TestDoesNotStubOtherPaths(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	src := &staticSource{name: "keyfile", value: string(keyfileJSON(t, srv.URL+"/token"))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: jwt_bearer
+    credential: {type: env, var: X}
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["s"]
+    rules:
+      - host: "bigquery.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, srv.URL+"/revoke")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action, "non-token path falls through")
+}
+
+// --- failure handling ---
+
+func TestInvalidGrantFails502(t *testing.T) {
+	srv := newTokenServer(t, func(url.Values) (int, map[string]any) {
+		return http.StatusBadRequest, map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "Token has been expired or revoked.",
+		}
+	})
+	src := &staticSource{name: "blob", value: string(refreshTokenJSON(t, srv.URL+"/token"))}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: refresh_token
+    credential: {type: env, var: X}
+    rules:
+      - host: "gmail.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	tctx := newContext()
+	res, err := o.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+	require.Equal(t, http.StatusBadGateway, res.Response.StatusCode)
+	require.Empty(t, req.Header.Get("Authorization"), "an unauthenticated request must not be forwarded")
+
+	body := decodeBody(t, res.Response)
+	require.Contains(t, string(body), "oauth_token failed to mint")
+
+	annotations := tctx.DrainAnnotations()
+	require.Equal(t, "invalid_grant", annotations["error"])
+	require.Equal(t, "token_unavailable", annotations["rejected"])
+}
+
+func TestCredentialUnavailableFails502(t *testing.T) {
+	src := &staticSource{name: "blob", err: io.ErrUnexpectedEOF}
+
+	o := buildTransform(t, `
+tokens:
+  - grant: refresh_token
+    credential: {type: env, var: X}
+    token_endpoint: "https://oauth2.example.com/token"
+    rules:
+      - host: "gmail.googleapis.com"
+`, src)
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+	require.Equal(t, http.StatusBadGateway, res.Response.StatusCode)
+}
+
+// --- factory end-to-end through the real secrets package ---
+
+func TestFactory_EndToEnd(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	t.Setenv("OAUTH_CREDENTIAL", string(clientCredentialsJSON(t)))
+
+	tr, err := factory(yamlFromString(t, `
+tokens:
+  - grant: client_credentials
+    credential:
+      type: env
+      var: OAUTH_CREDENTIAL
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`), slog.Default())
+	require.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+	res, err := tr.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -256,6 +256,44 @@ transforms:
   #     rules:
   #       - host: "*.googleapis.com"
 
+  # OAuth2 token injection. Mints short-lived OAuth2 access tokens and sets
+  # Authorization: Bearer on matching requests. Each entry under tokens names
+  # a grant type, a credential, and the hosts it applies to. Token exchange,
+  # caching, and refresh are handled automatically. Requires MITM mode. On a
+  # minting failure the request is rejected with a 502.
+  #
+  # grant is one of:
+  #   refresh_token       RFC 6749 — an authorized-user blob (a refresh token)
+  #   jwt_bearer          RFC 7523 — a GCP service-account keyfile
+  #   client_credentials  RFC 6749 4.4 — a client id and secret
+  #
+  # credential resolves the credential blob from any secret source (env,
+  # aws_sm, aws_ssm, 1password, 1password_connect), the same shape as a
+  # secrets transform source. Setting token_endpoint also stubs that endpoint,
+  # so a sandboxed client SDK can complete its own token dance against the
+  # proxy with a placeholder token while the proxy injects the real one.
+  # - name: oauth_token
+  #   config:
+  #     tokens:
+  #       - grant: refresh_token
+  #         credential:
+  #           type: 1password_connect
+  #           secret_ref: "op://Engineering/GSUITE-OAUTH/credential"
+  #         token_endpoint: "https://oauth2.googleapis.com/token"
+  #         scopes:
+  #           - "https://www.googleapis.com/auth/gmail.readonly"
+  #         rules:
+  #           - host: "gmail.googleapis.com"
+  #       - grant: jwt_bearer
+  #         credential:
+  #           type: 1password_connect
+  #           secret_ref: "op://Engineering/BIGQUERY-SA/credential"
+  #         subject: ""   # set for Workspace domain-wide delegation
+  #         scopes:
+  #           - "https://www.googleapis.com/auth/bigquery.readonly"
+  #         rules:
+  #           - host: "bigquery.googleapis.com"
+
   # Header allowlist: strips any request header not listed below before the
   # request goes upstream. Default-deny — every header must either match a
   # literal name (case-insensitive) or a /regex/ pattern. Place this AFTER


### PR DESCRIPTION
Adds an `oauth_token` request transform that mints short-lived OAuth2 access tokens and injects them as `Authorization: Bearer` headers on configured hosts. It supports three grant types — `refresh_token` (RFC 6749), `jwt_bearer` (RFC 7523), and `client_credentials` (RFC 6749 4.4) — with token exchange, caching, refresh, and single-flight delegated to `golang.org/x/oauth2`.

Credentials resolve from any secrets-package source (env, 1password, aws_sm, etc.), the credential is re-read on its `ttl` and the token source rebuilt when it changes. A configured `token_endpoint` is also stubbed so a sandboxed client SDK can complete its own token dance against the proxy with a placeholder token while the proxy injects the real one. Mint failures fail the request closed with a synthetic 502 rather than forwarding an unauthenticated request.

The existing `gcp_auth` transform is left in place; `oauth_token` ships purely additively. Covered by unit tests for each grant plus a jwt_bearer BigQuery integration test.