### PR TITLE
feat(transform): add body_capture transform exposing decoded request bodies in audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ Transforms run in order. Built-in transforms:
 
 | Transform   | What it does                                                                                                            |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `allowlist` | Permits requests to matching domains/CIDRs; rejects everything else (403).                                              |
-| `secrets`   | Scans headers, query params, and optionally body for proxy tokens and swaps in real secrets from environment variables. |
+| `allowlist`    | Permits requests to matching domains/CIDRs; rejects everything else (403).                                              |
+| `secrets`      | Scans headers, query params, and optionally body for proxy tokens and swaps in real secrets from environment variables. |
+| `body_capture` | Records decoded request bodies of matching hosts as `request_body` audit fields. Observation-only; never rejects.       |
 
 ## Configuration
 
@@ -356,6 +357,44 @@ transforms:
         - "/^X-Trace-.*$/"
       rules:
         - host: "api.openai.com"
+```
+
+### Body capture
+
+Records the decoded request body of matching requests and surfaces it on the
+audit log record as top-level `request_body` and `request_body_truncated`
+fields. Useful for auditing the payloads passing through the proxy, such as the
+prompts a sandbox sends to an LLM provider, without modifying the upstream
+traffic.
+
+Hosts, methods, and paths are matched with the same `rules` syntax as
+`allowlist` and `secrets`. `max_request_body_bytes` caps how much of each body
+is captured; bodies larger than the cap are truncated to the prefix and
+`request_body_truncated` is set to `true`. The cap defaults to 16 KiB and is
+independent of the global `proxy.max_request_body_bytes` limit. This transform
+is observation-only: it never rejects a request, and body read errors are
+annotated on the trace rather than failing the request.
+
+Response bodies are not captured. Streaming responses (SSE) would have to be
+buffered end-to-end before forwarding, which would stall the client.
+
+> **Warning:** Captured bodies are written to the audit log in plain text. When
+> `secrets` runs with `match_body: true`, place `body_capture` *before* `secrets`
+> so the audit log records the sandbox's proxy tokens rather than the real
+> credentials `secrets` swaps into the body.
+
+```yaml
+transforms:
+  - name: body_capture
+    config:
+      max_request_body_bytes: 16384
+      rules:
+        - host: "api.anthropic.com"
+          methods: ["POST"]
+          paths: ["/v1/messages"]
+        - host: "api.openai.com"
+          methods: ["POST"]
+          paths: ["/v1/chat/completions"]
 ```
 
 ### Secrets

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -32,6 +32,7 @@ import (
 	// Register built-in transforms.
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
+	_ "github.com/ironsh/iron-proxy/internal/transform/bodycapture"
 	_ "github.com/ironsh/iron-proxy/internal/transform/gcpauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -304,7 +304,13 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	r.Body = transform.NewBufferedBody(r.Body, bodyLimits.MaxRequestBodyBytes)
 
 	// Run request transforms
-	if rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &result.RequestTransforms); err != nil {
+	rejectResp, err := pl.ProcessRequest(r.Context(), tctx, r, &result.RequestTransforms)
+	// Copy any captured request body from the body_capture transform's side
+	// channel onto the PipelineResult so the audit emitters can render it as
+	// a top-level field. Done unconditionally so reject + error paths still
+	// preserve the captured body (matches MCP's behavior at line ~333 below).
+	result.BodyCapture = tctx.BodyCapture
+	if err != nil {
 		if markIfClientCancel(r, err, result) {
 			return
 		}
@@ -313,7 +319,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		result.Err = err
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
-	} else if rejectResp != nil {
+	}
+	if rejectResp != nil {
 		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
 		p.writeResponse(w, rejectResp)

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -86,6 +86,12 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 			}
 			attrs = append(attrs, slog.Group("mcp", mcpAttrs...))
 		}
+		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
+			attrs = append(attrs,
+				slog.String("request_body", result.BodyCapture.RequestBody()),
+				slog.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
+			)
+		}
 
 		switch {
 		case result.Err != nil:

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -294,7 +294,7 @@ func TestAudit_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
 
 	// request_body / request_body_truncated land at the TOP level of the log
 	// record (mirroring the MCP block's position), not inside the `audit`
-	// group. ENG-571 / litmus parseIronProxyAudit reads them at root.
+	// group.
 	require.Equal(t, `{"prompt":"hi"}`, parsed["request_body"], "raw=%s", raw)
 	require.Equal(t, false, parsed["request_body_truncated"])
 }

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -266,3 +266,95 @@ func TestAudit_EmptyTransforms(t *testing.T) {
 	audit := parsed["audit"].(map[string]any)
 	require.Equal(t, "allow", audit["action"])
 }
+
+// fakeBodyCapture is a test-only implementation of BodyCapture for exercising
+// the audit emitters without pulling in the bodycapture package (which would
+// cause an import cycle via its dependency on transform).
+type fakeBodyCapture struct {
+	body      string
+	truncated bool
+}
+
+func (f *fakeBodyCapture) RequestBody() string        { return f.body }
+func (f *fakeBodyCapture) RequestBodyTruncated() bool { return f.truncated }
+
+func TestAudit_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
+	result := &PipelineResult{
+		Host:        "api.anthropic.com",
+		Method:      "POST",
+		Path:        "/v1/messages",
+		StartedAt:   time.Now(),
+		Duration:    1 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{body: `{"prompt":"hi"}`, truncated: false},
+	}
+
+	parsed, raw := captureAuditLog(result)
+
+	// request_body / request_body_truncated land at the TOP level of the log
+	// record (mirroring the MCP block's position), not inside the `audit`
+	// group. ENG-571 / litmus parseIronProxyAudit reads them at root.
+	require.Equal(t, `{"prompt":"hi"}`, parsed["request_body"], "raw=%s", raw)
+	require.Equal(t, false, parsed["request_body_truncated"])
+}
+
+func TestAudit_BodyCapture_TruncationFlagPropagates(t *testing.T) {
+	result := &PipelineResult{
+		Host:        "api.openai.com",
+		Method:      "POST",
+		Path:        "/v1/chat/completions",
+		StartedAt:   time.Now(),
+		Duration:    1 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{body: "xxxxxxxxxxxxxxxx", truncated: true},
+	}
+
+	parsed, _ := captureAuditLog(result)
+
+	require.Equal(t, true, parsed["request_body_truncated"])
+}
+
+func TestAudit_BodyCapture_NilOmitsFields(t *testing.T) {
+	// No body_capture rule matched — BodyCapture is nil. Audit line must
+	// NOT include request_body / request_body_truncated fields.
+	result := &PipelineResult{
+		Host:       "example.com",
+		Method:     "GET",
+		Path:       "/",
+		StartedAt:  time.Now(),
+		Duration:   1 * time.Millisecond,
+		Action:     ActionContinue,
+		StatusCode: 200,
+	}
+
+	parsed, raw := captureAuditLog(result)
+
+	_, hasBody := parsed["request_body"]
+	require.False(t, hasBody, "request_body should be absent when BodyCapture is nil. raw=%s", raw)
+	_, hasFlag := parsed["request_body_truncated"]
+	require.False(t, hasFlag, "request_body_truncated should be absent when BodyCapture is nil. raw=%s", raw)
+}
+
+func TestAudit_BodyCapture_EmptyBodyOmitsFields(t *testing.T) {
+	// BodyCapture is set but RequestBody() is empty (defensive — shouldn't
+	// happen in practice because the transform skips empty bodies, but the
+	// audit emitter checks `!= ""` too). Audit line must not include the
+	// fields.
+	result := &PipelineResult{
+		Host:        "example.com",
+		Method:      "GET",
+		Path:        "/",
+		StartedAt:   time.Now(),
+		Duration:    1 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{body: "", truncated: false},
+	}
+
+	parsed, _ := captureAuditLog(result)
+
+	_, hasBody := parsed["request_body"]
+	require.False(t, hasBody, "request_body should be absent when RequestBody() is empty")
+}

--- a/internal/transform/bodycapture/bodycapture.go
+++ b/internal/transform/bodycapture/bodycapture.go
@@ -3,13 +3,10 @@
 // audit emitters to render as top-level `request_body` and
 // `request_body_truncated` audit fields.
 //
-// Phase 1a (litmus ENG-578): request bodies only. Response body capture is
-// deferred to a follow-up — iron-proxy's BufferedBody is "buffer-then-replay"
-// not "tee-stream", and buffering response bodies for matching hosts would
-// stall SSE-streaming model replies (Anthropic / OpenAI) for the duration of
-// the stream, breaking the candidate's terminal UX. Once iron-proxy gains
-// tee-stream support, response capture can be added behind the same
-// BodyCapture interface.
+// This transform captures request bodies only. It does not capture response
+// bodies: BufferedBody buffers then replays rather than streaming, so reading
+// a response body in a transform would stall SSE-streaming model replies
+// (Anthropic / OpenAI) for the duration of the stream.
 package bodycapture
 
 import (
@@ -18,6 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 
@@ -97,6 +95,17 @@ func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.Transf
 	if int64(len(data)) > b.maxRequestBodyBytes {
 		data = data[:b.maxRequestBodyBytes]
 		truncated = true
+		// The byte-boundary cut above may have split a multi-byte UTF-8 rune,
+		// leaving an invalid trailing fragment that renders as U+FFFD in the
+		// audit JSON. Drop up to UTFMax-1 trailing bytes to land on a rune
+		// boundary. Bounded so a body that is genuinely not UTF-8 (binary)
+		// keeps its tail rather than being progressively stripped.
+		for i := 0; i < utf8.UTFMax-1 && len(data) > 0; i++ {
+			if r, size := utf8.DecodeLastRune(data); r != utf8.RuneError || size > 1 {
+				break
+			}
+			data = data[:len(data)-1]
+		}
 	}
 	tctx.BodyCapture = &capture{
 		requestBody:          string(data),
@@ -105,8 +114,8 @@ func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.Transf
 	return cont, nil
 }
 
-// TransformResponse is a no-op for body_capture in Phase 1a. See the package
-// doc for the rationale (tee-stream needed before response capture is safe).
+// TransformResponse is a no-op for body_capture. See the package doc for why
+// response bodies are not captured.
 func (b *bodyCapture) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }

--- a/internal/transform/bodycapture/bodycapture.go
+++ b/internal/transform/bodycapture/bodycapture.go
@@ -1,0 +1,121 @@
+// Package bodycapture implements a transform that captures request bodies of
+// matching requests and exposes them via PipelineResult.BodyCapture for the
+// audit emitters to render as top-level `request_body` and
+// `request_body_truncated` audit fields.
+//
+// Phase 1a (litmus ENG-578): request bodies only. Response body capture is
+// deferred to a follow-up — iron-proxy's BufferedBody is "buffer-then-replay"
+// not "tee-stream", and buffering response bodies for matching hosts would
+// stall SSE-streaming model replies (Anthropic / OpenAI) for the duration of
+// the stream, breaking the candidate's terminal UX. Once iron-proxy gains
+// tee-stream support, response capture can be added behind the same
+// BodyCapture interface.
+package bodycapture
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func init() {
+	transform.Register("body_capture", factory)
+}
+
+// defaultMaxRequestBodyBytes is the per-request cap when the config doesn't
+// specify max_request_body_bytes. Sized for typical AI-prompt capture — a
+// well-structured chat completion request is comfortably under 16 KB. Long
+// conversation histories may truncate; the truncation flag in the audit
+// surface lets downstream consumers see when this happens.
+const defaultMaxRequestBodyBytes = 16 * 1024
+
+// bodyCapture is the transform itself. Unexported because all external use
+// goes through the factory registration.
+type bodyCapture struct {
+	rules               []hostmatch.Rule
+	maxRequestBodyBytes int64
+}
+
+type config struct {
+	MaxRequestBodyBytes int64                  `yaml:"max_request_body_bytes"`
+	Rules               []hostmatch.RuleConfig `yaml:"rules"`
+}
+
+func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing body_capture config: %w", err)
+	}
+	rules, err := hostmatch.CompileRules(c.Rules, "body_capture")
+	if err != nil {
+		return nil, err
+	}
+	maxBytes := c.MaxRequestBodyBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxRequestBodyBytes
+	}
+	return &bodyCapture{rules: rules, maxRequestBodyBytes: maxBytes}, nil
+}
+
+// Name returns the transform's registered name.
+func (b *bodyCapture) Name() string { return "body_capture" }
+
+// TransformRequest reads the request body via the pipeline's BufferedBody and,
+// if the request matches a configured rule, attaches the captured (and
+// possibly truncated) body bytes to TransformContext.BodyCapture. The proxy
+// copies that onto PipelineResult after the pipeline returns; the audit
+// emitters render it as top-level `request_body` + `request_body_truncated`.
+//
+// Always returns ActionContinue — body_capture is observation-only and never
+// rejects a request. Read errors are annotated for observability and swallowed
+// so a misbehaving body reader can't take down the request.
+func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	cont := &transform.TransformResult{Action: transform.ActionContinue}
+	if !hostmatch.MatchAnyRule(b.rules, req) {
+		return cont, nil
+	}
+	if req.Body == nil || req.Body == http.NoBody {
+		return cont, nil
+	}
+	bb := transform.RequireBufferedBody(req.Body)
+	data, err := io.ReadAll(bb)
+	if err != nil {
+		tctx.Annotate("body_capture_error", err.Error())
+		return cont, nil
+	}
+	if len(data) == 0 {
+		return cont, nil
+	}
+	truncated := false
+	if int64(len(data)) > b.maxRequestBodyBytes {
+		data = data[:b.maxRequestBodyBytes]
+		truncated = true
+	}
+	tctx.BodyCapture = &capture{
+		requestBody:          string(data),
+		requestBodyTruncated: truncated,
+	}
+	return cont, nil
+}
+
+// TransformResponse is a no-op for body_capture in Phase 1a. See the package
+// doc for the rationale (tee-stream needed before response capture is safe).
+func (b *bodyCapture) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+// capture is the concrete implementation of transform.BodyCapture.
+type capture struct {
+	requestBody          string
+	requestBodyTruncated bool
+}
+
+func (c *capture) RequestBody() string        { return c.requestBody }
+func (c *capture) RequestBodyTruncated() bool { return c.requestBodyTruncated }

--- a/internal/transform/bodycapture/bodycapture_test.go
+++ b/internal/transform/bodycapture/bodycapture_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -90,6 +91,28 @@ func TestBodyCapture_BodyExceedsCap_TruncatesWithFlag(t *testing.T) {
 	require.True(t, tctx.BodyCapture.RequestBodyTruncated(), "truncated flag should be set")
 }
 
+func TestBodyCapture_Truncation_TrimsPartialUTF8Rune(t *testing.T) {
+	// Cap falls in the middle of a multi-byte rune. The captured body must be
+	// valid UTF-8 (no dangling fragment) so it renders cleanly in audit JSON.
+	// "€" is 3 bytes (0xE2 0x82 0xAC). With a body of "ab€" (5 bytes) and a
+	// cap of 4, the naive cut keeps "ab" + the first 2 bytes of "€".
+	const cap = 4
+	bc := newTransform(t, cap, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+	})
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", "ab€")
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, tctx.BodyCapture)
+	got := tctx.BodyCapture.RequestBody()
+	require.True(t, utf8.ValidString(got), "captured body must be valid UTF-8, got %q", got)
+	require.Equal(t, "ab", got, "partial trailing rune should be trimmed back to a boundary")
+	require.True(t, tctx.BodyCapture.RequestBodyTruncated())
+}
+
 func TestBodyCapture_EmptyBody_DoesNotPopulateTctx(t *testing.T) {
 	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
 		{Host: "api.anthropic.com"},
@@ -130,10 +153,9 @@ func TestBodyCapture_MultipleRules_FirstMatchCapturesOnce(t *testing.T) {
 }
 
 func TestBodyCapture_TransformResponse_IsNoop(t *testing.T) {
-	// Phase 1a: response capture is deferred until iron-proxy gains tee-stream
-	// support. TransformResponse must NOT touch the response body — doing so
-	// would force-buffer streaming SSE responses (Claude/OpenAI replies),
-	// stalling the candidate's terminal. This test pins that behavior.
+	// TransformResponse must NOT touch the response body — doing so would
+	// force-buffer streaming SSE responses (Claude/OpenAI replies), stalling
+	// the client. This test pins that behavior.
 	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
 		{Host: "api.anthropic.com"},
 	})
@@ -152,8 +174,8 @@ func TestBodyCapture_TransformResponse_IsNoop(t *testing.T) {
 	// "never buffered"). If a future change starts reading it, this test
 	// fails and forces a deliberate update.
 	require.Equal(t, -1, transform.RequireBufferedBody(resp.Body).Len(),
-		"response body must not be read in Phase 1a — would break SSE streaming")
-	require.Nil(t, tctx.BodyCapture, "response transform must not populate BodyCapture in Phase 1a")
+		"response body must not be read — would break SSE streaming")
+	require.Nil(t, tctx.BodyCapture, "response transform must not populate BodyCapture")
 }
 
 func TestBodyCapture_BodyCaptureInterface(t *testing.T) {

--- a/internal/transform/bodycapture/bodycapture_test.go
+++ b/internal/transform/bodycapture/bodycapture_test.go
@@ -1,0 +1,166 @@
+package bodycapture
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// newTransform constructs a bodyCapture for testing without going through the
+// YAML factory. Tests pin behavior, not parsing.
+func newTransform(t *testing.T, maxBytes int64, rules []hostmatch.RuleConfig) *bodyCapture {
+	t.Helper()
+	compiled, err := hostmatch.CompileRules(rules, "body_capture")
+	require.NoError(t, err)
+	return &bodyCapture{
+		rules:               compiled,
+		maxRequestBodyBytes: maxBytes,
+	}
+}
+
+// makeRequest builds a POST request to the given host/path with body bytes,
+// wrapped in a BufferedBody (matches what the pipeline does in production
+// before any transform runs).
+func makeRequest(t *testing.T, host, path string, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest("POST", "http://"+host+path, strings.NewReader(body))
+	req.Host = host
+	// Wrap the body in a BufferedBody — the production pipeline does this in
+	// proxy.go before invoking transforms. The maxBytes here is the global
+	// BodyLimits cap, not the body_capture transform's own cap.
+	req.Body = transform.NewBufferedBody(req.Body, 1024*1024)
+	return req
+}
+
+func TestBodyCapture_MatchedRequest_PopulatesTctx(t *testing.T) {
+	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com", Methods: []string{"POST"}, Paths: []string{"/v1/messages"}},
+	})
+	body := `{"messages":[{"role":"user","content":"hello"}]}`
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", body)
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	require.NotNil(t, tctx.BodyCapture, "BodyCapture should be populated when a rule matches")
+	require.Equal(t, body, tctx.BodyCapture.RequestBody())
+	require.False(t, tctx.BodyCapture.RequestBodyTruncated())
+}
+
+func TestBodyCapture_NoMatch_DoesNotPopulateTctx(t *testing.T) {
+	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+	})
+	req := makeRequest(t, "example.com", "/anywhere", `{"hello":"world"}`)
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	require.Nil(t, tctx.BodyCapture, "BodyCapture should be nil when no rule matches")
+}
+
+func TestBodyCapture_BodyExceedsCap_TruncatesWithFlag(t *testing.T) {
+	const cap = 32
+	bc := newTransform(t, cap, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+	})
+	// 100 chars of body — should be truncated to 32.
+	body := strings.Repeat("x", 100)
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", body)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, tctx.BodyCapture)
+	require.Equal(t, cap, len(tctx.BodyCapture.RequestBody()), "captured body should be exactly cap bytes")
+	require.Equal(t, strings.Repeat("x", cap), tctx.BodyCapture.RequestBody())
+	require.True(t, tctx.BodyCapture.RequestBodyTruncated(), "truncated flag should be set")
+}
+
+func TestBodyCapture_EmptyBody_DoesNotPopulateTctx(t *testing.T) {
+	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+	})
+	// GET with no body — req.Body is http.NoBody or a BufferedBody wrapping
+	// an empty reader. Either way, we shouldn't emit a BodyCapture with an
+	// empty string (clutters audit logs with empty-body events).
+	req := httptest.NewRequest("GET", "http://api.anthropic.com/health", nil)
+	req.Host = "api.anthropic.com"
+	req.Body = transform.NewBufferedBody(req.Body, 1024)
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	require.Nil(t, tctx.BodyCapture, "empty body should not populate BodyCapture")
+}
+
+func TestBodyCapture_MultipleRules_FirstMatchCapturesOnce(t *testing.T) {
+	// Two rules that both match the same request. The transform should still
+	// capture exactly one body (hostmatch.MatchAnyRule short-circuits on first
+	// match, but the body is also read only once via io.ReadAll regardless).
+	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+		{Host: "*.anthropic.com"},
+	})
+	body := `{"prompt":"test"}`
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", body)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, tctx.BodyCapture)
+	require.Equal(t, body, tctx.BodyCapture.RequestBody())
+	require.False(t, tctx.BodyCapture.RequestBodyTruncated())
+}
+
+func TestBodyCapture_TransformResponse_IsNoop(t *testing.T) {
+	// Phase 1a: response capture is deferred until iron-proxy gains tee-stream
+	// support. TransformResponse must NOT touch the response body — doing so
+	// would force-buffer streaming SSE responses (Claude/OpenAI replies),
+	// stalling the candidate's terminal. This test pins that behavior.
+	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com"},
+	})
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       transform.NewBufferedBody(io.NopCloser(strings.NewReader("response body")), 1024),
+	}
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	// The response BufferedBody must NOT have been read (Len() == -1 means
+	// "never buffered"). If a future change starts reading it, this test
+	// fails and forces a deliberate update.
+	require.Equal(t, -1, transform.RequireBufferedBody(resp.Body).Len(),
+		"response body must not be read in Phase 1a — would break SSE streaming")
+	require.Nil(t, tctx.BodyCapture, "response transform must not populate BodyCapture in Phase 1a")
+}
+
+func TestBodyCapture_BodyCaptureInterface(t *testing.T) {
+	// Compile-time + runtime check that *capture satisfies transform.BodyCapture.
+	var _ transform.BodyCapture = (*capture)(nil)
+
+	c := &capture{requestBody: "hi", requestBodyTruncated: true}
+	require.Equal(t, "hi", c.RequestBody())
+	require.True(t, c.RequestBodyTruncated())
+}

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -97,6 +97,12 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 			}
 			attrs = append(attrs, log.KeyValue{Key: "mcp", Value: log.MapValue(mcpKVs...)})
 		}
+		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
+			attrs = append(attrs,
+				log.String("request_body", result.BodyCapture.RequestBody()),
+				log.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
+			)
+		}
 
 		rec.AddAttributes(attrs...)
 		logger.Emit(context.Background(), rec)

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -213,6 +213,80 @@ func TestOTELAuditFunc_ErroredRequest(t *testing.T) {
 	assert.Equal(t, "connection reset", attrs["error"].AsString())
 }
 
+func TestOTELAuditFunc_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:        "api.anthropic.com",
+		Method:      "POST",
+		Path:        "/v1/messages",
+		StartedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Duration:    50 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{body: `{"prompt":"hi"}`, truncated: false},
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	attrs := recordAttrs(records[0])
+	require.Contains(t, attrs, "request_body")
+	assert.Equal(t, `{"prompt":"hi"}`, attrs["request_body"].AsString())
+	require.Contains(t, attrs, "request_body_truncated")
+	assert.Equal(t, false, attrs["request_body_truncated"].AsBool())
+}
+
+func TestOTELAuditFunc_BodyCapture_TruncationFlagPropagates(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:        "api.openai.com",
+		Method:      "POST",
+		Path:        "/v1/chat/completions",
+		StartedAt:   time.Now(),
+		Duration:    50 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{body: "xxxxxxxxxx", truncated: true},
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	attrs := recordAttrs(records[0])
+	require.Contains(t, attrs, "request_body_truncated")
+	assert.True(t, attrs["request_body_truncated"].AsBool())
+}
+
+func TestOTELAuditFunc_BodyCapture_NilOmitsFields(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:       "example.com",
+		Method:     "GET",
+		Path:       "/",
+		StartedAt:  time.Now(),
+		Duration:   1 * time.Millisecond,
+		Action:     ActionContinue,
+		StatusCode: 200,
+		// BodyCapture: nil
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	attrs := recordAttrs(records[0])
+	assert.NotContains(t, attrs, "request_body")
+	assert.NotContains(t, attrs, "request_body_truncated")
+}
+
 func TestChainAuditFuncs(t *testing.T) {
 	var calls []string
 	f1 := AuditFunc(func(_ *PipelineResult) { calls = append(calls, "f1") })

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -182,10 +182,7 @@ type MCPAudit interface {
 // renderers from the concrete struct in internal/transform/bodycapture so the
 // audit emitters can render captured bodies without an import cycle.
 //
-// Phase 1a (ENG-572 in the litmus repo) covers request bodies only. A future
-// follow-up may add ResponseBody() / ResponseBodyTruncated() once iron-proxy
-// has tee-stream support so capturing response bodies doesn't stall SSE
-// streams.
+// This interface covers request bodies only.
 type BodyCapture interface {
 	// RequestBody returns the captured request body bytes (truncated to the
 	// transform's configured cap). Empty string when no rule matched the

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -81,6 +81,13 @@ type TransformContext struct {
 	Mode       Mode
 	Tunnel     *TunnelInfo
 
+	// BodyCapture is the side channel a body_capture transform uses to
+	// communicate captured request body bytes out of the pipeline. The proxy
+	// copies it onto PipelineResult after the request pipeline runs so the
+	// audit emitters can render top-level `request_body` / `request_body_truncated`
+	// fields. nil when no body_capture rule matched.
+	BodyCapture BodyCapture
+
 	// annotations is written by transforms via Annotate and read by the pipeline
 	// to build TransformTrace. Not exported — transforms use the Annotate method.
 	annotations map[string]any
@@ -142,6 +149,15 @@ type PipelineResult struct {
 	// internal/mcp.
 	MCP MCPAudit
 
+	// BodyCapture carries captured request body bytes from a body_capture
+	// transform when the request matched a configured rule. nil otherwise.
+	// Populated by the proxy by copying tctx.BodyCapture after the request
+	// pipeline runs; rendered by the audit functions as top-level
+	// `request_body` and `request_body_truncated` fields. The transform
+	// package treats the concrete type as opaque to avoid an import cycle
+	// with internal/transform/bodycapture.
+	BodyCapture BodyCapture
+
 	Err error
 
 	// ClientCanceled distinguishes client-initiated disconnect from a real
@@ -159,6 +175,25 @@ type MCPAudit interface {
 	// MCPMessages returns the audit messages in observed order. Each entry
 	// is a flat key/value map suitable for JSON encoding (string-keyed).
 	MCPMessages() []map[string]any
+}
+
+// BodyCapture is the read-only view of a body_capture transform's per-request
+// captured body data. The interface decouples internal/transform's audit
+// renderers from the concrete struct in internal/transform/bodycapture so the
+// audit emitters can render captured bodies without an import cycle.
+//
+// Phase 1a (ENG-572 in the litmus repo) covers request bodies only. A future
+// follow-up may add ResponseBody() / ResponseBodyTruncated() once iron-proxy
+// has tee-stream support so capturing response bodies doesn't stall SSE
+// streams.
+type BodyCapture interface {
+	// RequestBody returns the captured request body bytes (truncated to the
+	// transform's configured cap). Empty string when no rule matched the
+	// request or the request had no body.
+	RequestBody() string
+	// RequestBodyTruncated reports whether the captured RequestBody was
+	// truncated to fit the transform's configured cap.
+	RequestBodyTruncated() bool
 }
 
 // TransformTrace records what a single transform did.

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -311,6 +311,20 @@ transforms:
   #     rules:
   #       - host: "api.openai.com"
 
+  # Body capture: records decoded request bodies of matching hosts onto the
+  # audit log as top-level request_body / request_body_truncated fields.
+  # Observation-only — never rejects. max_request_body_bytes caps each capture
+  # (default 16384); larger bodies are truncated and flagged. When secrets runs
+  # with match_body: true, place body_capture BEFORE secrets so the audit log
+  # records proxy tokens rather than the real swapped-in credentials.
+  # - name: body_capture
+  #   config:
+  #     max_request_body_bytes: 16384
+  #     rules:
+  #       - host: "api.anthropic.com"
+  #         methods: ["POST"]
+  #         paths: ["/v1/messages"]
+
   # gRPC transforms: each entry delegates to one external TransformService server.
   # Use multiple entries for multiple servers; they run in pipeline order.
   - name: grpc


### PR DESCRIPTION
Adds a `body_capture` request transform that records decoded request bodies of matching hosts onto the audit log as top-level `request_body` and `request_body_truncated` fields. Useful for auditing payloads passing through the proxy, e.g. the prompts a sandbox sends to an LLM provider, without modifying upstream traffic.

This is @elenaxzhao's work from #121, re-pushed to a branch in this repo so it can be merged (I can't push to the contributor's fork). It carries her original two commits unchanged plus one review commit from me:

- Truncation cuts on a byte boundary, which could split a multi-byte UTF-8 rune and leave an invalid trailing fragment that renders as U+FFFD in the audit JSON. The captured body is now trimmed back to a rune boundary, bounded to UTFMax-1 bytes so a genuinely-binary body keeps its tail.
- Documented the transform in the README and example config, including a placement note: when `secrets` runs with `match_body: true`, `body_capture` should run before `secrets` so the audit log records proxy tokens rather than the real swapped-in credentials.
- Scrubbed contributor-internal references and roadmap speculation from the comments. The comments now describe only what the code does today; the technical rationale is kept.

Builds clean and all transform/proxy tests pass.