### PR TITLE
refactor(transform): nest body_capture audit fields under a group

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,10 @@ independent of the global `proxy.max_request_body_bytes` limit. This transform
 is observation-only: it never rejects a request, and body read errors are
 annotated on the trace rather than failing the request.
 
+On a successful capture, the transform's entry in `request_transforms` is
+annotated with `captured_bytes` and `truncated` so the trace records that a
+body was captured without duplicating the body itself.
+
 Response bodies are not captured. Streaming responses (SSE) would have to be
 buffered end-to-end before forwarding, which would stall the client.
 

--- a/README.md
+++ b/README.md
@@ -362,10 +362,10 @@ transforms:
 ### Body capture
 
 Records the decoded request body of matching requests and surfaces it on the
-audit log record as top-level `request_body` and `request_body_truncated`
-fields. Useful for auditing the payloads passing through the proxy, such as the
-prompts a sandbox sends to an LLM provider, without modifying the upstream
-traffic.
+audit log record in a `body_capture` group holding `request_body` and
+`request_body_truncated`. Useful for auditing the payloads passing through the
+proxy, such as the prompts a sandbox sends to an LLM provider, without
+modifying the upstream traffic.
 
 Hosts, methods, and paths are matched with the same `rules` syntax as
 `allowlist` and `secrets`. `max_request_body_bytes` caps how much of each body

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -87,10 +87,10 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 			attrs = append(attrs, slog.Group("mcp", mcpAttrs...))
 		}
 		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
-			attrs = append(attrs,
+			attrs = append(attrs, slog.Group("body_capture",
 				slog.String("request_body", result.BodyCapture.RequestBody()),
 				slog.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
-			)
+			))
 		}
 
 		switch {

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -278,7 +278,7 @@ type fakeBodyCapture struct {
 func (f *fakeBodyCapture) RequestBody() string        { return f.body }
 func (f *fakeBodyCapture) RequestBodyTruncated() bool { return f.truncated }
 
-func TestAudit_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
+func TestAudit_BodyCapture_PopulatesGroup(t *testing.T) {
 	result := &PipelineResult{
 		Host:        "api.anthropic.com",
 		Method:      "POST",
@@ -292,11 +292,13 @@ func TestAudit_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
 
 	parsed, raw := captureAuditLog(result)
 
-	// request_body / request_body_truncated land at the TOP level of the log
-	// record (mirroring the MCP block's position), not inside the `audit`
-	// group.
-	require.Equal(t, `{"prompt":"hi"}`, parsed["request_body"], "raw=%s", raw)
-	require.Equal(t, false, parsed["request_body_truncated"])
+	// request_body / request_body_truncated land inside a `body_capture` group
+	// at the root of the record — namespaced like the `mcp` and `audit`
+	// groups, not loose at the root.
+	bc, ok := parsed["body_capture"].(map[string]any)
+	require.True(t, ok, "body_capture group should be present. raw=%s", raw)
+	require.Equal(t, `{"prompt":"hi"}`, bc["request_body"])
+	require.Equal(t, false, bc["request_body_truncated"])
 }
 
 func TestAudit_BodyCapture_TruncationFlagPropagates(t *testing.T) {
@@ -311,14 +313,16 @@ func TestAudit_BodyCapture_TruncationFlagPropagates(t *testing.T) {
 		BodyCapture: &fakeBodyCapture{body: "xxxxxxxxxxxxxxxx", truncated: true},
 	}
 
-	parsed, _ := captureAuditLog(result)
+	parsed, raw := captureAuditLog(result)
 
-	require.Equal(t, true, parsed["request_body_truncated"])
+	bc, ok := parsed["body_capture"].(map[string]any)
+	require.True(t, ok, "body_capture group should be present. raw=%s", raw)
+	require.Equal(t, true, bc["request_body_truncated"])
 }
 
-func TestAudit_BodyCapture_NilOmitsFields(t *testing.T) {
+func TestAudit_BodyCapture_NilOmitsGroup(t *testing.T) {
 	// No body_capture rule matched — BodyCapture is nil. Audit line must
-	// NOT include request_body / request_body_truncated fields.
+	// NOT include the body_capture group.
 	result := &PipelineResult{
 		Host:       "example.com",
 		Method:     "GET",
@@ -331,17 +335,15 @@ func TestAudit_BodyCapture_NilOmitsFields(t *testing.T) {
 
 	parsed, raw := captureAuditLog(result)
 
-	_, hasBody := parsed["request_body"]
-	require.False(t, hasBody, "request_body should be absent when BodyCapture is nil. raw=%s", raw)
-	_, hasFlag := parsed["request_body_truncated"]
-	require.False(t, hasFlag, "request_body_truncated should be absent when BodyCapture is nil. raw=%s", raw)
+	_, hasGroup := parsed["body_capture"]
+	require.False(t, hasGroup, "body_capture group should be absent when BodyCapture is nil. raw=%s", raw)
 }
 
-func TestAudit_BodyCapture_EmptyBodyOmitsFields(t *testing.T) {
+func TestAudit_BodyCapture_EmptyBodyOmitsGroup(t *testing.T) {
 	// BodyCapture is set but RequestBody() is empty (defensive — shouldn't
 	// happen in practice because the transform skips empty bodies, but the
 	// audit emitter checks `!= ""` too). Audit line must not include the
-	// fields.
+	// body_capture group.
 	result := &PipelineResult{
 		Host:        "example.com",
 		Method:      "GET",
@@ -355,6 +357,6 @@ func TestAudit_BodyCapture_EmptyBodyOmitsFields(t *testing.T) {
 
 	parsed, _ := captureAuditLog(result)
 
-	_, hasBody := parsed["request_body"]
-	require.False(t, hasBody, "request_body should be absent when RequestBody() is empty")
+	_, hasGroup := parsed["body_capture"]
+	require.False(t, hasGroup, "body_capture group should be absent when RequestBody() is empty")
 }

--- a/internal/transform/bodycapture/bodycapture.go
+++ b/internal/transform/bodycapture/bodycapture.go
@@ -70,7 +70,9 @@ func (b *bodyCapture) Name() string { return "body_capture" }
 // possibly truncated) body bytes to TransformContext.BodyCapture. The proxy
 // copies that onto PipelineResult after the pipeline returns; the audit
 // emitters render it as a `body_capture` group with `request_body` +
-// `request_body_truncated`.
+// `request_body_truncated`. On a successful capture the transform also
+// annotates its own trace entry with `captured_bytes` and `truncated` markers
+// so the request_transforms array self-documents.
 //
 // Always returns ActionContinue — body_capture is observation-only and never
 // rejects a request. Read errors are annotated for observability and swallowed
@@ -112,6 +114,12 @@ func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.Transf
 		requestBody:          string(data),
 		requestBodyTruncated: truncated,
 	}
+	// Lightweight markers on the transform's own trace entry so the
+	// request_transforms array self-documents that a body was captured. The
+	// body itself is not duplicated here — it lives in the top-level
+	// body_capture group, which is cheaper for log consumers to query.
+	tctx.Annotate("captured_bytes", len(data))
+	tctx.Annotate("truncated", truncated)
 	return cont, nil
 }
 

--- a/internal/transform/bodycapture/bodycapture.go
+++ b/internal/transform/bodycapture/bodycapture.go
@@ -1,7 +1,7 @@
 // Package bodycapture implements a transform that captures request bodies of
 // matching requests and exposes them via PipelineResult.BodyCapture for the
-// audit emitters to render as top-level `request_body` and
-// `request_body_truncated` audit fields.
+// audit emitters to render as a `body_capture` group holding `request_body`
+// and `request_body_truncated`.
 //
 // This transform captures request bodies only. It does not capture response
 // bodies: BufferedBody buffers then replays rather than streaming, so reading
@@ -69,7 +69,8 @@ func (b *bodyCapture) Name() string { return "body_capture" }
 // if the request matches a configured rule, attaches the captured (and
 // possibly truncated) body bytes to TransformContext.BodyCapture. The proxy
 // copies that onto PipelineResult after the pipeline returns; the audit
-// emitters render it as top-level `request_body` + `request_body_truncated`.
+// emitters render it as a `body_capture` group with `request_body` +
+// `request_body_truncated`.
 //
 // Always returns ActionContinue — body_capture is observation-only and never
 // rejects a request. Read errors are annotated for observability and swallowed

--- a/internal/transform/bodycapture/bodycapture_test.go
+++ b/internal/transform/bodycapture/bodycapture_test.go
@@ -56,6 +56,12 @@ func TestBodyCapture_MatchedRequest_PopulatesTctx(t *testing.T) {
 	require.NotNil(t, tctx.BodyCapture, "BodyCapture should be populated when a rule matches")
 	require.Equal(t, body, tctx.BodyCapture.RequestBody())
 	require.False(t, tctx.BodyCapture.RequestBodyTruncated())
+
+	// The transform also annotates its own trace entry so request_transforms
+	// self-documents the capture without duplicating the body.
+	ann := tctx.DrainAnnotations()
+	require.Equal(t, len(body), ann["captured_bytes"])
+	require.Equal(t, false, ann["truncated"])
 }
 
 func TestBodyCapture_NoMatch_DoesNotPopulateTctx(t *testing.T) {
@@ -70,6 +76,7 @@ func TestBodyCapture_NoMatch_DoesNotPopulateTctx(t *testing.T) {
 	require.Equal(t, transform.ActionContinue, res.Action)
 
 	require.Nil(t, tctx.BodyCapture, "BodyCapture should be nil when no rule matches")
+	require.Nil(t, tctx.DrainAnnotations(), "no trace annotations when no rule matches")
 }
 
 func TestBodyCapture_BodyExceedsCap_TruncatesWithFlag(t *testing.T) {
@@ -89,6 +96,10 @@ func TestBodyCapture_BodyExceedsCap_TruncatesWithFlag(t *testing.T) {
 	require.Equal(t, cap, len(tctx.BodyCapture.RequestBody()), "captured body should be exactly cap bytes")
 	require.Equal(t, strings.Repeat("x", cap), tctx.BodyCapture.RequestBody())
 	require.True(t, tctx.BodyCapture.RequestBodyTruncated(), "truncated flag should be set")
+
+	ann := tctx.DrainAnnotations()
+	require.Equal(t, cap, ann["captured_bytes"], "captured_bytes reflects the truncated length")
+	require.Equal(t, true, ann["truncated"])
 }
 
 func TestBodyCapture_Truncation_TrimsPartialUTF8Rune(t *testing.T) {
@@ -130,6 +141,7 @@ func TestBodyCapture_EmptyBody_DoesNotPopulateTctx(t *testing.T) {
 	require.Equal(t, transform.ActionContinue, res.Action)
 
 	require.Nil(t, tctx.BodyCapture, "empty body should not populate BodyCapture")
+	require.Nil(t, tctx.DrainAnnotations(), "empty body should not annotate the trace")
 }
 
 func TestBodyCapture_MultipleRules_FirstMatchCapturesOnce(t *testing.T) {

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -98,10 +98,10 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 			attrs = append(attrs, log.KeyValue{Key: "mcp", Value: log.MapValue(mcpKVs...)})
 		}
 		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
-			attrs = append(attrs,
+			attrs = append(attrs, log.KeyValue{Key: "body_capture", Value: log.MapValue(
 				log.String("request_body", result.BodyCapture.RequestBody()),
 				log.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
-			)
+			)})
 		}
 
 		rec.AddAttributes(attrs...)

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -236,9 +236,9 @@ func TestOTELAuditFunc_BodyCapture_PopulatesGroup(t *testing.T) {
 	require.Contains(t, attrs, "body_capture")
 	bc := mapFromValue(attrs["body_capture"])
 	require.Contains(t, bc, "request_body")
-	assert.Equal(t, `{"prompt":"hi"}`, bc["request_body"].AsString())
+	require.Equal(t, `{"prompt":"hi"}`, bc["request_body"].AsString())
 	require.Contains(t, bc, "request_body_truncated")
-	assert.Equal(t, false, bc["request_body_truncated"].AsBool())
+	require.Equal(t, false, bc["request_body_truncated"].AsBool())
 }
 
 func TestOTELAuditFunc_BodyCapture_TruncationFlagPropagates(t *testing.T) {
@@ -264,7 +264,7 @@ func TestOTELAuditFunc_BodyCapture_TruncationFlagPropagates(t *testing.T) {
 	require.Contains(t, attrs, "body_capture")
 	bc := mapFromValue(attrs["body_capture"])
 	require.Contains(t, bc, "request_body_truncated")
-	assert.True(t, bc["request_body_truncated"].AsBool())
+	require.True(t, bc["request_body_truncated"].AsBool())
 }
 
 func TestOTELAuditFunc_BodyCapture_NilOmitsGroup(t *testing.T) {
@@ -287,7 +287,7 @@ func TestOTELAuditFunc_BodyCapture_NilOmitsGroup(t *testing.T) {
 	require.Len(t, records, 1)
 
 	attrs := recordAttrs(records[0])
-	assert.NotContains(t, attrs, "body_capture")
+	require.NotContains(t, attrs, "body_capture")
 }
 
 func TestChainAuditFuncs(t *testing.T) {

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -213,7 +213,7 @@ func TestOTELAuditFunc_ErroredRequest(t *testing.T) {
 	assert.Equal(t, "connection reset", attrs["error"].AsString())
 }
 
-func TestOTELAuditFunc_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
+func TestOTELAuditFunc_BodyCapture_PopulatesGroup(t *testing.T) {
 	proc := &recordProcessor{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
 	auditFunc := NewOTELAuditFunc(provider)
@@ -233,10 +233,12 @@ func TestOTELAuditFunc_BodyCapture_PopulatesTopLevelFields(t *testing.T) {
 	require.Len(t, records, 1)
 
 	attrs := recordAttrs(records[0])
-	require.Contains(t, attrs, "request_body")
-	assert.Equal(t, `{"prompt":"hi"}`, attrs["request_body"].AsString())
-	require.Contains(t, attrs, "request_body_truncated")
-	assert.Equal(t, false, attrs["request_body_truncated"].AsBool())
+	require.Contains(t, attrs, "body_capture")
+	bc := mapFromValue(attrs["body_capture"])
+	require.Contains(t, bc, "request_body")
+	assert.Equal(t, `{"prompt":"hi"}`, bc["request_body"].AsString())
+	require.Contains(t, bc, "request_body_truncated")
+	assert.Equal(t, false, bc["request_body_truncated"].AsBool())
 }
 
 func TestOTELAuditFunc_BodyCapture_TruncationFlagPropagates(t *testing.T) {
@@ -259,11 +261,13 @@ func TestOTELAuditFunc_BodyCapture_TruncationFlagPropagates(t *testing.T) {
 	require.Len(t, records, 1)
 
 	attrs := recordAttrs(records[0])
-	require.Contains(t, attrs, "request_body_truncated")
-	assert.True(t, attrs["request_body_truncated"].AsBool())
+	require.Contains(t, attrs, "body_capture")
+	bc := mapFromValue(attrs["body_capture"])
+	require.Contains(t, bc, "request_body_truncated")
+	assert.True(t, bc["request_body_truncated"].AsBool())
 }
 
-func TestOTELAuditFunc_BodyCapture_NilOmitsFields(t *testing.T) {
+func TestOTELAuditFunc_BodyCapture_NilOmitsGroup(t *testing.T) {
 	proc := &recordProcessor{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
 	auditFunc := NewOTELAuditFunc(provider)
@@ -283,8 +287,7 @@ func TestOTELAuditFunc_BodyCapture_NilOmitsFields(t *testing.T) {
 	require.Len(t, records, 1)
 
 	attrs := recordAttrs(records[0])
-	assert.NotContains(t, attrs, "request_body")
-	assert.NotContains(t, attrs, "request_body_truncated")
+	assert.NotContains(t, attrs, "body_capture")
 }
 
 func TestChainAuditFuncs(t *testing.T) {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -84,8 +84,8 @@ type TransformContext struct {
 	// BodyCapture is the side channel a body_capture transform uses to
 	// communicate captured request body bytes out of the pipeline. The proxy
 	// copies it onto PipelineResult after the request pipeline runs so the
-	// audit emitters can render top-level `request_body` / `request_body_truncated`
-	// fields. nil when no body_capture rule matched.
+	// audit emitters can render a `body_capture` group with `request_body` /
+	// `request_body_truncated`. nil when no body_capture rule matched.
 	BodyCapture BodyCapture
 
 	// annotations is written by transforms via Annotate and read by the pipeline
@@ -152,8 +152,8 @@ type PipelineResult struct {
 	// BodyCapture carries captured request body bytes from a body_capture
 	// transform when the request matched a configured rule. nil otherwise.
 	// Populated by the proxy by copying tctx.BodyCapture after the request
-	// pipeline runs; rendered by the audit functions as top-level
-	// `request_body` and `request_body_truncated` fields. The transform
+	// pipeline runs; rendered by the audit functions as a `body_capture`
+	// group with `request_body` and `request_body_truncated`. The transform
 	// package treats the concrete type as opaque to avoid an import cycle
 	// with internal/transform/bodycapture.
 	BodyCapture BodyCapture


### PR DESCRIPTION
Follow-up to #123 (originally #121). The `body_capture` transform rendered `request_body` and `request_body_truncated` as loose keys at the root of the audit record. Every other root entry is either a namespaced group (`audit`, `tunnel`, `mcp`) or a short scalar (`rejected_by`, `error`), so two un-namespaced string/bool fields matched neither convention and risked colliding in the root namespace.

This nests them under a `body_capture` group, parallel to the `mcp` group. The original "mirrors MCP" placement didn't hold up: MCP sits at the root because it is a separate policy layer, not a transform, whereas `body_capture` is a transform.

Updates both audit emitters (slog + OTEL), their tests, the interface/struct doc comments, and the README.