### PR TITLE
Add LLM usage event export

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Every request produces a structured JSON audit entry:
 Rejected requests include a `rejected_by` field and log at WARN level. See
 [Audit log format](#audit-log-format) for the full schema.
 
+When `usage_events.enabled` is true, iron-proxy also emits durable normalized
+LLM usage-count events to S3. The recorder supports Anthropic and OpenAI
+responses, including streaming responses when the provider sends usage in the
+stream. Events are queued in-process, flushed as newline-delimited JSON batches,
+and dropped with a warning if the queue is full.
+
 ## Production usage
 
 ### 1. Generate a CA
@@ -242,6 +248,16 @@ tls:
   ca_key: "/etc/iron-proxy/ca.key" # Required
   cert_cache_size: 1000 # LRU cache for generated leaf certs
   leaf_cert_expiry_hours: 72
+
+usage_events:
+  enabled: true
+  queue_size: 1000
+  max_batch: 100
+  flush_interval: "10s"
+  s3:
+    bucket: "my-usage-events"
+    prefix: "iron-proxy/usage-events"
+    region: "us-east-1"
 
 transforms:
   - name: allowlist

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/proxy"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/usage"
 	"github.com/ironsh/iron-proxy/internal/version"
 
 	// Register built-in transforms.
@@ -156,6 +157,27 @@ func main() {
 	}
 	holder.Load().SetAuditFunc(auditFunc)
 
+	var usageRecorder *usage.Recorder
+	if cfg.Usage.Enabled {
+		sink, sinkErr := usage.NewS3Sink(ctx, usage.S3SinkConfig{
+			Bucket:        cfg.Usage.S3.Bucket,
+			Prefix:        cfg.Usage.S3.Prefix,
+			Region:        cfg.Usage.S3.Region,
+			QueueSize:     cfg.Usage.QueueSize,
+			MaxBatch:      cfg.Usage.MaxBatch,
+			FlushInterval: time.Duration(cfg.Usage.FlushInterval),
+		}, logger)
+		if sinkErr != nil {
+			logger.Error("initializing usage event sink", slog.String("error", sinkErr.Error()))
+			os.Exit(1)
+		}
+		usageRecorder = usage.NewRecorder(sink, logger)
+		logger.Info("usage event export enabled",
+			slog.String("bucket", cfg.Usage.S3.Bucket),
+			slog.String("prefix", cfg.Usage.S3.Prefix),
+		)
+	}
+
 	// Initialize cert cache. Not needed in sni-only mode since TLS is never
 	// terminated and no leaf certs are generated.
 	var certCache *certcache.Cache
@@ -222,6 +244,7 @@ func main() {
 		Guard:                         guard,
 		MCPPolicy:                     mcpHolder,
 		Logger:                        logger,
+		UsageRecorder:                 usageRecorder,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 	})
 
@@ -290,6 +313,11 @@ func main() {
 	}
 	if err := p.Shutdown(shutdownCtx); err != nil {
 		logger.Error("proxy shutdown error", slog.String("error", err.Error()))
+	}
+	if usageRecorder != nil {
+		if err := usageRecorder.Close(shutdownCtx); err != nil {
+			logger.Error("usage event sink shutdown error", slog.String("error", err.Error()))
+		}
 	}
 	if err := metricsServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("metrics server shutdown error", slog.String("error", err.Error()))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Postgres   yaml.Node   `yaml:"postgres"`
 	Metrics    Metrics     `yaml:"metrics"`
 	Management Management  `yaml:"management"`
+	Usage      UsageEvents `yaml:"usage_events"`
 	Log        Log         `yaml:"log"`
 }
 
@@ -149,6 +150,21 @@ type Management struct {
 	APIKeyEnv string `yaml:"api_key_env"`
 }
 
+// UsageEvents configures durable provider usage-count event emission.
+type UsageEvents struct {
+	Enabled       bool     `yaml:"enabled"`
+	QueueSize     int      `yaml:"queue_size"`
+	MaxBatch      int      `yaml:"max_batch"`
+	FlushInterval Duration `yaml:"flush_interval"`
+	S3            UsageS3  `yaml:"s3"`
+}
+
+type UsageS3 struct {
+	Bucket string `yaml:"bucket"`
+	Prefix string `yaml:"prefix"`
+	Region string `yaml:"region"`
+}
+
 // Log configures structured logging.
 type Log struct {
 	Level string `yaml:"level"`
@@ -240,6 +256,18 @@ func applyDefaults(cfg *Config) {
 	if cfg.Management.Listen != "" && cfg.Management.APIKeyEnv == "" {
 		cfg.Management.APIKeyEnv = "IRON_MANAGEMENT_API_KEY"
 	}
+	if cfg.Usage.QueueSize == 0 {
+		cfg.Usage.QueueSize = 1000
+	}
+	if cfg.Usage.MaxBatch == 0 {
+		cfg.Usage.MaxBatch = 100
+	}
+	if cfg.Usage.FlushInterval == 0 {
+		cfg.Usage.FlushInterval = Duration(10 * time.Second)
+	}
+	if cfg.Usage.S3.Prefix == "" {
+		cfg.Usage.S3.Prefix = "iron-proxy/usage-events"
+	}
 	if cfg.Log.Level == "" {
 		cfg.Log.Level = "info"
 	}
@@ -283,6 +311,21 @@ func Validate(cfg *Config) error {
 		}
 		if os.Getenv(cfg.Management.APIKeyEnv) == "" {
 			return fmt.Errorf("management.api_key_env %q is not set in the environment", cfg.Management.APIKeyEnv)
+		}
+	}
+
+	if cfg.Usage.Enabled {
+		if cfg.Usage.S3.Bucket == "" {
+			return fmt.Errorf("usage_events.s3.bucket is required when usage_events.enabled=true")
+		}
+		if cfg.Usage.QueueSize <= 0 {
+			return fmt.Errorf("usage_events.queue_size must be positive")
+		}
+		if cfg.Usage.MaxBatch <= 0 {
+			return fmt.Errorf("usage_events.max_batch must be positive")
+		}
+		if cfg.Usage.FlushInterval <= 0 {
+			return fmt.Errorf("usage_events.flush_interval must be positive")
 		}
 	}
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -43,6 +43,22 @@ func applyEnvOverrides(cfg *Config) error {
 	if v := os.Getenv("IRON_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
 	}
+	if v := os.Getenv("IRON_USAGE_EVENTS_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("IRON_USAGE_EVENTS_ENABLED: %w", err)
+		}
+		cfg.Usage.Enabled = b
+	}
+	if v := os.Getenv("IRON_USAGE_EVENTS_S3_BUCKET"); v != "" {
+		cfg.Usage.S3.Bucket = v
+	}
+	if v := os.Getenv("IRON_USAGE_EVENTS_S3_PREFIX"); v != "" {
+		cfg.Usage.S3.Prefix = v
+	}
+	if v := os.Getenv("IRON_USAGE_EVENTS_S3_REGION"); v != "" {
+		cfg.Usage.S3.Region = v
+	}
 
 	if v := os.Getenv("IRON_PROXY_MAX_REQUEST_BODY_BYTES"); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
@@ -82,6 +98,30 @@ func applyEnvOverrides(cfg *Config) error {
 			return fmt.Errorf("IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT: %w", err)
 		}
 		cfg.Proxy.UpstreamResponseHeaderTimeout = Duration(d)
+	}
+
+	if v := os.Getenv("IRON_USAGE_EVENTS_QUEUE_SIZE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("IRON_USAGE_EVENTS_QUEUE_SIZE: %w", err)
+		}
+		cfg.Usage.QueueSize = n
+	}
+
+	if v := os.Getenv("IRON_USAGE_EVENTS_MAX_BATCH"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("IRON_USAGE_EVENTS_MAX_BATCH: %w", err)
+		}
+		cfg.Usage.MaxBatch = n
+	}
+
+	if v := os.Getenv("IRON_USAGE_EVENTS_FLUSH_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("IRON_USAGE_EVENTS_FLUSH_INTERVAL: %w", err)
+		}
+		cfg.Usage.FlushInterval = Duration(d)
 	}
 
 	return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/usage"
 )
 
 // Proxy is the HTTP/HTTPS proxy server. When Mode is TLSModeMITM, the HTTPS
@@ -44,6 +45,7 @@ type Proxy struct {
 	resolver       *net.Resolver
 	guard          *dnsguard.Guard
 	mcpPolicy      *mcp.PolicyHolder
+	usageRecorder  *usage.Recorder
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -59,16 +61,17 @@ type Proxy struct {
 
 // Options configures Proxy construction.
 type Options struct {
-	HTTPAddr   string
-	HTTPSAddr  string
-	TunnelAddr string
-	TLSMode    string
-	CertCache  *certcache.Cache // required when TLSMode == config.TLSModeMITM
-	Pipeline   *transform.PipelineHolder
-	Resolver   *net.Resolver
-	Guard      *dnsguard.Guard // nil is treated as an empty (no-op) guard
-	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
-	Logger     *slog.Logger
+	HTTPAddr      string
+	HTTPSAddr     string
+	TunnelAddr    string
+	TLSMode       string
+	CertCache     *certcache.Cache // required when TLSMode == config.TLSModeMITM
+	Pipeline      *transform.PipelineHolder
+	Resolver      *net.Resolver
+	Guard         *dnsguard.Guard   // nil is treated as an empty (no-op) guard
+	MCPPolicy     *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
+	UsageRecorder *usage.Recorder
+	Logger        *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
 	// config.DefaultUpstreamResponseHeaderTimeout.
@@ -97,6 +100,7 @@ func New(opts Options) *Proxy {
 		resolver:       opts.Resolver,
 		guard:          guard,
 		mcpPolicy:      opts.MCPPolicy,
+		usageRecorder:  opts.UsageRecorder,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -323,7 +327,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	if rejectResp != nil {
 		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
-		p.writeResponse(w, rejectResp)
+		_ = p.writeResponse(w, rejectResp, nil)
 		return
 	}
 
@@ -352,7 +356,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 			if rejectResp != nil {
 				result.Action = transform.ActionReject
 				result.StatusCode = rejectResp.StatusCode
-				p.writeResponse(w, rejectResp)
+				_ = p.writeResponse(w, rejectResp, nil)
 				return
 			}
 		}
@@ -393,6 +397,14 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		upstreamReq.ContentLength = int64(reqBodyLen)
 	} else {
 		upstreamReq.ContentLength = r.ContentLength
+	}
+
+	var usageObs *usage.Observation
+	if p.usageRecorder != nil {
+		usageObs = p.usageRecorder.Observe(r)
+	}
+	if usageObs != nil && upstreamReq.Body != nil {
+		upstreamReq.Body = usageObs.WrapRequestReadCloser(upstreamReq.Body)
 	}
 
 	resp, err := p.doUpstream(upstreamReq)
@@ -443,11 +455,17 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	// SSE: stream with flushing
 	if isSSE(finalResp) {
-		p.streamSSE(w, finalResp)
+		copyErr := p.streamSSE(w, finalResp, usageObs)
+		if usageObs != nil {
+			usageObs.Finish(result.StartedAt, result.StatusCode, copyErr)
+		}
 		return
 	}
 
-	p.writeResponse(w, finalResp)
+	copyErr := p.writeResponse(w, finalResp, usageObs)
+	if usageObs != nil {
+		usageObs.Finish(result.StartedAt, result.StatusCode, copyErr)
+	}
 }
 
 // isWebSocketUpgrade detects a WebSocket upgrade request.
@@ -563,18 +581,22 @@ func isSSE(resp *http.Response) bool {
 }
 
 // streamSSE writes an SSE response with per-chunk flushing.
-func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
+func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response, usageObs *usage.Observation) error {
 	copyHeaders(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 
 	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
+	if usageObs != nil {
+		reader = usageObs.WrapResponse(reader)
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		if _, err := io.Copy(w, reader); err != nil {
 			p.logger.Warn("SSE copy error", slog.String("error", err.Error()))
+			return err
 		}
-		return
+		return nil
 	}
 
 	buf := make([]byte, 32*1024)
@@ -583,20 +605,22 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				p.logger.Warn("SSE write error", slog.String("error", writeErr.Error()))
-				break
+				return writeErr
 			}
 			flusher.Flush()
 		}
 		if readErr != nil {
 			if readErr != io.EOF {
 				p.logger.Warn("SSE read error", slog.String("error", readErr.Error()))
+				return readErr
 			}
 			break
 		}
 	}
+	return nil
 }
 
-func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
+func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response, usageObs *usage.Observation) error {
 	copyHeaders(w.Header(), resp.Header)
 	if buf, ok := resp.Body.(*transform.BufferedBody); ok {
 		// If a transform buffered the response body, set Content-Length
@@ -607,18 +631,29 @@ func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 			w.Header().Set("Content-Length", strconv.FormatInt(int64(n), 10))
 		}
 		w.WriteHeader(resp.StatusCode)
-		if _, err := io.Copy(w, buf.StreamingReader()); err != nil {
+		reader := buf.StreamingReader()
+		if usageObs != nil {
+			reader = usageObs.WrapResponse(reader)
+		}
+		if _, err := io.Copy(w, reader); err != nil {
 			p.logger.Warn("response body copy error", slog.String("error", err.Error()))
+			return err
 		}
 	} else {
 		// Synthetic responses (e.g. reject) with plain bodies.
 		w.WriteHeader(resp.StatusCode)
 		if resp.Body != nil {
-			if _, err := io.Copy(w, resp.Body); err != nil {
+			reader := io.Reader(resp.Body)
+			if usageObs != nil {
+				reader = usageObs.WrapResponse(reader)
+			}
+			if _, err := io.Copy(w, reader); err != nil {
 				p.logger.Warn("response body copy error", slog.String("error", err.Error()))
+				return err
 			}
 		}
 	}
+	return nil
 }
 
 // buildTransport creates the HTTP transport used for upstream requests.

--- a/internal/usage/adapter.go
+++ b/internal/usage/adapter.go
@@ -1,0 +1,250 @@
+package usage
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const maxParseBytes = 1 << 20
+
+type adapter interface {
+	Provider() string
+	Matches(host, path string) bool
+	NewParser(req *http.Request) parser
+}
+
+type parser interface {
+	FeedRequest([]byte)
+	FeedResponse([]byte)
+	Finalize() parsed
+}
+
+type parsed struct {
+	Model                    string
+	InputTokens              *int64
+	OutputTokens             *int64
+	CacheCreationInputTokens *int64
+	CacheReadInputTokens     *int64
+	UnavailableReason        string
+}
+
+func defaultAdapters() []adapter {
+	return []adapter{
+		anthropicAdapter{},
+		openAIAdapter{},
+	}
+}
+
+type anthropicAdapter struct{}
+
+func (anthropicAdapter) Provider() string { return "anthropic" }
+
+func (anthropicAdapter) Matches(host, path string) bool {
+	return hostOnly(host) == "api.anthropic.com" && strings.HasPrefix(path, "/v1/")
+}
+
+func (a anthropicAdapter) NewParser(req *http.Request) parser {
+	return newJSONUsageParser(a.Provider())
+}
+
+type openAIAdapter struct{}
+
+func (openAIAdapter) Provider() string { return "openai" }
+
+func (openAIAdapter) Matches(host, path string) bool {
+	return hostOnly(host) == "api.openai.com" && strings.HasPrefix(path, "/v1/")
+}
+
+func (a openAIAdapter) NewParser(req *http.Request) parser {
+	return newJSONUsageParser(a.Provider())
+}
+
+type jsonUsageParser struct {
+	provider string
+
+	request  boundedBuffer
+	response boundedBuffer
+
+	line []byte
+	seen bool
+	out  parsed
+}
+
+func newJSONUsageParser(provider string) *jsonUsageParser {
+	return &jsonUsageParser{provider: provider}
+}
+
+func (p *jsonUsageParser) FeedRequest(chunk []byte) {
+	p.request.Write(chunk)
+}
+
+func (p *jsonUsageParser) FeedResponse(chunk []byte) {
+	p.response.Write(chunk)
+	p.feedSSE(chunk)
+}
+
+func (p *jsonUsageParser) Finalize() parsed {
+	if p.out.Model == "" {
+		p.out.Model = modelFromJSON(p.request.Bytes())
+	}
+	if !p.seen && !p.response.Truncated() {
+		p.parseResponseObject(p.response.Bytes())
+	}
+	if !hasUsage(p.out) {
+		if p.response.Truncated() {
+			p.out.UnavailableReason = "response_too_large"
+		} else if p.out.UnavailableReason == "" {
+			p.out.UnavailableReason = "usage_unavailable"
+		}
+	}
+	return p.out
+}
+
+func (p *jsonUsageParser) feedSSE(chunk []byte) {
+	for _, b := range chunk {
+		if b == '\n' {
+			p.parseSSELine(bytes.TrimSpace(p.line))
+			p.line = p.line[:0]
+			continue
+		}
+		if len(p.line) < maxParseBytes {
+			p.line = append(p.line, b)
+		}
+	}
+}
+
+func (p *jsonUsageParser) parseSSELine(line []byte) {
+	line = bytes.TrimPrefix(line, []byte("data:"))
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || bytes.Equal(line, []byte("[DONE]")) {
+		return
+	}
+	p.parseResponseObject(line)
+}
+
+func (p *jsonUsageParser) parseResponseObject(data []byte) {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return
+	}
+	p.applyObject(obj)
+}
+
+func (p *jsonUsageParser) applyObject(obj map[string]any) {
+	if p.out.Model == "" {
+		if model, _ := obj["model"].(string); model != "" {
+			p.out.Model = model
+		}
+	}
+
+	if usageObj, _ := obj["usage"].(map[string]any); usageObj != nil {
+		p.applyUsage(usageObj)
+	}
+
+	if msg, _ := obj["message"].(map[string]any); msg != nil {
+		if p.out.Model == "" {
+			if model, _ := msg["model"].(string); model != "" {
+				p.out.Model = model
+			}
+		}
+		if usageObj, _ := msg["usage"].(map[string]any); usageObj != nil {
+			p.applyUsage(usageObj)
+		}
+	}
+
+	if resp, _ := obj["response"].(map[string]any); resp != nil {
+		if p.out.Model == "" {
+			if model, _ := resp["model"].(string); model != "" {
+				p.out.Model = model
+			}
+		}
+		if usageObj, _ := resp["usage"].(map[string]any); usageObj != nil {
+			p.applyUsage(usageObj)
+		}
+	}
+}
+
+func (p *jsonUsageParser) applyUsage(obj map[string]any) {
+	p.seen = true
+	setIfPresent(&p.out.InputTokens, obj, "input_tokens", "prompt_tokens")
+	setIfPresent(&p.out.OutputTokens, obj, "output_tokens", "completion_tokens")
+	setIfPresent(&p.out.CacheCreationInputTokens, obj, "cache_creation_input_tokens")
+	setIfPresent(&p.out.CacheReadInputTokens, obj, "cache_read_input_tokens")
+}
+
+func setIfPresent(dst **int64, obj map[string]any, names ...string) {
+	for _, name := range names {
+		if v, ok := intValue(obj[name]); ok {
+			*dst = &v
+			return
+		}
+	}
+}
+
+func intValue(v any) (int64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return int64(x), true
+	case int64:
+		return x, true
+	case int:
+		return int64(x), true
+	default:
+		return 0, false
+	}
+}
+
+func modelFromJSON(data []byte) string {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return ""
+	}
+	model, _ := obj["model"].(string)
+	return model
+}
+
+func hasUsage(p parsed) bool {
+	return p.InputTokens != nil || p.OutputTokens != nil ||
+		p.CacheCreationInputTokens != nil || p.CacheReadInputTokens != nil
+}
+
+func hostOnly(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+type boundedBuffer struct {
+	buf       bytes.Buffer
+	truncated bool
+}
+
+func (b *boundedBuffer) Write(p []byte) {
+	if b.truncated {
+		return
+	}
+	remaining := maxParseBytes - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return
+	}
+	if len(p) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		return
+	}
+	_, _ = b.buf.Write(p)
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *boundedBuffer) Truncated() bool {
+	return b.truncated
+}

--- a/internal/usage/event.go
+++ b/internal/usage/event.go
@@ -1,0 +1,36 @@
+package usage
+
+import (
+	"context"
+	"time"
+)
+
+// Event is the durable usage-count record emitted by iron-proxy.
+type Event struct {
+	SchemaVersion int       `json:"schema_version"`
+	RequestID     string    `json:"request_id"`
+	TS            time.Time `json:"ts"`
+
+	Provider string `json:"provider"`
+	Host     string `json:"host"`
+	Method   string `json:"method"`
+	Path     string `json:"path"`
+	Model    string `json:"model,omitempty"`
+
+	StatusCode int     `json:"status_code"`
+	DurationMS float64 `json:"duration_ms"`
+
+	InputTokens              *int64 `json:"input_tokens,omitempty"`
+	OutputTokens             *int64 `json:"output_tokens,omitempty"`
+	CacheCreationInputTokens *int64 `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     *int64 `json:"cache_read_input_tokens,omitempty"`
+
+	ErrorClass             string `json:"error_class,omitempty"`
+	UsageUnavailableReason string `json:"usage_unavailable_reason,omitempty"`
+}
+
+// Sink accepts usage events from the proxy hot path.
+type Sink interface {
+	TryEnqueue(Event) bool
+	Close(context.Context) error
+}

--- a/internal/usage/recorder.go
+++ b/internal/usage/recorder.go
@@ -1,0 +1,173 @@
+package usage
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Recorder creates per-request observations and pushes finalized events.
+type Recorder struct {
+	adapters []adapter
+	sink     Sink
+	logger   *slog.Logger
+}
+
+func NewRecorder(sink Sink, logger *slog.Logger) *Recorder {
+	return &Recorder{
+		adapters: defaultAdapters(),
+		sink:     sink,
+		logger:   logger,
+	}
+}
+
+func (r *Recorder) Observe(req *http.Request) *Observation {
+	if r == nil || r.sink == nil {
+		return nil
+	}
+	for _, a := range r.adapters {
+		if a.Matches(req.Host, req.URL.Path) {
+			return &Observation{
+				recorder:  r,
+				parser:    a.NewParser(req),
+				provider:  a.Provider(),
+				requestID: newRequestID(),
+				host:      req.Host,
+				method:    req.Method,
+				path:      req.URL.Path,
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Recorder) Close(ctx context.Context) error {
+	if r == nil || r.sink == nil {
+		return nil
+	}
+	return r.sink.Close(ctx)
+}
+
+type Observation struct {
+	recorder  *Recorder
+	parser    parser
+	requestID string
+	provider  string
+	host      string
+	method    string
+	path      string
+}
+
+func (o *Observation) WrapRequest(reader io.Reader) io.Reader {
+	if o == nil || o.parser == nil {
+		return reader
+	}
+	return &tapReader{
+		reader: reader,
+		feed:   o.parser.FeedRequest,
+	}
+}
+
+func (o *Observation) WrapRequestReadCloser(rc io.ReadCloser) io.ReadCloser {
+	if o == nil || o.parser == nil {
+		return rc
+	}
+	return &tapReadCloser{
+		ReadCloser: rc,
+		reader:     o.WrapRequest(rc),
+	}
+}
+
+func (o *Observation) WrapResponse(reader io.Reader) io.Reader {
+	if o == nil || o.parser == nil {
+		return reader
+	}
+	return &tapReader{
+		reader: reader,
+		feed:   o.parser.FeedResponse,
+	}
+}
+
+func (o *Observation) Finish(startedAt time.Time, statusCode int, copyErr error) {
+	if o == nil || o.recorder == nil || o.parser == nil {
+		return
+	}
+
+	parsed := o.parser.Finalize()
+	event := Event{
+		SchemaVersion:            1,
+		RequestID:                o.requestID,
+		TS:                       startedAt.UTC(),
+		Provider:                 o.provider,
+		Host:                     o.host,
+		Method:                   o.method,
+		Path:                     o.path,
+		Model:                    parsed.Model,
+		StatusCode:               statusCode,
+		DurationMS:               float64(time.Since(startedAt).Microseconds()) / 1000.0,
+		InputTokens:              parsed.InputTokens,
+		OutputTokens:             parsed.OutputTokens,
+		CacheCreationInputTokens: parsed.CacheCreationInputTokens,
+		CacheReadInputTokens:     parsed.CacheReadInputTokens,
+		UsageUnavailableReason:   parsed.UnavailableReason,
+	}
+	event.ErrorClass = classifyError(statusCode, copyErr, parsed.UnavailableReason)
+
+	if ok := o.recorder.sink.TryEnqueue(event); !ok && o.recorder.logger != nil {
+		o.recorder.logger.Warn("usage event queue full; dropping event",
+			slog.String("provider", event.Provider),
+			slog.String("host", event.Host),
+			slog.Int("status_code", event.StatusCode),
+		)
+	}
+}
+
+type tapReader struct {
+	reader io.Reader
+	feed   func([]byte)
+}
+
+func (r *tapReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		r.feed(p[:n])
+	}
+	return n, err
+}
+
+type tapReadCloser struct {
+	io.ReadCloser
+	reader io.Reader
+}
+
+func (r *tapReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func classifyError(statusCode int, copyErr error, unavailable string) string {
+	if copyErr != nil {
+		return "stream_interrupted"
+	}
+	if unavailable == "usage_parse_failed" {
+		return "usage_parse_failed"
+	}
+	if statusCode >= 500 {
+		return "provider_5xx"
+	}
+	if statusCode >= 400 {
+		return "provider_4xx"
+	}
+	return ""
+}
+
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return time.Now().UTC().Format("20060102150405.000000000")
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/usage/s3sink.go
+++ b/internal/usage/s3sink.go
@@ -1,0 +1,174 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type S3SinkConfig struct {
+	Bucket        string
+	Prefix        string
+	Region        string
+	QueueSize     int
+	MaxBatch      int
+	FlushInterval time.Duration
+}
+
+type S3Sink struct {
+	client        s3PutObjectAPI
+	bucket        string
+	prefix        string
+	events        chan Event
+	done          chan struct{}
+	closeOnce     sync.Once
+	maxBatch      int
+	flushInterval time.Duration
+	logger        *slog.Logger
+}
+
+type s3PutObjectAPI interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+func NewS3Sink(ctx context.Context, cfg S3SinkConfig, logger *slog.Logger) (*S3Sink, error) {
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("usage_events.s3.bucket is required")
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 1000
+	}
+	if cfg.MaxBatch <= 0 {
+		cfg.MaxBatch = 100
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 10 * time.Second
+	}
+
+	opts := []func(*awsconfig.LoadOptions) error{}
+	if cfg.Region != "" {
+		opts = append(opts, awsconfig.WithRegion(cfg.Region))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+
+	s := &S3Sink{
+		client:        s3.NewFromConfig(awsCfg),
+		bucket:        cfg.Bucket,
+		prefix:        strings.Trim(cfg.Prefix, "/"),
+		events:        make(chan Event, cfg.QueueSize),
+		done:          make(chan struct{}),
+		maxBatch:      cfg.MaxBatch,
+		flushInterval: cfg.FlushInterval,
+		logger:        logger,
+	}
+	go s.run()
+	return s, nil
+}
+
+func (s *S3Sink) TryEnqueue(event Event) bool {
+	select {
+	case s.events <- event:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *S3Sink) Close(ctx context.Context) error {
+	s.closeOnce.Do(func() {
+		close(s.events)
+	})
+	select {
+	case <-s.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *S3Sink) run() {
+	defer close(s.done)
+	ticker := time.NewTicker(s.flushInterval)
+	defer ticker.Stop()
+
+	batch := make([]Event, 0, s.maxBatch)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if err := s.putBatch(context.Background(), batch); err != nil && s.logger != nil {
+			s.logger.Error("writing usage event batch to S3",
+				slog.String("bucket", s.bucket),
+				slog.String("prefix", s.prefix),
+				slog.Int("events", len(batch)),
+				slog.String("error", err.Error()),
+			)
+		}
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case event, ok := <-s.events:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, event)
+			if len(batch) >= s.maxBatch {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func (s *S3Sink) putBatch(ctx context.Context, batch []Event) error {
+	var body bytes.Buffer
+	for _, event := range batch {
+		line, err := json.Marshal(event)
+		if err != nil {
+			return fmt.Errorf("marshaling event: %w", err)
+		}
+		body.Write(line)
+		body.WriteByte('\n')
+	}
+
+	key := s.key(batch[0].TS)
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(body.Bytes()),
+		ContentType: aws.String("application/x-ndjson"),
+	})
+	if err != nil {
+		return fmt.Errorf("put object %s: %w", key, err)
+	}
+	return nil
+}
+
+func (s *S3Sink) key(ts time.Time) string {
+	ts = ts.UTC()
+	parts := []string{
+		s.prefix,
+		"schema_version=1",
+		fmt.Sprintf("date=%04d-%02d-%02d", ts.Year(), ts.Month(), ts.Day()),
+		fmt.Sprintf("hour=%02d", ts.Hour()),
+		fmt.Sprintf("%d.ndjson", ts.UnixNano()),
+	}
+	return path.Join(parts...)
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -67,6 +67,19 @@ tls:
   cert_cache_size: 1000
   leaf_cert_expiry_hours: 72
 
+# Durable LLM usage-count events. This taps request/response streams while
+# forwarding them, so it does not buffer SSE responses. Currently extracts
+# Anthropic and OpenAI token usage when providers include it in the response.
+# usage_events:
+#   enabled: true
+#   queue_size: 1000
+#   max_batch: 100
+#   flush_interval: "10s"
+#   s3:
+#     bucket: "my-usage-events"
+#     prefix: "iron-proxy/usage-events"
+#     region: "us-east-1"
+
 # Transform configuration
 transforms:
   - name: allowlist


### PR DESCRIPTION
## Summary
- Add `usage_events` config for durable LLM usage-count export to S3.
- Add streaming request/response taps for Anthropic and OpenAI usage parsing without buffering SSE responses.
- Emit bounded, batched NDJSON usage events with status/error metadata and graceful sink shutdown.

## Validation
- `docker run --rm -v "$PWD":/src -w /src golang:1.26.1 go test ./...`
- Built release image locally after producing the expected `linux/arm64/iron-proxy` binary.
