### PR TITLE
feat(secrets): gate query string scanning behind match_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Transforms run in order. Built-in transforms:
 | Transform   | What it does                                                                                                            |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `allowlist`    | Permits requests to matching domains/CIDRs; rejects everything else (403).                                              |
-| `secrets`      | Scans headers, query params, and optionally body for proxy tokens and swaps in real secrets from environment variables. |
+| `secrets`      | Scans headers (and optionally query, path, or body) for proxy tokens and swaps in real secrets from environment variables. |
 | `body_capture` | Records decoded request bodies of matching hosts as `request_body` audit fields. Observation-only; never rejects.       |
 
 ## Configuration
@@ -418,6 +418,9 @@ values before forwarding upstream. You control where it looks:
   Entries delimited by `/.../` are compiled as case-insensitive regular
   expressions matched against canonical header names (e.g. `/^x-.*-key$/`).
 - **`match_body`:** scan the request body (buffered up to `max_request_body_bytes`).
+- **`match_query`:** scan the URL query string. Defaults to `false`; opt in for
+  upstreams that expect the secret in a query parameter. Query strings often
+  appear in access logs on either side of the proxy, so this is off by default.
 - **`match_path`:** scan the URL path. Defaults to `false`; opt in for upstreams
   like Telegram that embed the secret in the path (e.g.
   `/bot<TOKEN>/sendMessage`). URL paths often appear in access logs on either
@@ -821,8 +824,10 @@ transforms:
         - source:
             type: env
             var: OPENAI_API_KEY
-          proxy_value: "proxy-openai-abc123"
-          match_headers: ["Authorization"]
+          replace:
+            proxy_value: "proxy-openai-abc123"
+            match_headers: ["Authorization"]
+            match_query: true # scan the query string
           rules:
             - host: "httpbin.org"
 

--- a/examples/docker-compose/proxy.yaml
+++ b/examples/docker-compose/proxy.yaml
@@ -28,9 +28,11 @@ transforms:
         - source:
             type: env
             var: OPENAI_API_KEY
-          proxy_value: "proxy-openai-abc123"
-          match_headers: ["Authorization"]
-          match_body: false
+          replace:
+            proxy_value: "proxy-openai-abc123"
+            match_headers: ["Authorization"]
+            match_query: true
+            match_body: false
           rules:
             - host: "httpbin.org"
 

--- a/examples/nftables/proxy.yaml
+++ b/examples/nftables/proxy.yaml
@@ -28,9 +28,11 @@ transforms:
         - source:
             type: env
             var: OPENAI_API_KEY
-          proxy_value: "proxy-openai-abc123"
-          match_headers: ["Authorization"]
-          match_body: false
+          replace:
+            proxy_value: "proxy-openai-abc123"
+            match_headers: ["Authorization"]
+            match_query: true
+            match_body: false
           rules:
             - host: "httpbin.org"
 

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -49,6 +49,7 @@ type replaceConfig struct {
 	MatchHeaders []string `yaml:"match_headers,omitempty"`
 	MatchBody    bool     `yaml:"match_body,omitempty"`
 	MatchPath    bool     `yaml:"match_path,omitempty"`
+	MatchQuery   bool     `yaml:"match_query,omitempty"`
 	Require      bool     `yaml:"require,omitempty"`
 }
 
@@ -72,6 +73,7 @@ type resolvedSecret struct {
 	matchHeaders []headerMatcher // empty = all headers
 	matchBody    bool
 	matchPath    bool
+	matchQuery   bool
 	require      bool
 
 	// inject mode fields
@@ -238,6 +240,7 @@ func newFromConfig(cfg secretsConfig, registry sourceBuilderRegistry) (*Secrets,
 				matchHeaders: matchers,
 				matchBody:    replace.MatchBody,
 				matchPath:    replace.MatchPath,
+				matchQuery:   replace.MatchQuery,
 				require:      replace.Require,
 				rules:        rules,
 			})
@@ -358,7 +361,10 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 		var locations []string
 		locations = append(locations, s.swapHeaders(req, &sec, realValue)...)
-		locations = append(locations, s.swapQuery(req, &sec, realValue)...)
+
+		if sec.matchQuery {
+			locations = append(locations, s.swapQuery(req, &sec, realValue)...)
+		}
 
 		if sec.matchPath {
 			if loc := s.swapPath(req, &sec, realValue); loc != "" {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -149,9 +149,14 @@ func TestSecrets_HeaderSwap(t *testing.T) {
 }
 
 func TestSecrets_QueryParamSwap(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
-		e.MatchHeaders = nil
-	})})
+	s := makeSecrets(t, []secretEntry{{
+		Source: envSource("OPENAI_API_KEY"),
+		Rules:  []hostmatch.RuleConfig{{Host: "api.openai.com"}},
+		Replace: &replaceConfig{
+			ProxyValue: "proxy-openai-abc123",
+			MatchQuery: true,
+		},
+	}})
 
 	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat?token=proxy-openai-abc123&other=value", nil)
 	req.Host = "api.openai.com"
@@ -161,6 +166,20 @@ func TestSecrets_QueryParamSwap(t *testing.T) {
 	require.Contains(t, req.URL.RawQuery, "sk-real-openai-key")
 	require.NotContains(t, req.URL.RawQuery, "proxy-openai-abc123")
 	require.Contains(t, req.URL.RawQuery, "other=value")
+}
+
+func TestSecrets_QueryParamNotSwappedByDefault(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = nil
+	})})
+
+	req := httptest.NewRequest("GET", "http://api.openai.com/v1/chat?token=proxy-openai-abc123&other=value", nil)
+	req.Host = "api.openai.com"
+
+	doTransform(t, s, req)
+
+	require.Contains(t, req.URL.RawQuery, "proxy-openai-abc123")
+	require.NotContains(t, req.URL.RawQuery, "sk-real-openai-key")
 }
 
 func TestSecrets_BodySwap(t *testing.T) {

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -159,6 +159,20 @@ transforms:
         #   rules:
         #     - host: "api.telegram.org"
 
+        # Replace mode with URL query string scanning. Use match_query when the
+        # client puts the proxy token in a query parameter. Defaults to false;
+        # opt in explicitly because query strings often appear in access logs.
+        # - source:
+        #     type: env
+        #     var: MAPS_API_KEY
+        #   replace:
+        #     proxy_value: "proxy-maps-token-123"
+        #     match_headers: []          # disable header scanning if query-only
+        #     match_query: true
+        #     require: true
+        #   rules:
+        #     - host: "maps.googleapis.com"
+
         # Replace mode with AWS Secrets Manager and background refresh:
         # - source:
         #     type: aws_sm


### PR DESCRIPTION
The `secrets` transform's replace mode no longer scans the URL query string for proxy tokens automatically. Scanning now requires an explicit `match_query: true`, consistent with how `match_path` already works. Query strings often appear in access logs, so this is now opt-in.

This is a behavior change: existing configs relying on the implicit query-string swap (including legacy top-level-field entries) must move to a `replace` block with `match_query: true` to keep swapping query params.