### PR TITLE
feat(secrets): preserve user-specified casing for match_headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,10 @@ iron-proxy scans outbound requests and replaces proxy tokens with the real
 values before forwarding upstream. You control where it looks:
 
 - **`match_headers`:** list of header names to scan. Empty list = all headers.
-  Entries delimited by `/.../` are compiled as case-insensitive regular
-  expressions matched against canonical header names (e.g. `/^x-.*-key$/`).
+  Literal names are matched case-insensitively, but the casing you write is
+  preserved when the header is forwarded upstream. Entries delimited by `/.../`
+  are compiled as case-insensitive regular expressions matched against canonical
+  header names (e.g. `/^x-.*-key$/`).
 - **`match_body`:** scan the request body (buffered up to `max_request_body_bytes`).
 - **`match_query`:** scan the URL query string. Defaults to `false`; opt in for
   upstreams that expect the secret in a query parameter. Query strings often

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -84,13 +84,16 @@ type resolvedSecret struct {
 
 // headerMatcher selects request headers to scan. Exactly one of name or re is set.
 type headerMatcher struct {
-	name string         // canonical header name; "" if regex
-	re   *regexp.Regexp // nil if literal name match
+	name     string         // canonical header name; "" if regex
+	wireName string         // header name with the user's original casing; "" if regex
+	re       *regexp.Regexp // nil if literal name match
 }
 
 // parseHeaderMatchers compiles match_headers entries. Patterns delimited by
 // "/.../" are compiled as case-insensitive regular expressions matched against
-// canonical header names; all other entries are literal header names.
+// canonical header names; all other entries are literal header names. Literal
+// names are matched case-insensitively (via canonicalization) but the user's
+// original casing is preserved when writing the header back over the wire.
 func parseHeaderMatchers(patterns []string, ctx string) ([]headerMatcher, error) {
 	if len(patterns) == 0 {
 		return nil, nil
@@ -105,7 +108,7 @@ func parseHeaderMatchers(patterns []string, ctx string) ([]headerMatcher, error)
 			matchers = append(matchers, headerMatcher{re: re})
 			continue
 		}
-		matchers = append(matchers, headerMatcher{name: http.CanonicalHeaderKey(p)})
+		matchers = append(matchers, headerMatcher{name: http.CanonicalHeaderKey(p), wireName: p})
 	}
 	return matchers, nil
 }
@@ -449,40 +452,45 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue 
 	}
 
 	processed := make(map[string]struct{})
-	swap := func(name string) {
-		if _, done := processed[name]; done {
+	// swap scans the header identified by its canonical name and, on a match,
+	// rewrites it under wireName so the user's requested casing is sent over
+	// the wire. For regex matches wireName is the header's existing casing.
+	swap := func(canonical, wireName string) {
+		if _, done := processed[canonical]; done {
 			return
 		}
-		processed[name] = struct{}{}
-		vals := req.Header.Values(name)
+		processed[canonical] = struct{}{}
+		vals := req.Header.Values(canonical)
 		if len(vals) == 0 {
 			return
 		}
 		hit := false
 		for _, v := range vals {
-			if headerContains(name, v, sec.proxyValue) {
+			if headerContains(canonical, v, sec.proxyValue) {
 				hit = true
 				break
 			}
 		}
-		req.Header.Del(name)
+		req.Header.Del(canonical)
 		for _, v := range vals {
-			req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, realValue))
+			// Assign the map key directly: http.Header.Add would
+			// canonicalize the key and discard the user's casing.
+			req.Header[wireName] = append(req.Header[wireName], replaceInHeader(canonical, v, sec.proxyValue, realValue))
 		}
 		if hit {
-			locations = append(locations, "header:"+name)
+			locations = append(locations, "header:"+wireName)
 		}
 	}
 	for _, m := range sec.matchHeaders {
 		if m.re != nil {
 			for name := range req.Header {
 				if m.re.MatchString(name) {
-					swap(name)
+					swap(name, name)
 				}
 			}
 			continue
 		}
-		swap(m.name)
+		swap(m.name, m.wireName)
 	}
 	return locations
 }

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -125,6 +125,13 @@ func makeSecrets(t *testing.T, entries []secretEntry) *Secrets {
 	return s
 }
 
+// rawHeaderValues reads header values by the exact map key, bypassing the
+// canonicalization that http.Header.Get/Values apply. The indirection through
+// a variable also keeps staticcheck's SA1008 from flagging non-canonical keys.
+func rawHeaderValues(h http.Header, name string) []string {
+	return h[name]
+}
+
 func doTransform(t *testing.T, s *Secrets, req *http.Request) {
 	t.Helper()
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
@@ -401,7 +408,7 @@ func TestSecrets_MatchHeaders_PreservesUserCasing(t *testing.T) {
 	// req.Header.Get canonicalizes its lookup, so it no longer finds it.
 	_, canonicalExists := req.Header["X-Api-Key"]
 	require.False(t, canonicalExists, "canonical key should be removed")
-	require.Equal(t, []string{"sk-real-openai-key"}, req.Header["x-api-KEY"])
+	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "x-api-KEY"))
 }
 
 func TestSecrets_MatchHeaders_UserCasingInLocations(t *testing.T) {
@@ -761,7 +768,7 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
 	// match_headers preserves the user's casing, so "X-SSM-Key" is written
 	// back verbatim rather than canonicalized to "X-Ssm-Key".
-	require.Equal(t, []string{"ssm-secret-value"}, req.Header["X-SSM-Key"])
+	require.Equal(t, []string{"ssm-secret-value"}, rawHeaderValues(req.Header, "X-SSM-Key"))
 }
 
 // --- End-to-end tests with real awsSMBuilder and mock AWS client ---

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -384,6 +385,59 @@ func TestSecrets_RegexMatchHeaders_InvalidRegex(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid match_headers regex")
 }
 
+func TestSecrets_MatchHeaders_PreservesUserCasing(t *testing.T) {
+	// A match_headers entry with non-canonical casing matches the header
+	// case-insensitively but is written back with the user's casing.
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{"x-api-KEY"}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123") // canonical casing inbound
+
+	doTransform(t, s, req)
+
+	// Value swapped, and stored under the user-specified casing only.
+	// req.Header.Get canonicalizes its lookup, so it no longer finds it.
+	_, canonicalExists := req.Header["X-Api-Key"]
+	require.False(t, canonicalExists, "canonical key should be removed")
+	require.Equal(t, []string{"sk-real-openai-key"}, req.Header["x-api-KEY"])
+}
+
+func TestSecrets_MatchHeaders_UserCasingInLocations(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{"x-api-key"}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123")
+
+	tctx := &transform.TransformContext{}
+	res, err := s.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	// The swapped location annotation reports the user's header casing.
+	encoded, err := json.Marshal(tctx.DrainAnnotations()["swapped"])
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"header:x-api-key"`)
+}
+
+func TestSecrets_RegexMatchHeaders_KeepsExistingCasing(t *testing.T) {
+	// Regex matches carry no user-specified casing, so the header's
+	// existing casing on the request is preserved.
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.MatchHeaders = []string{`/^x-api-key$/`}
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "proxy-openai-abc123")
+
+	doTransform(t, s, req)
+
+	require.Equal(t, []string{"sk-real-openai-key"}, req.Header["X-Api-Key"])
+}
+
 func TestSecrets_ConfigErrors(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -705,7 +759,9 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 
 	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"))
 	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
-	require.Equal(t, "ssm-secret-value", req.Header.Get("X-SSM-Key"))
+	// match_headers preserves the user's casing, so "X-SSM-Key" is written
+	// back verbatim rather than canonicalized to "X-Ssm-Key".
+	require.Equal(t, []string{"ssm-secret-value"}, req.Header["X-SSM-Key"])
 }
 
 // --- End-to-end tests with real awsSMBuilder and mock AWS client ---


### PR DESCRIPTION
The secrets transform now preserves the casing the user wrote in `match_headers` rather than canonicalizing it. Literal entries are still matched case-insensitively (so `x-ssm-key` matches an inbound `X-Ssm-Key`), but the rewritten header is forwarded upstream with exactly the configured casing. Regex matchers are unaffected and pass through the header's existing casing.

Note: HTTP/2 upstreams lowercase header names regardless, so this casing control applies to HTTP/1.x.