### PR TITLE
feat(secrets): preserve user-specified casing for inject headers

### DIFF
--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -410,7 +410,11 @@ func (s *Secrets) injectSecret(req *http.Request, sec *resolvedSecret, realValue
 
 	var locations []string
 	if sec.injectHeader != "" {
-		req.Header.Set(sec.injectHeader, formatted)
+		// Remove any existing header under the canonical name, then assign
+		// the map key directly so the user's configured casing is sent over
+		// the wire. http.Header.Set would canonicalize the key.
+		req.Header.Del(sec.injectHeader)
+		req.Header[sec.injectHeader] = []string{formatted}
 		locations = append(locations, "header:"+sec.injectHeader)
 	}
 	if sec.injectQueryParam != "" {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -1063,6 +1063,40 @@ func TestInject_HeaderNoFormatter(t *testing.T) {
 	require.Equal(t, "sk-real-openai-key", req.Header.Get("X-Api-Key"))
 }
 
+func TestInject_HeaderPreservesUserCasing(t *testing.T) {
+	// The configured header casing is sent over the wire verbatim rather
+	// than being canonicalized.
+	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
+		e.Inject.Formatter = ""
+		e.Inject.Header = "X-API-KEY"
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	doTransform(t, s, req)
+
+	// Stored under the user's casing; canonical lookup no longer finds it.
+	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "X-API-KEY"))
+	_, canonicalExists := req.Header["X-Api-Key"]
+	require.False(t, canonicalExists, "canonical key should not be present")
+}
+
+func TestInject_HeaderReplacesExistingCanonicalValue(t *testing.T) {
+	// An inbound header under the canonical name is replaced, not duplicated,
+	// when the configured casing differs.
+	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
+		e.Inject.Formatter = ""
+		e.Inject.Header = "X-API-KEY"
+	})})
+
+	req := openaiReq("GET", "/v1/chat")
+	req.Header.Set("X-Api-Key", "stale-value")
+	doTransform(t, s, req)
+
+	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "X-API-KEY"))
+	_, canonicalExists := req.Header["X-Api-Key"]
+	require.False(t, canonicalExists, "stale canonical header should be removed")
+}
+
 func TestInject_Base64Formatter(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{injectEntry(func(e *secretEntry) {
 		e.Inject.Formatter = `Basic {{ base64 "x-credential:" .Value }}`

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -100,6 +100,7 @@ transforms:
             type: env
             var: OPENAI_API_KEY
           inject:
+            # The header name is sent upstream with the casing written here.
             header: "Authorization"
             # Go template with .Value (the secret) and base64 (variadic concat+encode).
             formatter: "Bearer {{ .Value }}"


### PR DESCRIPTION
Inject mode set headers via `http.Header.Set`, which canonicalizes the header name, so a configured `header: X-API-KEY` was forwarded upstream as `X-Api-Key`. It now deletes any existing canonical entry and assigns the map key directly, sending the configured casing verbatim. This matches the replace-mode `match_headers` behavior from #127 and also makes the `injected` audit annotation agree with the wire.

Note: HTTP/2 upstreams lowercase header names regardless, so this applies to HTTP/1.x.