### PR TITLE
feat(proxy): harden header forwarding, WS detection, and path matching

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -260,6 +260,15 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 
+	// Reject paths with "." or ".." segments. Policy rules (allowlist,
+	// secrets, etc.) match against the raw request path, but an upstream
+	// may canonicalize "/public/../admin" to "/admin" and serve a resource
+	// the rule was meant to protect. Rejecting up front avoids the gap.
+	if containsDotSegments(r.URL.Path) {
+		http.Error(w, "path contains dot segments", http.StatusBadRequest)
+		return
+	}
+
 	// Validate SNI matches Host header on TLS connections
 	if r.TLS != nil {
 		hostOnly := r.Host
@@ -386,6 +395,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 	copyHeaders(upstreamReq.Header, r.Header)
+	sanitizeUpstreamHeaders(upstreamReq.Header)
 	// If a transform buffered the request body, set ContentLength so the
 	// upstream receives a Content-Length header instead of chunked encoding.
 	// Otherwise, preserve the original Content-Length from the client.
@@ -450,10 +460,70 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	p.writeResponse(w, finalResp)
 }
 
-// isWebSocketUpgrade detects a WebSocket upgrade request.
+// isWebSocketUpgrade detects a WebSocket upgrade request. Connection is
+// parsed as comma-separated tokens with an exact case-insensitive "upgrade"
+// match so a value like "notupgrade" does not satisfy the check.
 func isWebSocketUpgrade(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
-		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+		headerHasToken(r.Header, "Connection", "upgrade")
+}
+
+// headerHasToken reports whether the named header contains an exact
+// case-insensitive token (per RFC 7230 §3.2.6 comma-separated values).
+func headerHasToken(h http.Header, name, token string) bool {
+	for _, v := range h.Values(name) {
+		for _, t := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(t), token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hopByHopHeaders are the headers consumed at the connection boundary per
+// RFC 7230 §6.1, plus Proxy-Connection (a common non-standard variant).
+// These must not be forwarded to the upstream.
+var hopByHopHeaders = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// sanitizeUpstreamHeaders removes hop-by-hop headers and any header named
+// by the client's Connection header before the request is forwarded
+// upstream. Modeled after net/http/httputil.ReverseProxy.
+func sanitizeUpstreamHeaders(h http.Header) {
+	// Collect Connection-named tokens before deleting Connection itself.
+	var connectionTokens []string
+	for _, v := range h.Values("Connection") {
+		for _, t := range strings.Split(v, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				connectionTokens = append(connectionTokens, t)
+			}
+		}
+	}
+
+	// Preserve TE: trailers for gRPC-over-HTTP/1.1 compatibility, matching
+	// net/http/httputil.ReverseProxy.
+	keepTrailers := headerHasToken(h, "Te", "trailers")
+
+	for _, name := range hopByHopHeaders {
+		h.Del(name)
+	}
+	for _, name := range connectionTokens {
+		h.Del(name)
+	}
+	if keepTrailers {
+		h.Set("Te", "trailers")
+	}
 }
 
 // handleWebSocket hijacks the client connection and proxies raw bytes
@@ -500,7 +570,15 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 		return
 	}
 
-	// Write the original HTTP upgrade request to upstream
+	// Sanitize the inbound request headers before serializing the upgrade
+	// upstream so client-supplied Proxy-Authorization, hop-by-hop headers,
+	// and Connection-named tokens are not leaked. Re-set the upgrade
+	// headers explicitly with the proxy's own values.
+	sanitizeUpstreamHeaders(r.Header)
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+
+	// Write the rewritten HTTP upgrade request to upstream
 	if writeErr := r.Write(upstreamConn); writeErr != nil {
 		p.logger.Error("websocket upstream write failed", slog.String("error", writeErr.Error()))
 		upstreamConn.Close()
@@ -666,6 +744,16 @@ func markIfClientCancel(r *http.Request, err error, result *transform.PipelineRe
 	result.StatusCode = http.StatusOK
 	result.ClientCanceled = true
 	return true
+}
+
+// containsDotSegments reports whether p has any "." or ".." path segment.
+func containsDotSegments(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == "." || seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func copyHeaders(dst, src http.Header) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -616,3 +616,186 @@ func TestHTTPProxy_TransformReplacesResponseBody(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, replacedBody, string(body))
 }
+
+func TestHTTPProxy_HopByHopHeadersStripped(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	_, httpAddr, _, _ := startProxy(t)
+
+	// Dial the proxy as a raw TCP client so we can send arbitrary hop-by-hop
+	// headers without Go's client library normalizing them away.
+	conn, err := net.DialTimeout("tcp", httpAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rawReq := fmt.Sprintf("GET /test HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Proxy-Authorization: Basic c2VjcmV0\r\n"+
+		"Proxy-Connection: keep-alive\r\n"+
+		"Connection: Cookie\r\n"+
+		"Cookie: session=leaky\r\n"+
+		"X-Custom: keepme\r\n"+
+		"\r\n",
+		upstream.Listener.Addr().String())
+	_, err = conn.Write([]byte(rawReq))
+	require.NoError(t, err)
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 4096)
+	_, err = conn.Read(buf)
+	require.NoError(t, err)
+
+	require.NotNil(t, gotHeaders)
+	require.Empty(t, gotHeaders.Get("Proxy-Authorization"))
+	require.Empty(t, gotHeaders.Get("Proxy-Connection"))
+	require.Empty(t, gotHeaders.Get("Cookie"), "Cookie was named by Connection and must not be forwarded")
+	require.Equal(t, "keepme", gotHeaders.Get("X-Custom"))
+}
+
+func TestHTTPProxy_WebSocketHopByHopHeadersStripped(t *testing.T) {
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer upstreamLn.Close()
+
+	gotReqCh := make(chan []byte, 1)
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4096)
+		n, _ := conn.Read(buf)
+		gotReqCh <- append([]byte(nil), buf[:n]...)
+		resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n\r\n"
+		_, _ = conn.Write([]byte(resp))
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+
+	_, httpAddr, _, _ := startProxy(t)
+
+	conn, err := net.DialTimeout("tcp", httpAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	upgradeReq := fmt.Sprintf("GET /ws HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade, Cookie\r\n"+
+		"Cookie: session=leaky\r\n"+
+		"Proxy-Authorization: Basic c2VjcmV0\r\n"+
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"+
+		"Sec-WebSocket-Version: 13\r\n\r\n",
+		upstreamLn.Addr().String())
+	_, err = conn.Write([]byte(upgradeReq))
+	require.NoError(t, err)
+
+	var rawUpstream []byte
+	select {
+	case rawUpstream = <-gotReqCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream did not receive request")
+	}
+
+	upstreamStr := string(rawUpstream)
+	require.NotContains(t, upstreamStr, "Proxy-Authorization")
+	require.NotContains(t, upstreamStr, "session=leaky")
+	require.NotContains(t, strings.ToLower(upstreamStr), "cookie:")
+	// Go canonicalizes "Sec-WebSocket-Key" to "Sec-Websocket-Key" when the
+	// header is parsed through the server and re-serialized.
+	lower := strings.ToLower(upstreamStr)
+	require.Contains(t, lower, "sec-websocket-key")
+	require.Contains(t, lower, "upgrade: websocket")
+	require.Contains(t, lower, "connection: upgrade")
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	cases := []struct {
+		name       string
+		upgrade    string
+		connection string
+		want       bool
+	}{
+		{"valid upgrade", "websocket", "Upgrade", true},
+		{"upgrade with extra tokens", "websocket", "keep-alive, Upgrade", true},
+		{"case insensitive", "WebSocket", "upgrade", true},
+		{"missing upgrade header", "", "Upgrade", false},
+		{"connection substring not token", "websocket", "notupgrade", false},
+		{"connection no upgrade", "websocket", "keep-alive", false},
+		{"upgrade not websocket", "h2c", "Upgrade", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &http.Request{Header: http.Header{}}
+			if tc.upgrade != "" {
+				r.Header.Set("Upgrade", tc.upgrade)
+			}
+			if tc.connection != "" {
+				r.Header.Set("Connection", tc.connection)
+			}
+			require.Equal(t, tc.want, isWebSocketUpgrade(r))
+		})
+	}
+}
+
+func TestHTTPProxy_RejectsDotSegmentPaths(t *testing.T) {
+	upstreamHit := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	_, httpAddr, _, _ := startProxy(t)
+
+	// Use a raw TCP write so the dot-segment path is not normalized by the
+	// Go client before reaching the proxy.
+	conn, err := net.DialTimeout("tcp", httpAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	rawReq := fmt.Sprintf("GET /public/../admin/secret HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"\r\n",
+		upstream.Listener.Addr().String())
+	_, err = conn.Write([]byte(rawReq))
+	require.NoError(t, err)
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+
+	require.Contains(t, string(buf[:n]), "400")
+	require.False(t, upstreamHit, "upstream must not be reached for dot-segment paths")
+}
+
+func TestContainsDotSegments(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/admin/secret", false},
+		{"/admin/.secret", false},
+		{"/admin/..secret", false},
+		{"/", false},
+		{"/public/../admin", true},
+		{"/./admin", true},
+		{"/admin/..", true},
+		{"/admin/.", true},
+		{"..", true},
+		{".", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			require.Equal(t, tc.want, containsDotSegments(tc.path))
+		})
+	}
+}


### PR DESCRIPTION
Harden the proxy path. 

Three small changes in the proxy request path: strip hop-by-hop and Connection-named tokens before forwarding upstream (both HTTP and WebSocket paths, with `TE: trailers` preserved for gRPC), tokenize the Connection header in WebSocket upgrade detection so values like `notupgrade` no longer satisfy a substring match, and reject request paths containing `.` or `..` segments before policy evaluation.