### PR TITLE
feat(transform): add hmac_sign for venue request signing

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/gcpauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
+	_ "github.com/ironsh/iron-proxy/internal/transform/hmacsign"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
 	_ "github.com/ironsh/iron-proxy/internal/transform/oauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"

--- a/internal/transform/headers.go
+++ b/internal/transform/headers.go
@@ -1,0 +1,25 @@
+package transform
+
+import "net/http"
+
+// SetHeaderPreservingCase replaces any existing values under name (matched
+// case-insensitively via http.Header.Del) with a single value stored under
+// the exact name provided. Use this when the upstream venue cares about the
+// literal wire casing of the header — http.Header.Set would canonicalize
+// the key and discard the user's casing.
+func SetHeaderPreservingCase(h http.Header, name, value string) {
+	h.Del(name)
+	h[name] = []string{value}
+}
+
+// HeaderValuesByExactName returns the values stored under the exact map key
+// name, bypassing the canonicalization that http.Header.Get and Values apply.
+// Use this to inspect (in transforms or tests) headers that were written with
+// preserved casing.
+//
+// Routing the name through a function also keeps staticcheck's SA1008 from
+// flagging non-canonical string literals at call sites — the lint rule only
+// fires on direct http.Header literal-key access.
+func HeaderValuesByExactName(h http.Header, name string) []string {
+	return h[name]
+}

--- a/internal/transform/hmacsign/hmacsign.go
+++ b/internal/transform/hmacsign/hmacsign.go
@@ -1,0 +1,443 @@
+// Package hmacsign implements a generic HMAC request-signing transform.
+//
+// It computes an HMAC signature over a configurable message template derived
+// from the request (timestamp, method, path, query, host, body) and injects
+// the resulting signature plus any auxiliary credentials into a configurable
+// set of request headers. The same transform configures cleanly for
+// FalconX-, Coinbase Prime-, and similar venue auth schemes.
+//
+// Because a truncated request body would produce an invalid signature, the
+// transform rejects any request whose body cannot be verified intact: a body
+// that came up short of its Content-Length (truncated by the proxy's global
+// max_request_body_bytes), or — by default — a chunked body whose length
+// the proxy cannot verify. Set allow_chunked_body: true to opt out of the
+// chunked-body check.
+//
+// Like all header-injecting transforms this requires MITM mode; sni-only
+// mode has no method, path, or body to sign.
+package hmacsign
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+func init() {
+	transform.Register("hmac_sign", factory)
+}
+
+// credentialSecretField is the conventional name of the credential whose
+// resolved value is used as the HMAC key. It is required in every config.
+const credentialSecretField = "secret"
+
+type config struct {
+	Timestamp        timestampConfig        `yaml:"timestamp"`
+	Signature        signatureConfig        `yaml:"signature"`
+	Credentials      map[string]yaml.Node   `yaml:"credentials"`
+	Headers          []headerConfig         `yaml:"headers"`
+	AllowChunkedBody bool                   `yaml:"allow_chunked_body,omitempty"`
+	Rules            []hostmatch.RuleConfig `yaml:"rules"`
+}
+
+type timestampConfig struct {
+	Format string `yaml:"format"`
+}
+
+type signatureConfig struct {
+	Algorithm      string `yaml:"algorithm"`
+	KeyEncoding    string `yaml:"key_encoding"`
+	OutputEncoding string `yaml:"output_encoding"`
+	Message        string `yaml:"message"`
+}
+
+type headerConfig struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+// sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
+// can inject a stub instead of constructing real source backends.
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+
+// HMACSign is the transform.
+type HMACSign struct {
+	logger           *slog.Logger
+	rules            []hostmatch.Rule
+	credentials      map[string]secrets.Source
+	msgTmpl          *template.Template
+	headerTmpls      []compiledHeader
+	timestampFn      func(time.Time) string
+	now              func() time.Time
+	newHash          func() hash.Hash
+	decodeKey        func([]byte) ([]byte, error)
+	encodeSignature  func([]byte) string
+	allowChunkedBody bool
+}
+
+type compiledHeader struct {
+	name string // exact casing the user wrote in YAML
+	tmpl *template.Template
+}
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing hmac_sign config: %w", err)
+	}
+	return newFromConfig(c, logger, secrets.BuildSource)
+}
+
+func newFromConfig(c config, logger *slog.Logger, build sourceBuilder) (*HMACSign, error) {
+	tsFn, err := compileTimestampFormat(c.Timestamp.Format)
+	if err != nil {
+		return nil, err
+	}
+	newHash, err := compileAlgorithm(c.Signature.Algorithm)
+	if err != nil {
+		return nil, err
+	}
+	decodeKey, err := compileKeyEncoding(c.Signature.KeyEncoding)
+	if err != nil {
+		return nil, err
+	}
+	encodeSig, err := compileOutputEncoding(c.Signature.OutputEncoding)
+	if err != nil {
+		return nil, err
+	}
+	if c.Signature.Message == "" {
+		return nil, fmt.Errorf("hmac_sign: signature.message is required")
+	}
+	msgTmpl, err := template.New("hmac_sign.message").Option("missingkey=error").Parse(c.Signature.Message)
+	if err != nil {
+		return nil, fmt.Errorf("hmac_sign: parsing signature.message: %w", err)
+	}
+
+	if len(c.Headers) == 0 {
+		return nil, fmt.Errorf("hmac_sign: at least one entry in \"headers\" is required")
+	}
+	headerTmpls := make([]compiledHeader, 0, len(c.Headers))
+	for i, h := range c.Headers {
+		if h.Name == "" {
+			return nil, fmt.Errorf("hmac_sign: headers[%d].name is required", i)
+		}
+		if h.Value == "" {
+			return nil, fmt.Errorf("hmac_sign: headers[%d].value is required", i)
+		}
+		t, err := template.New(fmt.Sprintf("hmac_sign.header[%d]", i)).Option("missingkey=error").Parse(h.Value)
+		if err != nil {
+			return nil, fmt.Errorf("hmac_sign: parsing headers[%d].value: %w", i, err)
+		}
+		headerTmpls = append(headerTmpls, compiledHeader{name: h.Name, tmpl: t})
+	}
+
+	if len(c.Credentials) == 0 {
+		return nil, fmt.Errorf("hmac_sign: \"credentials\" must include at least %q", credentialSecretField)
+	}
+	if _, ok := c.Credentials[credentialSecretField]; !ok {
+		return nil, fmt.Errorf("hmac_sign: \"credentials\" must include %q (the HMAC key)", credentialSecretField)
+	}
+	creds := make(map[string]secrets.Source, len(c.Credentials))
+	for name, node := range c.Credentials {
+		src, err := build(node, logger)
+		if err != nil {
+			return nil, fmt.Errorf("hmac_sign: building credentials[%q] source: %w", name, err)
+		}
+		creds[name] = src
+	}
+
+	rules, err := hostmatch.CompileRules(c.Rules, "hmac_sign")
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("hmac_sign: at least one entry in \"rules\" is required")
+	}
+
+	return &HMACSign{
+		logger:           logger,
+		rules:            rules,
+		credentials:      creds,
+		msgTmpl:          msgTmpl,
+		headerTmpls:      headerTmpls,
+		timestampFn:      tsFn,
+		now:              time.Now,
+		newHash:          newHash,
+		decodeKey:        decodeKey,
+		encodeSignature:  encodeSig,
+		allowChunkedBody: c.AllowChunkedBody,
+	}, nil
+}
+
+func (h *HMACSign) Name() string { return "hmac_sign" }
+
+func (h *HMACSign) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if !hostmatch.MatchAnyRule(h.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	body, ok, reject := h.readBodyForSigning(tctx, req)
+	if !ok {
+		return reject, nil
+	}
+
+	credValues := make(map[string]string, len(h.credentials))
+	for name, src := range h.credentials {
+		v, err := src.Get(ctx)
+		if err != nil {
+			tctx.Annotate("rejected", "credential_unavailable")
+			tctx.Annotate("credential", name)
+			tctx.Annotate("error", err.Error())
+			return &transform.TransformResult{
+				Action:   transform.ActionReject,
+				Response: errorResponse(req, http.StatusBadGateway, "credential_unavailable"),
+			}, nil
+		}
+		credValues[name] = v
+	}
+
+	timestamp := h.timestampFn(h.now())
+	msgData := messageData{
+		Timestamp:     timestamp,
+		Method:        req.Method,
+		Path:          req.URL.Path,
+		PathWithQuery: pathWithQuery(req.URL.Path, req.URL.RawQuery),
+		Query:         req.URL.RawQuery,
+		Host:          hostmatch.StripPort(req.Host),
+		Body:          string(body),
+	}
+	var msgBuf strings.Builder
+	if err := h.msgTmpl.Execute(&msgBuf, msgData); err != nil {
+		tctx.Annotate("rejected", "message_template_failed")
+		tctx.Annotate("error", err.Error())
+		return &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: errorResponse(req, http.StatusInternalServerError, "message_template_failed"),
+		}, nil
+	}
+
+	key, err := h.decodeKey([]byte(credValues[credentialSecretField]))
+	if err != nil {
+		tctx.Annotate("rejected", "key_decode_failed")
+		tctx.Annotate("error", err.Error())
+		return &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: errorResponse(req, http.StatusInternalServerError, "key_decode_failed"),
+		}, nil
+	}
+	mac := hmac.New(h.newHash, key)
+	mac.Write([]byte(msgBuf.String()))
+	signature := h.encodeSignature(mac.Sum(nil))
+
+	hdrData := headerData{
+		Timestamp:   timestamp,
+		Signature:   signature,
+		Credentials: credValues,
+	}
+	injected := make([]string, 0, len(h.headerTmpls))
+	for _, hdr := range h.headerTmpls {
+		var buf strings.Builder
+		if err := hdr.tmpl.Execute(&buf, hdrData); err != nil {
+			tctx.Annotate("rejected", "header_template_failed")
+			tctx.Annotate("header", hdr.name)
+			tctx.Annotate("error", err.Error())
+			return &transform.TransformResult{
+				Action:   transform.ActionReject,
+				Response: errorResponse(req, http.StatusInternalServerError, "header_template_failed"),
+			}, nil
+		}
+		// Preserve user-specified casing on the wire: req.Header.Set would
+		// canonicalize the key.
+		req.Header.Del(hdr.name)
+		req.Header[hdr.name] = []string{buf.String()}
+		injected = append(injected, "header:"+hdr.name)
+	}
+
+	req.Body = transform.NewBufferedBodyFromBytes(body)
+	tctx.Annotate("injected", injected)
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (h *HMACSign) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+// readBodyForSigning buffers the request body and verifies it was not silently
+// truncated by the proxy's global max_request_body_bytes cap. A truncated body
+// would produce a signature the upstream venue rejects, which is harder to
+// debug than a clean proxy-side rejection.
+//
+// Returns (body, true, nil) when safe to sign. Otherwise returns
+// (nil, false, rejectResult) — the caller should propagate rejectResult.
+func (h *HMACSign) readBodyForSigning(tctx *transform.TransformContext, req *http.Request) ([]byte, bool, *transform.TransformResult) {
+	if req.Body == nil || req.Body == http.NoBody {
+		if req.ContentLength > 0 {
+			tctx.Annotate("rejected", "body_missing")
+			tctx.Annotate("content_length", req.ContentLength)
+			return nil, false, &transform.TransformResult{
+				Action:   transform.ActionReject,
+				Response: errorResponse(req, http.StatusBadRequest, "body_missing"),
+			}
+		}
+		return nil, true, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		tctx.Annotate("rejected", "body_read_failed")
+		tctx.Annotate("error", err.Error())
+		return nil, false, &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: errorResponse(req, http.StatusBadRequest, "body_read_failed"),
+		}
+	}
+
+	switch {
+	case req.ContentLength >= 0 && int64(len(body)) < req.ContentLength:
+		// BufferedBody silently truncates at maxBytes; len(body) shorter than
+		// the client-declared Content-Length is unambiguous evidence.
+		tctx.Annotate("rejected", "body_truncated")
+		tctx.Annotate("content_length", req.ContentLength)
+		tctx.Annotate("buffered_length", len(body))
+		return nil, false, &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: errorResponse(req, http.StatusRequestEntityTooLarge, "body_truncated"),
+		}
+
+	case req.ContentLength < 0 && !h.allowChunkedBody:
+		// Chunked / unknown length: cannot prove the body wasn't truncated.
+		tctx.Annotate("rejected", "chunked_body_not_allowed")
+		return nil, false, &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: errorResponse(req, http.StatusBadRequest, "chunked_body_not_allowed"),
+		}
+
+	case req.ContentLength < 0 && h.allowChunkedBody:
+		h.logger.Warn("hmac_sign signing chunked request body without length verification",
+			"host", hostmatch.StripPort(req.Host),
+			"path", req.URL.Path,
+			"buffered_length", len(body),
+		)
+	}
+
+	return body, true, nil
+}
+
+// messageData is the template context for signature.message.
+type messageData struct {
+	Timestamp     string
+	Method        string
+	Path          string
+	PathWithQuery string
+	Query         string
+	Host          string
+	Body          string
+}
+
+// headerData is the template context for each headers[].value.
+type headerData struct {
+	Timestamp   string
+	Signature   string
+	Credentials map[string]string
+}
+
+func pathWithQuery(path, rawQuery string) string {
+	if rawQuery == "" {
+		return path
+	}
+	return path + "?" + rawQuery
+}
+
+func compileTimestampFormat(format string) (func(time.Time) string, error) {
+	switch format {
+	case "", "unix_seconds":
+		return func(t time.Time) string { return strconv.FormatInt(t.Unix(), 10) }, nil
+	case "unix_millis":
+		return func(t time.Time) string { return strconv.FormatInt(t.UnixMilli(), 10) }, nil
+	case "unix_nanos":
+		return func(t time.Time) string { return strconv.FormatInt(t.UnixNano(), 10) }, nil
+	case "rfc3339":
+		return func(t time.Time) string { return t.UTC().Format(time.RFC3339) }, nil
+	}
+	return nil, fmt.Errorf("hmac_sign: unknown timestamp.format %q (want unix_seconds|unix_millis|unix_nanos|rfc3339)", format)
+}
+
+func compileAlgorithm(algo string) (func() hash.Hash, error) {
+	switch algo {
+	case "", "sha256":
+		return sha256.New, nil
+	case "sha512":
+		return sha512.New, nil
+	case "sha1":
+		return sha1.New, nil
+	}
+	return nil, fmt.Errorf("hmac_sign: unknown signature.algorithm %q (want sha256|sha512|sha1)", algo)
+}
+
+func compileKeyEncoding(enc string) (func([]byte) ([]byte, error), error) {
+	switch enc {
+	case "", "raw":
+		return func(b []byte) ([]byte, error) { return b, nil }, nil
+	case "base64":
+		return func(b []byte) ([]byte, error) {
+			out, err := base64.StdEncoding.DecodeString(string(b))
+			if err != nil {
+				return nil, fmt.Errorf("decoding base64 key: %w", err)
+			}
+			return out, nil
+		}, nil
+	case "hex":
+		return func(b []byte) ([]byte, error) {
+			out, err := hex.DecodeString(string(b))
+			if err != nil {
+				return nil, fmt.Errorf("decoding hex key: %w", err)
+			}
+			return out, nil
+		}, nil
+	}
+	return nil, fmt.Errorf("hmac_sign: unknown signature.key_encoding %q (want raw|base64|hex)", enc)
+}
+
+func compileOutputEncoding(enc string) (func([]byte) string, error) {
+	switch enc {
+	case "", "base64":
+		return base64.StdEncoding.EncodeToString, nil
+	case "hex":
+		return hex.EncodeToString, nil
+	}
+	return nil, fmt.Errorf("hmac_sign: unknown signature.output_encoding %q (want base64|hex)", enc)
+}
+
+func errorResponse(req *http.Request, status int, reason string) *http.Response {
+	body := []byte(`{"error":"hmac_sign","reason":"` + reason + `"}`)
+	return &http.Response{
+		StatusCode:    status,
+		Status:        strconv.Itoa(status) + " " + http.StatusText(status),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          transform.NewBufferedBodyFromBytes(body),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}

--- a/internal/transform/hmacsign/hmacsign.go
+++ b/internal/transform/hmacsign/hmacsign.go
@@ -265,10 +265,7 @@ func (h *HMACSign) TransformRequest(ctx context.Context, tctx *transform.Transfo
 				Response: errorResponse(req, http.StatusInternalServerError, "header_template_failed"),
 			}, nil
 		}
-		// Preserve user-specified casing on the wire: req.Header.Set would
-		// canonicalize the key.
-		req.Header.Del(hdr.name)
-		req.Header[hdr.name] = []string{buf.String()}
+		transform.SetHeaderPreservingCase(req.Header, hdr.name, buf.String())
 		injected = append(injected, "header:"+hdr.name)
 	}
 

--- a/internal/transform/hmacsign/hmacsign_test.go
+++ b/internal/transform/hmacsign/hmacsign_test.go
@@ -146,10 +146,10 @@ func TestTransformRequest(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, transform.ActionContinue, res.Action)
 
-		require.Equal(t, []string{"the-api-key"}, req.Header["FX-ACCESS-KEY"])
-		require.Equal(t, []string{wantSig}, req.Header["FX-ACCESS-SIGN"])
-		require.Equal(t, []string{wantTimestamp}, req.Header["FX-ACCESS-TIMESTAMP"])
-		require.Equal(t, []string{"the-passphrase"}, req.Header["FX-ACCESS-PASSPHRASE"])
+		require.Equal(t, []string{"the-api-key"}, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-KEY"))
+		require.Equal(t, []string{wantSig}, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-SIGN"))
+		require.Equal(t, []string{wantTimestamp}, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-TIMESTAMP"))
+		require.Equal(t, []string{"the-passphrase"}, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-PASSPHRASE"))
 	})
 
 	t.Run("sha512 hex output with raw key", func(t *testing.T) {
@@ -181,8 +181,8 @@ rules:
 		res, err := h.TransformRequest(context.Background(), newContext(), req)
 		require.NoError(t, err)
 		require.Equal(t, transform.ActionContinue, res.Action)
-		require.Equal(t, []string{wantSig}, req.Header["X-Signature"])
-		require.Equal(t, []string{"1700000000000"}, req.Header["X-Timestamp"])
+		require.Equal(t, []string{wantSig}, transform.HeaderValuesByExactName(req.Header, "X-Signature"))
+		require.Equal(t, []string{"1700000000000"}, transform.HeaderValuesByExactName(req.Header, "X-Timestamp"))
 	})
 
 	t.Run("GET request has empty body in signature", func(t *testing.T) {
@@ -221,7 +221,7 @@ rules:
 		req2.ContentLength = 0
 		_, err = h.TransformRequest(context.Background(), newContext(), req2)
 		require.NoError(t, err)
-		require.Equal(t, req.Header["X-Sig"], req2.Header["X-Sig"])
+		require.Equal(t, transform.HeaderValuesByExactName(req.Header, "X-Sig"), transform.HeaderValuesByExactName(req2.Header, "X-Sig"))
 	})
 
 	t.Run("rule miss skips transform", func(t *testing.T) {
@@ -263,11 +263,10 @@ rules:
 		req := requestWithBody(t, http.MethodGet, "https://api.example.com/", nil, 1<<20)
 		_, err := h.TransformRequest(context.Background(), newContext(), req)
 		require.NoError(t, err)
-		// Look up the exact map keys: http.Header.Get canonicalizes.
-		_, ok := req.Header["FX-ACCESS-KEY"]
-		require.True(t, ok, "FX-ACCESS-KEY must be set with this exact casing")
-		_, ok = req.Header["X-Mixed-Case-Header"]
-		require.True(t, ok, "X-Mixed-Case-Header must be set with this exact casing")
+		// HeaderValuesByExactName bypasses http.Header.Get's canonicalization
+		// so we can verify the user's exact casing landed on the wire.
+		require.NotEmpty(t, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-KEY"), "FX-ACCESS-KEY must be set with this exact casing")
+		require.NotEmpty(t, transform.HeaderValuesByExactName(req.Header, "X-Mixed-Case-Header"), "X-Mixed-Case-Header must be set with this exact casing")
 	})
 
 	t.Run("body still readable downstream", func(t *testing.T) {
@@ -302,9 +301,11 @@ rules:
 		require.NoError(t, err)
 		_, err = h.TransformRequest(context.Background(), newContext(), req2)
 		require.NoError(t, err)
-		require.NotEmpty(t, req1.Header["FX-ACCESS-SIGN"])
-		require.NotEmpty(t, req2.Header["FX-ACCESS-SIGN"])
-		require.NotEqual(t, req1.Header["FX-ACCESS-SIGN"], req2.Header["FX-ACCESS-SIGN"])
+		sig1 := transform.HeaderValuesByExactName(req1.Header, "FX-ACCESS-SIGN")
+		sig2 := transform.HeaderValuesByExactName(req2.Header, "FX-ACCESS-SIGN")
+		require.NotEmpty(t, sig1)
+		require.NotEmpty(t, sig2)
+		require.NotEqual(t, sig1, sig2)
 	})
 
 	t.Run("body truncated by global limit rejects", func(t *testing.T) {
@@ -323,7 +324,7 @@ rules:
 		require.NoError(t, err)
 		require.Equal(t, transform.ActionReject, res.Action)
 		require.Equal(t, http.StatusRequestEntityTooLarge, res.Response.StatusCode)
-		require.Empty(t, req.Header["FX-ACCESS-SIGN"], "must not sign a truncated body")
+		require.Empty(t, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-SIGN"), "must not sign a truncated body")
 		require.Equal(t, "body_truncated", tctx.DrainAnnotations()["rejected"])
 	})
 
@@ -359,7 +360,7 @@ rules:
 		res, err := h.TransformRequest(context.Background(), newContext(), req)
 		require.NoError(t, err)
 		require.Equal(t, transform.ActionContinue, res.Action)
-		require.NotEmpty(t, req.Header["FX-ACCESS-SIGN"])
+		require.NotEmpty(t, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-SIGN"))
 	})
 
 	t.Run("credential unavailable rejects with 502", func(t *testing.T) {
@@ -562,6 +563,6 @@ rules: [{host: "api.falconx.io"}]
 	res, err := tr.TransformRequest(context.Background(), newContext(), req)
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionContinue, res.Action)
-	require.Equal(t, []string{"the-api-key"}, req.Header["FX-ACCESS-KEY"])
-	require.NotEmpty(t, req.Header["FX-ACCESS-SIGN"])
+	require.Equal(t, []string{"the-api-key"}, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-KEY"))
+	require.NotEmpty(t, transform.HeaderValuesByExactName(req.Header, "FX-ACCESS-SIGN"))
 }

--- a/internal/transform/hmacsign/hmacsign_test.go
+++ b/internal/transform/hmacsign/hmacsign_test.go
@@ -1,0 +1,567 @@
+package hmacsign
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+// --- test doubles ---
+
+type staticSource struct {
+	name  string
+	value string
+	err   error
+	calls atomic.Int64
+}
+
+func (s *staticSource) Name() string { return s.name }
+func (s *staticSource) Get(context.Context) (string, error) {
+	s.calls.Add(1)
+	return s.value, s.err
+}
+
+// mapBuilder dispatches each credential node to a source keyed by the node's
+// "var" field, so tests can give every credential its own static value.
+func mapBuilder(srcs map[string]secrets.Source) sourceBuilder {
+	return func(n yaml.Node, _ *slog.Logger) (secrets.Source, error) {
+		var c struct {
+			Var string `yaml:"var"`
+		}
+		if err := n.Decode(&c); err != nil {
+			return nil, err
+		}
+		src, ok := srcs[c.Var]
+		if !ok {
+			return nil, fmt.Errorf("no test source for var %q", c.Var)
+		}
+		return src, nil
+	}
+}
+
+func yamlFromString(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	return *node.Content[0]
+}
+
+func newContext() *transform.TransformContext {
+	return &transform.TransformContext{Mode: transform.ModeMITM, Logger: slog.Default()}
+}
+
+// requestWithBody builds an http.Request with a properly wrapped BufferedBody.
+// maxBytes mirrors the pipeline's per-request body cap.
+func requestWithBody(t *testing.T, method, rawURL string, body []byte, maxBytes int64) *http.Request {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, rawURL, bodyReader)
+	require.NoError(t, err)
+	if body == nil {
+		req.Body = transform.NewBufferedBody(http.NoBody, maxBytes)
+	} else {
+		req.Body = transform.NewBufferedBody(io.NopCloser(bytes.NewReader(body)), maxBytes)
+		req.ContentLength = int64(len(body))
+	}
+	return req
+}
+
+func buildTransformWith(t *testing.T, cfgYAML string, build sourceBuilder) *HMACSign {
+	t.Helper()
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+	h, err := newFromConfig(c, slog.Default(), build)
+	require.NoError(t, err)
+	return h
+}
+
+// fixedNow returns a now-func that always returns t.
+func fixedNow(unixSeconds int64) func() time.Time {
+	return func() time.Time { return time.Unix(unixSeconds, 0).UTC() }
+}
+
+const falconxYAML = `
+timestamp:
+  format: unix_seconds
+signature:
+  algorithm: sha256
+  key_encoding: base64
+  output_encoding: base64
+  message: "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}"
+credentials:
+  key:        {type: env, var: KEY}
+  secret:     {type: env, var: SECRET}
+  passphrase: {type: env, var: PASSPHRASE}
+headers:
+  - name: "FX-ACCESS-KEY"
+    value: "{{.Credentials.key}}"
+  - name: "FX-ACCESS-SIGN"
+    value: "{{.Signature}}"
+  - name: "FX-ACCESS-TIMESTAMP"
+    value: "{{.Timestamp}}"
+  - name: "FX-ACCESS-PASSPHRASE"
+    value: "{{.Credentials.passphrase}}"
+rules:
+  - host: "api.falconx.io"
+`
+
+func TestTransformRequest(t *testing.T) {
+	t.Run("falconx scheme matches reference vector", func(t *testing.T) {
+		// Generated offline with the FalconX docs Python snippet:
+		//   secret_b64 = base64.b64encode(b'supersecretkey-bytes').decode()
+		//                = "c3VwZXJzZWNyZXRrZXktYnl0ZXM="
+		//   msg         = "1700000000POST/v1/quotes?account=acct1" + body
+		//   sig         = base64(HMAC_SHA256(base64decode(secret_b64), msg))
+		const (
+			wantSig       = "osdip9KkbMtE/ZfIpdt432z++Syz0fIQ3M6mAsfbr6Q="
+			wantTimestamp = "1700000000"
+		)
+		body := []byte(`{"base":"BTC","quote":"USD","quantity":"1"}`)
+
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "the-api-key"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXRrZXktYnl0ZXM="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "the-passphrase"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes?account=acct1", body, 1<<20)
+		res, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+
+		require.Equal(t, []string{"the-api-key"}, req.Header["FX-ACCESS-KEY"])
+		require.Equal(t, []string{wantSig}, req.Header["FX-ACCESS-SIGN"])
+		require.Equal(t, []string{wantTimestamp}, req.Header["FX-ACCESS-TIMESTAMP"])
+		require.Equal(t, []string{"the-passphrase"}, req.Header["FX-ACCESS-PASSPHRASE"])
+	})
+
+	t.Run("sha512 hex output with raw key", func(t *testing.T) {
+		// HMAC_SHA512(b"rawsecret123", "1700000000000GET/v1/accounts").hex()
+		const wantSig = "188d9d5920717ac6a9bb1e8f3d8e93322d75ac7d7bb80c53a78366ef57be1759ee1a1f80a4f7b1cffa7d279702849dc1947f2b33d0b040c73c400457d54bb377"
+
+		h := buildTransformWith(t, `
+timestamp: {format: unix_millis}
+signature:
+  algorithm: sha512
+  key_encoding: raw
+  output_encoding: hex
+  message: "{{.Timestamp}}{{.Method}}{{.Path}}"
+credentials:
+  secret: {type: env, var: SECRET}
+headers:
+  - name: "X-Signature"
+    value: "{{.Signature}}"
+  - name: "X-Timestamp"
+    value: "{{.Timestamp}}"
+rules:
+  - host: "api.example.com"
+`, mapBuilder(map[string]secrets.Source{
+			"SECRET": &staticSource{name: "secret", value: "rawsecret123"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req := requestWithBody(t, http.MethodGet, "https://api.example.com/v1/accounts", nil, 1<<20)
+		res, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+		require.Equal(t, []string{wantSig}, req.Header["X-Signature"])
+		require.Equal(t, []string{"1700000000000"}, req.Header["X-Timestamp"])
+	})
+
+	t.Run("GET request has empty body in signature", func(t *testing.T) {
+		// Reference: HMAC_SHA256(b'k', "1700000000GET/v1/health") base64.
+		// We don't precompute it — instead verify by mirroring with a second
+		// signer over the empty-body message and comparing headers.
+		h := buildTransformWith(t, `
+timestamp: {format: unix_seconds}
+signature:
+  algorithm: sha256
+  key_encoding: raw
+  output_encoding: base64
+  message: "{{.Timestamp}}{{.Method}}{{.Path}}{{.Body}}"
+credentials:
+  secret: {type: env, var: SECRET}
+headers:
+  - name: "X-Sig"
+    value: "{{.Signature}}"
+rules:
+  - host: "api.example.com"
+`, mapBuilder(map[string]secrets.Source{
+			"SECRET": &staticSource{name: "secret", value: "k"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req := requestWithBody(t, http.MethodGet, "https://api.example.com/v1/health", nil, 1<<20)
+		res, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+		require.NotEmpty(t, req.Header.Get("X-Sig"))
+
+		// The same config with an explicit empty-body request must produce the
+		// same signature, proving .Body resolves to "" for both GET and
+		// zero-length-body requests.
+		req2 := requestWithBody(t, http.MethodGet, "https://api.example.com/v1/health", []byte(""), 1<<20)
+		req2.ContentLength = 0
+		_, err = h.TransformRequest(context.Background(), newContext(), req2)
+		require.NoError(t, err)
+		require.Equal(t, req.Header["X-Sig"], req2.Header["X-Sig"])
+	})
+
+	t.Run("rule miss skips transform", func(t *testing.T) {
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req := requestWithBody(t, http.MethodGet, "https://other.example.com/v1/health", nil, 1<<20)
+		res, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+		require.Empty(t, req.Header.Get("FX-ACCESS-KEY"))
+		require.Empty(t, req.Header.Get("FX-ACCESS-SIGN"))
+	})
+
+	t.Run("header casing preserved verbatim", func(t *testing.T) {
+		h := buildTransformWith(t, `
+timestamp: {format: unix_seconds}
+signature:
+  algorithm: sha256
+  key_encoding: raw
+  output_encoding: hex
+  message: "{{.Method}}"
+credentials:
+  secret: {type: env, var: SECRET}
+headers:
+  - name: "FX-ACCESS-KEY"
+    value: "v"
+  - name: "X-Mixed-Case-Header"
+    value: "v"
+rules:
+  - host: "api.example.com"
+`, mapBuilder(map[string]secrets.Source{
+			"SECRET": &staticSource{name: "secret", value: "k"},
+		}))
+		req := requestWithBody(t, http.MethodGet, "https://api.example.com/", nil, 1<<20)
+		_, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		// Look up the exact map keys: http.Header.Get canonicalizes.
+		_, ok := req.Header["FX-ACCESS-KEY"]
+		require.True(t, ok, "FX-ACCESS-KEY must be set with this exact casing")
+		_, ok = req.Header["X-Mixed-Case-Header"]
+		require.True(t, ok, "X-Mixed-Case-Header must be set with this exact casing")
+	})
+
+	t.Run("body still readable downstream", func(t *testing.T) {
+		body := []byte(`{"hello":"world"}`)
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", body, 1<<20)
+		_, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, got, "downstream transforms must still see the original body bytes")
+	})
+
+	t.Run("query string included in path with query", func(t *testing.T) {
+		// Two requests, same body and timestamp, differing only in query;
+		// signatures must differ because PathWithQuery includes the query.
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req1 := requestWithBody(t, http.MethodGet, "https://api.falconx.io/v1/quotes", nil, 1<<20)
+		req2 := requestWithBody(t, http.MethodGet, "https://api.falconx.io/v1/quotes?foo=bar", nil, 1<<20)
+		_, err := h.TransformRequest(context.Background(), newContext(), req1)
+		require.NoError(t, err)
+		_, err = h.TransformRequest(context.Background(), newContext(), req2)
+		require.NoError(t, err)
+		require.NotEmpty(t, req1.Header["FX-ACCESS-SIGN"])
+		require.NotEmpty(t, req2.Header["FX-ACCESS-SIGN"])
+		require.NotEqual(t, req1.Header["FX-ACCESS-SIGN"], req2.Header["FX-ACCESS-SIGN"])
+	})
+
+	t.Run("body truncated by global limit rejects", func(t *testing.T) {
+		body := bytes.Repeat([]byte("a"), 1024)
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		// maxBytes shorter than the body simulates the proxy's global cap
+		// silently truncating: io.LimitReader returns EOF after 512 bytes.
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", body, 512)
+
+		tctx := newContext()
+		res, err := h.TransformRequest(context.Background(), tctx, req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionReject, res.Action)
+		require.Equal(t, http.StatusRequestEntityTooLarge, res.Response.StatusCode)
+		require.Empty(t, req.Header["FX-ACCESS-SIGN"], "must not sign a truncated body")
+		require.Equal(t, "body_truncated", tctx.DrainAnnotations()["rejected"])
+	})
+
+	t.Run("chunked body rejected by default", func(t *testing.T) {
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", []byte(`{"x":1}`), 1<<20)
+		req.ContentLength = -1 // simulate chunked / unknown length
+
+		tctx := newContext()
+		res, err := h.TransformRequest(context.Background(), tctx, req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionReject, res.Action)
+		require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
+		require.Equal(t, "chunked_body_not_allowed", tctx.DrainAnnotations()["rejected"])
+	})
+
+	t.Run("chunked body signed when opted in", func(t *testing.T) {
+		yamlWithChunked := falconxYAML + "allow_chunked_body: true\n"
+		h := buildTransformWith(t, yamlWithChunked, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "c3VwZXJzZWNyZXQ="},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		h.now = fixedNow(1700000000)
+
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", []byte(`{"x":1}`), 1<<20)
+		req.ContentLength = -1
+
+		res, err := h.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+		require.NotEmpty(t, req.Header["FX-ACCESS-SIGN"])
+	})
+
+	t.Run("credential unavailable rejects with 502", func(t *testing.T) {
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", err: io.ErrUnexpectedEOF},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", []byte(`{}`), 1<<20)
+		tctx := newContext()
+		res, err := h.TransformRequest(context.Background(), tctx, req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionReject, res.Action)
+		require.Equal(t, http.StatusBadGateway, res.Response.StatusCode)
+		require.Equal(t, "credential_unavailable", tctx.DrainAnnotations()["rejected"])
+	})
+
+	t.Run("base64 key decode error rejects", func(t *testing.T) {
+		h := buildTransformWith(t, falconxYAML, mapBuilder(map[string]secrets.Source{
+			"KEY":        &staticSource{name: "key", value: "k"},
+			"SECRET":     &staticSource{name: "secret", value: "not!!!valid!!!base64"},
+			"PASSPHRASE": &staticSource{name: "pass", value: "p"},
+		}))
+		req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", []byte(`{}`), 1<<20)
+		tctx := newContext()
+		res, err := h.TransformRequest(context.Background(), tctx, req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionReject, res.Action)
+		require.Equal(t, "key_decode_failed", tctx.DrainAnnotations()["rejected"])
+	})
+}
+
+// --- factory validation ---
+
+func TestFactoryValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantError string
+	}{
+		{
+			name: "missing message",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "signature.message is required",
+		},
+		{
+			name: "unknown algorithm",
+			yaml: `
+signature: {algorithm: md5, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "unknown signature.algorithm",
+		},
+		{
+			name: "unknown key encoding",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: rot13, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "unknown signature.key_encoding",
+		},
+		{
+			name: "unknown output encoding",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: morse, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "unknown signature.output_encoding",
+		},
+		{
+			name: "unknown timestamp format",
+			yaml: `
+timestamp: {format: nanos}
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "unknown timestamp.format",
+		},
+		{
+			name: "missing secret credential",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {key: {type: env, var: K}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: `"credentials" must include "secret"`,
+		},
+		{
+			name: "missing headers",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+rules: [{host: "x.example.com"}]
+`,
+			wantError: `at least one entry in "headers"`,
+		},
+		{
+			name: "missing rules",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+`,
+			wantError: `at least one entry in "rules"`,
+		},
+		{
+			name: "header missing name",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "headers[0].name is required",
+		},
+		{
+			name: "header missing value",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "x"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "headers[0].value is required",
+		},
+		{
+			name: "bad message template",
+			yaml: `
+signature: {algorithm: sha256, key_encoding: raw, output_encoding: hex, message: "{{.NotAField"}
+credentials: {secret: {type: env, var: S}}
+headers: [{name: X, value: v}]
+rules: [{host: "x.example.com"}]
+`,
+			wantError: "parsing signature.message",
+		},
+	}
+	build := mapBuilder(map[string]secrets.Source{
+		"S": &staticSource{name: "s", value: "k"},
+		"K": &staticSource{name: "k", value: "k"},
+	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c config
+			node := yamlFromString(t, tc.yaml)
+			require.NoError(t, node.Decode(&c))
+			_, err := newFromConfig(c, slog.Default(), build)
+			require.ErrorContains(t, err, tc.wantError)
+		})
+	}
+}
+
+// TestFactory_EndToEnd verifies the registered factory wires up correctly
+// through the real secrets.BuildSource (env source).
+func TestFactory_EndToEnd(t *testing.T) {
+	t.Setenv("HMAC_KEY", "the-api-key")
+	t.Setenv("HMAC_SECRET", "c3VwZXJzZWNyZXRrZXktYnl0ZXM=")
+	t.Setenv("HMAC_PASS", "the-passphrase")
+
+	tr, err := factory(yamlFromString(t, falconxYAML+`# end`+"\n"), slog.Default())
+	require.NoError(t, err)
+	require.Equal(t, "hmac_sign", tr.Name())
+
+	// Rebuild with env-mapped vars: the YAML refers to KEY/SECRET/PASSPHRASE
+	// vars, which we map to the env vars we set above.
+	tr, err = factory(yamlFromString(t, `
+timestamp: {format: unix_seconds}
+signature:
+  algorithm: sha256
+  key_encoding: base64
+  output_encoding: base64
+  message: "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}"
+credentials:
+  key: {type: env, var: HMAC_KEY}
+  secret: {type: env, var: HMAC_SECRET}
+  passphrase: {type: env, var: HMAC_PASS}
+headers:
+  - {name: "FX-ACCESS-KEY", value: "{{.Credentials.key}}"}
+  - {name: "FX-ACCESS-SIGN", value: "{{.Signature}}"}
+  - {name: "FX-ACCESS-TIMESTAMP", value: "{{.Timestamp}}"}
+  - {name: "FX-ACCESS-PASSPHRASE", value: "{{.Credentials.passphrase}}"}
+rules: [{host: "api.falconx.io"}]
+`), slog.Default())
+	require.NoError(t, err)
+
+	req := requestWithBody(t, http.MethodPost, "https://api.falconx.io/v1/quotes", []byte(`{"a":1}`), 1<<20)
+	res, err := tr.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, []string{"the-api-key"}, req.Header["FX-ACCESS-KEY"])
+	require.NotEmpty(t, req.Header["FX-ACCESS-SIGN"])
+}

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -410,11 +410,7 @@ func (s *Secrets) injectSecret(req *http.Request, sec *resolvedSecret, realValue
 
 	var locations []string
 	if sec.injectHeader != "" {
-		// Remove any existing header under the canonical name, then assign
-		// the map key directly so the user's configured casing is sent over
-		// the wire. http.Header.Set would canonicalize the key.
-		req.Header.Del(sec.injectHeader)
-		req.Header[sec.injectHeader] = []string{formatted}
+		transform.SetHeaderPreservingCase(req.Header, sec.injectHeader, formatted)
 		locations = append(locations, "header:"+sec.injectHeader)
 	}
 	if sec.injectQueryParam != "" {

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -125,13 +125,6 @@ func makeSecrets(t *testing.T, entries []secretEntry) *Secrets {
 	return s
 }
 
-// rawHeaderValues reads header values by the exact map key, bypassing the
-// canonicalization that http.Header.Get/Values apply. The indirection through
-// a variable also keeps staticcheck's SA1008 from flagging non-canonical keys.
-func rawHeaderValues(h http.Header, name string) []string {
-	return h[name]
-}
-
 func doTransform(t *testing.T, s *Secrets, req *http.Request) {
 	t.Helper()
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
@@ -408,7 +401,7 @@ func TestSecrets_MatchHeaders_PreservesUserCasing(t *testing.T) {
 	// req.Header.Get canonicalizes its lookup, so it no longer finds it.
 	_, canonicalExists := req.Header["X-Api-Key"]
 	require.False(t, canonicalExists, "canonical key should be removed")
-	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "x-api-KEY"))
+	require.Equal(t, []string{"sk-real-openai-key"}, transform.HeaderValuesByExactName(req.Header, "x-api-KEY"))
 }
 
 func TestSecrets_MatchHeaders_UserCasingInLocations(t *testing.T) {
@@ -768,7 +761,7 @@ func TestSecrets_MixedSourceTypes(t *testing.T) {
 	require.Equal(t, "aws-secret-value", req.Header.Get("X-Api-Key"))
 	// match_headers preserves the user's casing, so "X-SSM-Key" is written
 	// back verbatim rather than canonicalized to "X-Ssm-Key".
-	require.Equal(t, []string{"ssm-secret-value"}, rawHeaderValues(req.Header, "X-SSM-Key"))
+	require.Equal(t, []string{"ssm-secret-value"}, transform.HeaderValuesByExactName(req.Header, "X-SSM-Key"))
 }
 
 // --- End-to-end tests with real awsSMBuilder and mock AWS client ---
@@ -1075,7 +1068,7 @@ func TestInject_HeaderPreservesUserCasing(t *testing.T) {
 	doTransform(t, s, req)
 
 	// Stored under the user's casing; canonical lookup no longer finds it.
-	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "X-API-KEY"))
+	require.Equal(t, []string{"sk-real-openai-key"}, transform.HeaderValuesByExactName(req.Header, "X-API-KEY"))
 	_, canonicalExists := req.Header["X-Api-Key"]
 	require.False(t, canonicalExists, "canonical key should not be present")
 }
@@ -1092,7 +1085,7 @@ func TestInject_HeaderReplacesExistingCanonicalValue(t *testing.T) {
 	req.Header.Set("X-Api-Key", "stale-value")
 	doTransform(t, s, req)
 
-	require.Equal(t, []string{"sk-real-openai-key"}, rawHeaderValues(req.Header, "X-API-KEY"))
+	require.Equal(t, []string{"sk-real-openai-key"}, transform.HeaderValuesByExactName(req.Header, "X-API-KEY"))
 	_, canonicalExists := req.Header["X-Api-Key"]
 	require.False(t, canonicalExists, "stale canonical header should be removed")
 }

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -329,6 +329,46 @@ transforms:
   #         rules:
   #           - host: "api.example.com"
 
+  # Generic HMAC request signing. Computes an HMAC signature over a Go-template
+  # message derived from the request (timestamp, method, path, query, host,
+  # body) and injects the resulting signature plus any auxiliary credentials
+  # into a configurable set of headers. Configure once per venue (FalconX,
+  # Coinbase Prime, etc.) — the four enums (algorithm, key_encoding,
+  # output_encoding, timestamp format) cover most signing schemes.
+  #
+  # Requires MITM mode. A truncated body would produce an invalid signature, so
+  # the transform rejects any request whose body cannot be verified intact:
+  # bodies shorter than Content-Length (truncated by max_request_body_bytes
+  # above) → 413, chunked bodies → 400 unless allow_chunked_body: true. If you
+  # sign large bodies, raise proxy.max_request_body_bytes accordingly.
+  #
+  # The required "secret" credential is the HMAC key; all other credentials are
+  # user-named and addressable from header templates as .Credentials.<name>.
+  #
+  # Example: FalconX RFQ/RFS authentication
+  # - name: hmac_sign
+  #   config:
+  #     timestamp:
+  #       format: unix_seconds      # unix_seconds | unix_millis | unix_nanos | rfc3339
+  #     signature:
+  #       algorithm: sha256         # sha256 | sha512 | sha1
+  #       key_encoding: base64      # raw | base64 | hex (decoded before HMAC keying)
+  #       output_encoding: base64   # base64 | hex
+  #       # Go template. Available: .Timestamp .Method .Path .PathWithQuery .Query .Host .Body
+  #       message: "{{.Timestamp}}{{.Method}}{{.PathWithQuery}}{{.Body}}"
+  #     credentials:
+  #       key:        {type: env, var: FALCONX_API_KEY}
+  #       secret:     {type: env, var: FALCONX_SECRET}      # required: the HMAC key
+  #       passphrase: {type: env, var: FALCONX_PASSPHRASE}
+  #     headers:                    # ordered list — case is preserved on the wire
+  #       - {name: "FX-ACCESS-KEY",        value: "{{.Credentials.key}}"}
+  #       - {name: "FX-ACCESS-SIGN",       value: "{{.Signature}}"}
+  #       - {name: "FX-ACCESS-TIMESTAMP",  value: "{{.Timestamp}}"}
+  #       - {name: "FX-ACCESS-PASSPHRASE", value: "{{.Credentials.passphrase}}"}
+  #     # allow_chunked_body: false # opt-in to signing chunked (no Content-Length) bodies
+  #     rules:
+  #       - host: "api.falconx.io"
+
   # Header allowlist: strips any request header not listed below before the
   # request goes upstream. Default-deny — every header must either match a
   # literal name (case-insensitive) or a /regex/ pattern. Place this AFTER


### PR DESCRIPTION
Adds a generic `hmac_sign` transform that signs outbound requests with HMAC for venues like FalconX (and structurally similar schemes such as Coinbase Prime). Algorithm, key encoding, output encoding, timestamp format, message template, header set, and named credentials are all configurable, so one transform configures per-venue instead of growing a stack of `falconx_auth`/`coinbase_auth`/... copies. Credentials resolve through the existing `secrets.BuildSource` so env/AWS SM/SSM/1Password all work, and headers preserve user-specified casing.

Because a truncated body would produce an invalid signature (worse than a clean rejection), the transform rejects any request whose buffered body falls short of `Content-Length` (i.e. clipped by `proxy.max_request_body_bytes`) with 413, and rejects chunked bodies with 400 unless `allow_chunked_body: true` is set. The check is done by comparing the buffered length to `req.ContentLength` so no plumbing of `BodyLimits` through the factory signature was needed. Example YAML and the body-size caveat are documented in `iron-proxy.example.yaml`.