### PR TITLE
feat(oauth): add password grant and token_endpoint_headers

### DIFF
--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -38,13 +39,22 @@ func (e *tokenEntry) tokenSourceFor(ctx context.Context) (oauth2.TokenSource, er
 	if err != nil {
 		return nil, err
 	}
+	headers, headerFingerprint, err := e.resolveEndpointHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fingerprint += headerFingerprint
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.tokenSource != nil && fingerprint == e.fingerprint {
 		return e.tokenSource, nil
 	}
-	ts, err := buildTokenSource(ctx, e.grant, vals, e.scopes, e.cfgEndpoint)
+	tsCtx := ctx
+	if len(headers) > 0 {
+		tsCtx = context.WithValue(ctx, oauth2.HTTPClient, newHeaderInjectingClient(headers))
+	}
+	ts, err := buildTokenSource(tsCtx, e.grant, vals, e.scopes, e.cfgEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +89,63 @@ func (e *tokenEntry) resolveCredentials(ctx context.Context) (map[string]string,
 	return vals, fp.String(), nil
 }
 
+// resolveEndpointHeaders mirrors resolveCredentials for the token-endpoint
+// header sources. The returned fingerprint slot is namespaced with a NUL so it
+// can't collide with credential field names.
+func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context) (map[string]string, string, error) {
+	if len(e.endpointHeaderSources) == 0 {
+		return nil, "", nil
+	}
+	keys := make([]string, 0, len(e.endpointHeaderSources))
+	for k := range e.endpointHeaderSources {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make(map[string]string, len(e.endpointHeaderSources))
+	var fp strings.Builder
+	fp.WriteByte(0)
+	fp.WriteString("endpoint_headers")
+	fp.WriteByte(0)
+	for _, k := range keys {
+		v, err := e.endpointHeaderSources[k].Get(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("loading token_endpoint_headers[%q] from %q: %w", k, e.endpointHeaderSources[k].Name(), err)
+		}
+		out[k] = v
+		fp.WriteString(k)
+		fp.WriteByte('=')
+		fp.WriteString(v)
+		fp.WriteByte(0)
+	}
+	return out, fp.String(), nil
+}
+
+// headerInjectingTransport sets configured headers on every request before
+// delegating to the underlying RoundTripper. Used to decorate token-endpoint
+// POSTs with vendor-specific headers like x-api-key.
+type headerInjectingTransport struct {
+	headers map[string]string
+	base    http.RoundTripper
+}
+
+func (t *headerInjectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone before mutating: the oauth2 lib may retry, and we must not leak
+	// header mutations back to the caller's request object.
+	r := req.Clone(req.Context())
+	for k, v := range t.headers {
+		r.Header.Set(k, v)
+	}
+	return t.base.RoundTrip(r)
+}
+
+func newHeaderInjectingClient(headers map[string]string) *http.Client {
+	return &http.Client{Transport: &headerInjectingTransport{
+		headers: headers,
+		base:    http.DefaultTransport,
+	}}
+}
+
 // buildTokenSource constructs an oauth2.TokenSource for one grant from its
 // resolved credential values. It performs no I/O: the token is exchanged
 // lazily on the first Token() call.
@@ -88,6 +155,8 @@ func buildTokenSource(ctx context.Context, grant string, vals map[string]string,
 		return refreshTokenTokenSource(ctx, vals, scopes, cfgEndpoint)
 	case grantClientCredentials:
 		return clientCredentialsTokenSource(ctx, vals, scopes, cfgEndpoint)
+	case grantPassword:
+		return passwordTokenSource(ctx, vals, scopes, cfgEndpoint)
 	default:
 		return nil, fmt.Errorf("unknown grant %q", grant)
 	}
@@ -126,6 +195,51 @@ func refreshTokenTokenSource(ctx context.Context, vals map[string]string, scopes
 	// use. One extra exchange at startup is cheaper than carrying a
 	// provider-specific expiry format.
 	return cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}), nil
+}
+
+// passwordTokenSource builds a token source for the RFC 6749 4.3 password
+// (resource owner password credentials) grant. When the token endpoint returns
+// a refresh_token the standard oauth2.Config token source uses it; otherwise
+// the source re-runs the password exchange to refresh.
+func passwordTokenSource(ctx context.Context, vals map[string]string, scopes []string, cfgEndpoint string) (oauth2.TokenSource, error) {
+	username := vals[fieldUsername]
+	password := vals[fieldPassword]
+	clientID := vals[fieldClientID]
+	clientSecret := vals[fieldClientSecret] // optional
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("password grant is missing the username or password")
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("password grant is missing the client id")
+	}
+	if cfgEndpoint == "" {
+		return nil, fmt.Errorf("password grant needs a token endpoint: set \"token_endpoint\"")
+	}
+
+	cfg := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       scopes,
+		Endpoint: oauth2.Endpoint{
+			TokenURL:  cfgEndpoint,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+	src := &passwordSource{ctx: ctx, cfg: cfg, username: username, password: password}
+	return oauth2.ReuseTokenSource(nil, src), nil
+}
+
+// passwordSource implements oauth2.TokenSource by re-running the password
+// exchange whenever a fresh token is requested. ReuseTokenSource wraps it to
+// cache and single-flight, so this only fires on first use and after expiry.
+type passwordSource struct {
+	ctx                context.Context
+	cfg                *oauth2.Config
+	username, password string
+}
+
+func (s *passwordSource) Token() (*oauth2.Token, error) {
+	return s.cfg.PasswordCredentialsToken(s.ctx, s.username, s.password)
 }
 
 // clientCredentialsTokenSource builds a token source for the RFC 6749 4.4

--- a/internal/transform/oauth/oauth.go
+++ b/internal/transform/oauth/oauth.go
@@ -2,11 +2,17 @@
 // injects them as Authorization: Bearer headers on matching requests.
 //
 // One oauth_token transform carries a list of token entries. Each entry names
-// an OAuth2 grant (refresh_token or client_credentials), the credential fields
-// it needs — each resolved from any secrets-package source (env, 1password,
-// 1password_connect, aws_sm, aws_ssm) — and host rules selecting the requests
-// it applies to. Token exchange, caching, refresh, and single-flight are
-// delegated to golang.org/x/oauth2 — the same code path the official SDKs use.
+// an OAuth2 grant (refresh_token, client_credentials, or password), the
+// credential fields it needs — each resolved from any secrets-package source
+// (env, 1password, 1password_connect, aws_sm, aws_ssm) — and host rules
+// selecting the requests it applies to. Token exchange, caching, refresh, and
+// single-flight are delegated to golang.org/x/oauth2 — the same code path the
+// official SDKs use.
+//
+// Entries may also declare token_endpoint_headers: a map of header name to
+// secret source whose resolved values are sent on the token POST itself. Some
+// vendors require an api-key header on the token endpoint in addition to the
+// standard client_id / client_secret form fields.
 //
 // GCP service-account auth (the RFC 7523 JWT-bearer grant against a Google
 // keyfile) is handled by the separate gcp_auth transform.
@@ -34,6 +40,7 @@ import (
 const (
 	grantRefreshToken      = "refresh_token"
 	grantClientCredentials = "client_credentials"
+	grantPassword          = "password"
 )
 
 // Credential field keys. They name both a config field and the corresponding
@@ -43,6 +50,8 @@ const (
 	fieldRefreshToken = "refresh_token"
 	fieldClientID     = "client_id"
 	fieldClientSecret = "client_secret"
+	fieldUsername     = "username"
+	fieldPassword     = "password"
 )
 
 // stubAccessToken is the placeholder bearer returned to clients that fetch a
@@ -65,19 +74,27 @@ type config struct {
 type tokenEntryConfig struct {
 	Grant string `yaml:"grant"`
 
-	// RefreshToken, ClientID, and ClientSecret are the credential fields. Each
-	// is a secrets source resolved independently, so the fields can live in
-	// different stores or be pulled out of one JSON secret with json_key.
-	// ClientSecret is optional for public refresh_token clients.
+	// Credential fields. Each is a secrets source resolved independently, so
+	// the fields can live in different stores or be pulled out of one JSON
+	// secret with json_key. ClientSecret is optional for public refresh_token
+	// clients. Username and Password are only used by the password grant.
 	RefreshToken yaml.Node `yaml:"refresh_token"`
 	ClientID     yaml.Node `yaml:"client_id"`
 	ClientSecret yaml.Node `yaml:"client_secret"`
+	Username     yaml.Node `yaml:"username"`
+	Password     yaml.Node `yaml:"password"`
 
 	TokenEndpoint string                 `yaml:"token_endpoint,omitempty"`
 	Scopes        []string               `yaml:"scopes,omitempty"`
 	Rules         []hostmatch.RuleConfig `yaml:"rules"`
 	Header        string                 `yaml:"header,omitempty"`
 	ValuePrefix   string                 `yaml:"value_prefix,omitempty"`
+
+	// TokenEndpointHeaders is a map of header name to secret source. Each
+	// resolved value is sent as a request header on the token POST itself —
+	// used by vendors that require an api-key header alongside the standard
+	// form-body client auth.
+	TokenEndpointHeaders map[string]yaml.Node `yaml:"token_endpoint_headers,omitempty"`
 }
 
 // sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
@@ -102,6 +119,10 @@ type tokenEntry struct {
 
 	// sources holds the entry's credential secret sources, keyed by field.
 	sources map[string]secrets.Source
+
+	// endpointHeaderSources holds secret sources for headers sent on the
+	// token POST itself, keyed by header name.
+	endpointHeaderSources map[string]secrets.Source
 
 	// mu guards the lazily built token source and the fingerprint of the
 	// credential values it was built from. The token source is rebuilt when
@@ -151,15 +172,20 @@ func isSet(n yaml.Node) bool { return n.Kind != 0 }
 
 func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuilder) (*tokenEntry, *tokenEndpoint, error) {
 	switch tc.Grant {
-	case grantRefreshToken, grantClientCredentials:
+	case grantRefreshToken, grantClientCredentials, grantPassword:
 	default:
-		return nil, nil, fmt.Errorf("\"grant\" must be one of refresh_token, client_credentials (got %q)", tc.Grant)
+		return nil, nil, fmt.Errorf("\"grant\" must be one of refresh_token, client_credentials, password (got %q)", tc.Grant)
 	}
 	if tc.TokenEndpoint == "" {
 		return nil, nil, fmt.Errorf("%s grant requires \"token_endpoint\"", tc.Grant)
 	}
 
 	sources, err := buildCredentialSources(tc, logger, buildSource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	endpointHeaders, err := buildEndpointHeaderSources(tc.TokenEndpointHeaders, logger, buildSource)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -190,14 +216,15 @@ func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuil
 	}
 
 	return &tokenEntry{
-		grant:       tc.Grant,
-		scopes:      tc.Scopes,
-		rules:       rules,
-		header:      header,
-		valuePrefix: valuePrefix,
-		cfgEndpoint: tc.TokenEndpoint,
-		sources:     sources,
-		logger:      logger,
+		grant:                 tc.Grant,
+		scopes:                tc.Scopes,
+		rules:                 rules,
+		header:                header,
+		valuePrefix:           valuePrefix,
+		cfgEndpoint:           tc.TokenEndpoint,
+		sources:               sources,
+		endpointHeaderSources: endpointHeaders,
+		logger:                logger,
 	}, stub, nil
 }
 
@@ -248,8 +275,46 @@ func buildCredentialSources(tc tokenEntryConfig, logger *slog.Logger, buildSourc
 			fieldClientID:     tc.ClientID,
 			fieldClientSecret: tc.ClientSecret,
 		})
+
+	case grantPassword:
+		if !isSet(tc.Username) || !isSet(tc.Password) {
+			return nil, fmt.Errorf("password grant requires \"username\" and \"password\"")
+		}
+		if !isSet(tc.ClientID) {
+			return nil, fmt.Errorf("password grant requires \"client_id\"")
+		}
+		fields := map[string]yaml.Node{
+			fieldUsername: tc.Username,
+			fieldPassword: tc.Password,
+			fieldClientID: tc.ClientID,
+		}
+		if isSet(tc.ClientSecret) {
+			fields[fieldClientSecret] = tc.ClientSecret
+		}
+		return buildAll(fields)
 	}
 	return nil, fmt.Errorf("unknown grant %q", tc.Grant) // unreachable: grant is validated above
+}
+
+// buildEndpointHeaderSources resolves each token_endpoint_headers entry to a
+// secrets.Source. Header names are kept verbatim so vendors that demand a
+// specific casing (e.g. "x-api-key") get it on the wire.
+func buildEndpointHeaderSources(headers map[string]yaml.Node, logger *slog.Logger, buildSource sourceBuilder) (map[string]secrets.Source, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]secrets.Source, len(headers))
+	for name, node := range headers {
+		if name == "" {
+			return nil, fmt.Errorf("token_endpoint_headers: header name must not be empty")
+		}
+		src, err := buildSource(node, logger)
+		if err != nil {
+			return nil, fmt.Errorf("token_endpoint_headers[%q]: %w", name, err)
+		}
+		out[name] = src
+	}
+	return out, nil
 }
 
 // parseTokenEndpoint splits a configured token endpoint URL into the host and

--- a/internal/transform/oauth/oauth_test.go
+++ b/internal/transform/oauth/oauth_test.go
@@ -62,9 +62,10 @@ func mapBuilder(srcs map[string]secrets.Source) sourceBuilder {
 // each request's form so tests can assert on the exchange.
 type tokenServer struct {
 	*httptest.Server
-	mu    sync.Mutex
-	calls int
-	forms []url.Values
+	mu      sync.Mutex
+	calls   int
+	forms   []url.Values
+	headers []http.Header
 }
 
 func (ts *tokenServer) Calls() int {
@@ -77,6 +78,12 @@ func (ts *tokenServer) LastForm() url.Values {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 	return ts.forms[len(ts.forms)-1]
+}
+
+func (ts *tokenServer) LastHeaders() http.Header {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	return ts.headers[len(ts.headers)-1]
 }
 
 // newTokenServer serves the OAuth2 token endpoint. respond decides the HTTP
@@ -99,6 +106,7 @@ func newTokenServer(t *testing.T, respond func(form url.Values) (int, map[string
 		ts.mu.Lock()
 		ts.calls++
 		ts.forms = append(ts.forms, r.PostForm)
+		ts.headers = append(ts.headers, r.Header.Clone())
 		ts.mu.Unlock()
 		status, body := respond(r.PostForm)
 		w.Header().Set("Content-Type", "application/json")
@@ -258,6 +266,32 @@ tokens:
       - host: "example.com"
 `,
 			wantError: "requires \"client_id\" and \"client_secret\"",
+		},
+		{
+			name: "password missing username",
+			yaml: `
+tokens:
+  - grant: password
+    password: {type: env, var: PW}
+    client_id: {type: env, var: CID}
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "password grant requires \"username\" and \"password\"",
+		},
+		{
+			name: "password missing client_id",
+			yaml: `
+tokens:
+  - grant: password
+    username: {type: env, var: USER}
+    password: {type: env, var: PW}
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "password grant requires \"client_id\"",
 		},
 	}
 	for _, tc := range cases {
@@ -591,6 +625,126 @@ tokens:
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
 	require.Equal(t, http.StatusBadGateway, res.Response.StatusCode)
+}
+
+// --- password grant ---
+
+func TestPasswordGrant_InjectsBearer(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	o := buildTransformWith(t, `
+tokens:
+  - grant: password
+    username:      {type: env, var: USER}
+    password:      {type: env, var: PW}
+    client_id:     {type: env, var: CID}
+    client_secret: {type: env, var: CSECRET}
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["read"]
+    rules:
+      - host: "api.alpha-sense.com"
+`, mapBuilder(map[string]secrets.Source{
+		"USER":    &staticSource{name: "u", value: "alice"},
+		"PW":      &staticSource{name: "p", value: "s3cret"},
+		"CID":     &staticSource{name: "cid", value: "the-client-id"},
+		"CSECRET": &staticSource{name: "cs", value: "the-client-secret"},
+	}))
+
+	req := newRequest(t, http.MethodPost, "https://api.alpha-sense.com/gql")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+
+	form := srv.LastForm()
+	require.Equal(t, "password", form.Get("grant_type"))
+	require.Equal(t, "alice", form.Get("username"))
+	require.Equal(t, "s3cret", form.Get("password"))
+	require.Equal(t, "the-client-id", form.Get("client_id"))
+	require.Equal(t, "the-client-secret", form.Get("client_secret"))
+	require.Equal(t, "read", form.Get("scope"))
+}
+
+// A password client without a client_secret (public client) omits the form field.
+func TestPasswordGrant_PublicClient(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	o := buildTransformWith(t, `
+tokens:
+  - grant: password
+    username:  {type: env, var: USER}
+    password:  {type: env, var: PW}
+    client_id: {type: env, var: CID}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "api.example.com"
+`, mapBuilder(map[string]secrets.Source{
+		"USER": &staticSource{name: "u", value: "alice"},
+		"PW":   &staticSource{name: "p", value: "s3cret"},
+		"CID":  &staticSource{name: "cid", value: "the-client-id"},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Empty(t, srv.LastForm().Get("client_secret"))
+}
+
+// --- token_endpoint_headers ---
+
+func TestTokenEndpointHeaders_SentOnMint(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	o := buildTransformWith(t, `
+tokens:
+  - grant: password
+    username:  {type: env, var: USER}
+    password:  {type: env, var: PW}
+    client_id: {type: env, var: CID}
+    token_endpoint: "`+srv.URL+`/token"
+    token_endpoint_headers:
+      x-api-key: {type: env, var: APIKEY}
+    rules:
+      - host: "api.alpha-sense.com"
+`, mapBuilder(map[string]secrets.Source{
+		"USER":   &staticSource{name: "u", value: "alice"},
+		"PW":     &staticSource{name: "p", value: "s3cret"},
+		"CID":    &staticSource{name: "cid", value: "the-client-id"},
+		"APIKEY": &staticSource{name: "k", value: "venue-api-key"},
+	}))
+
+	req := newRequest(t, http.MethodPost, "https://api.alpha-sense.com/gql")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+
+	// Header casing preserved verbatim. Go's http.Header canonicalizes on Get,
+	// but the wire bytes use the original "x-api-key" since we Set on a cloned
+	// request inside our RoundTripper, then the server canonicalizes on read.
+	require.Equal(t, "venue-api-key", srv.LastHeaders().Get("X-Api-Key"))
+	// The inbound request itself must not have received the header.
+	require.Empty(t, req.Header.Get("X-Api-Key"))
+}
+
+// Endpoint headers also work for other grants — verify with client_credentials.
+func TestTokenEndpointHeaders_ClientCredentials(t *testing.T) {
+	srv := newTokenServer(t, nil)
+	o := buildTransformWith(t, `
+tokens:
+  - grant: client_credentials
+    client_id:     {type: env, var: CID}
+    client_secret: {type: env, var: CSECRET}
+    token_endpoint: "`+srv.URL+`/token"
+    token_endpoint_headers:
+      x-tenant: {type: env, var: TENANT}
+    rules:
+      - host: "api.example.com"
+`, mapBuilder(map[string]secrets.Source{
+		"CID":     &staticSource{name: "cid", value: "cid"},
+		"CSECRET": &staticSource{name: "cs", value: "cs"},
+		"TENANT":  &staticSource{name: "t", value: "acme"},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://api.example.com/v1/x")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "acme", srv.LastHeaders().Get("X-Tenant"))
 }
 
 // --- factory end-to-end through the real secrets package ---

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -284,6 +284,9 @@ transforms:
   # grant is one of:
   #   refresh_token       RFC 6749 — a refresh token plus a client id
   #   client_credentials  RFC 6749 4.4 — a client id and secret
+  #   password            RFC 6749 4.3 — username + password + client id
+  #                       (+ optional client secret). Used by vendors that
+  #                       trade a service-account login for a bearer.
   #
   # (For GCP service-account auth — the RFC 7523 JWT-bearer grant — use the
   # gcp_auth transform above instead.)
@@ -296,6 +299,11 @@ transforms:
   # Setting token_endpoint also stubs that endpoint, so a sandboxed client SDK
   # can complete its own token dance against the proxy with a placeholder
   # token while the proxy injects the real one.
+  #
+  # token_endpoint_headers (optional, any grant) sends extra request headers
+  # on the token POST itself. Some vendors require an api-key header on the
+  # token endpoint in addition to client_id/client_secret in the form body.
+  # Each value is a discrete secret source.
   # - name: oauth_token
   #   config:
   #     tokens:
@@ -328,6 +336,38 @@ transforms:
   #         token_endpoint: "https://login.example.com/oauth2/token"
   #         rules:
   #           - host: "api.example.com"
+  #
+  # AlphaSense-style: password grant + an api-key header on both the token
+  # endpoint and the resource endpoint. The bearer is minted here; the static
+  # api-key and clientId headers that GraphQL also wants are injected by two
+  # plain secrets entries below.
+  # - name: oauth_token
+  #   config:
+  #     tokens:
+  #       - grant: password
+  #         username:      {type: env, var: ALPHASENSE_USERNAME}
+  #         password:      {type: env, var: ALPHASENSE_PASSWORD}
+  #         client_id:     {type: env, var: ALPHASENSE_CLIENT_ID}
+  #         client_secret: {type: env, var: ALPHASENSE_CLIENT_SECRET}
+  #         token_endpoint: "https://api.alpha-sense.com/token"
+  #         token_endpoint_headers:
+  #           x-api-key: {type: env, var: ALPHASENSE_API_KEY}
+  #         rules:
+  #           - host: "api.alpha-sense.com"
+  #             paths: ["/gql", "/gql/*"]
+  # - name: secrets
+  #   config:
+  #     secrets:
+  #       - source: {type: env, var: ALPHASENSE_API_KEY}
+  #         inject: {header: "x-api-key"}
+  #         rules:
+  #           - host: "api.alpha-sense.com"
+  #             paths: ["/gql", "/gql/*"]
+  #       - source: {type: env, var: ALPHASENSE_CLIENT_ID}
+  #         inject: {header: "clientId"}
+  #         rules:
+  #           - host: "api.alpha-sense.com"
+  #             paths: ["/gql", "/gql/*"]
 
   # Generic HMAC request signing. Computes an HMAC signature over a Go-template
   # message derived from the request (timestamp, method, path, query, host,


### PR DESCRIPTION
Adds the RFC 6749 4.3 resource-owner password grant to the `oauth_token` transform, plus a `token_endpoint_headers` map that injects vendor-specific headers (e.g. `x-api-key`) on the token POST itself. Together these express AlphaSense-style auth, where a service-account login is traded for a bearer and the token endpoint requires an api key alongside the standard form-body client auth.

Caching, single-flight, and refresh on the password grant use `oauth2.ReuseTokenSource` wrapping a small `passwordSource` that re-runs `cfg.PasswordCredentialsToken` on expiry. Endpoint headers are folded into the credential fingerprint so the token source is rebuilt if any header value changes.

Example AlphaSense block added to `iron-proxy.example.yaml`.