### PR TITLE
refactor(oauth): fingerprint secret sources with BLAKE3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/wasilibs/go-pgquery v0.0.0-20260428021157-dca720e45577
+	github.com/zeebo/blake3 v0.2.4
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
@@ -104,7 +105,6 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -103,6 +104,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -202,6 +204,8 @@ github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb h1:gQ+ZV4w
 github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,12 @@ github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb h1:gQ+ZV4w
 github.com/wasilibs/wazero-helpers v0.0.0-20250123031827-cd30c44769bb/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
 github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=

--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash"
@@ -92,8 +93,8 @@ func (e *tokenEntry) resolveCredentials(ctx context.Context, h hash.Hash) (map[s
 }
 
 // resolveEndpointHeaders mirrors resolveCredentials for the token-endpoint
-// header sources. Its slice of the hasher is namespaced with a NUL-bracketed
-// marker so it can't collide with credential field names.
+// header sources. A length-prefixed section marker precedes its fields so a
+// header named the same as a credential field can't collide with it.
 func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context, h hash.Hash) (map[string]string, error) {
 	if len(e.endpointHeaderSources) == 0 {
 		return nil, nil
@@ -105,9 +106,7 @@ func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context, h hash.Hash) (m
 	sort.Strings(keys)
 
 	out := make(map[string]string, len(e.endpointHeaderSources))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte("endpoint_headers"))
-	_, _ = h.Write([]byte{0})
+	writeFingerprintBytes(h, []byte("endpoint_headers"))
 	for _, k := range keys {
 		v, err := e.endpointHeaderSources[k].Get(ctx)
 		if err != nil {
@@ -119,14 +118,20 @@ func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context, h hash.Hash) (m
 	return out, nil
 }
 
-// writeFingerprintField streams a key/value pair into the hasher using the
-// same NUL-terminated `key=value\0` framing the previous string-builder
-// fingerprint used. hash.Hash writes never fail, so the errors are dropped.
+// writeFingerprintField streams a key/value pair into the hasher with explicit
+// uint32 length prefixes. Length prefixing rules out canonicalization
+// collisions regardless of what bytes a secret source returns. hash.Hash
+// writes never fail, so the errors are dropped.
 func writeFingerprintField(h hash.Hash, k, v string) {
-	_, _ = h.Write([]byte(k))
-	_, _ = h.Write([]byte{'='})
-	_, _ = h.Write([]byte(v))
-	_, _ = h.Write([]byte{0})
+	writeFingerprintBytes(h, []byte(k))
+	writeFingerprintBytes(h, []byte(v))
+}
+
+func writeFingerprintBytes(h hash.Hash, b []byte) {
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(b)))
+	_, _ = h.Write(lenBuf[:])
+	_, _ = h.Write(b)
 }
 
 // headerInjectingTransport sets configured headers on every request before

--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash"
 	"log/slog"
 	"net/http"
 	"sort"
-	"strings"
 
+	"github.com/zeebo/blake3"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -34,16 +35,20 @@ func (e *tokenEntry) mint(ctx context.Context) (string, error) {
 // caches the access token and single-flights concurrent refreshes.
 func (e *tokenEntry) tokenSourceFor(ctx context.Context) (oauth2.TokenSource, error) {
 	// Sources are read outside the lock: each has its own ttl cache, so this is
-	// cheap and returns stable values within the ttl window.
-	vals, fingerprint, err := e.resolveCredentials(ctx)
+	// cheap and returns stable values within the ttl window. Credential bytes
+	// stream straight into the hasher so plaintext secrets aren't held in an
+	// intermediate buffer.
+	h := blake3.New()
+	vals, err := e.resolveCredentials(ctx, h)
 	if err != nil {
 		return nil, err
 	}
-	headers, headerFingerprint, err := e.resolveEndpointHeaders(ctx)
+	headers, err := e.resolveEndpointHeaders(ctx, h)
 	if err != nil {
 		return nil, err
 	}
-	fingerprint += headerFingerprint
+	var fingerprint [32]byte
+	copy(fingerprint[:], h.Sum(nil))
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -63,10 +68,11 @@ func (e *tokenEntry) tokenSourceFor(ctx context.Context) (oauth2.TokenSource, er
 	return ts, nil
 }
 
-// resolveCredentials fetches every credential source for the entry and returns
-// the resolved values keyed by field, plus a fingerprint that changes whenever
+// resolveCredentials fetches every credential source for the entry, returns
+// the resolved values keyed by field, and streams each key/value pair into the
+// given hasher so the caller can derive a fingerprint that changes whenever
 // any value does.
-func (e *tokenEntry) resolveCredentials(ctx context.Context) (map[string]string, string, error) {
+func (e *tokenEntry) resolveCredentials(ctx context.Context, h hash.Hash) (map[string]string, error) {
 	keys := make([]string, 0, len(e.sources))
 	for k := range e.sources {
 		keys = append(keys, k)
@@ -74,27 +80,23 @@ func (e *tokenEntry) resolveCredentials(ctx context.Context) (map[string]string,
 	sort.Strings(keys)
 
 	vals := make(map[string]string, len(e.sources))
-	var fp strings.Builder
 	for _, k := range keys {
 		v, err := e.sources[k].Get(ctx)
 		if err != nil {
-			return nil, "", fmt.Errorf("loading %s from %q: %w", k, e.sources[k].Name(), err)
+			return nil, fmt.Errorf("loading %s from %q: %w", k, e.sources[k].Name(), err)
 		}
 		vals[k] = v
-		fp.WriteString(k)
-		fp.WriteByte('=')
-		fp.WriteString(v)
-		fp.WriteByte(0)
+		writeFingerprintField(h, k, v)
 	}
-	return vals, fp.String(), nil
+	return vals, nil
 }
 
 // resolveEndpointHeaders mirrors resolveCredentials for the token-endpoint
-// header sources. The returned fingerprint slot is namespaced with a NUL so it
-// can't collide with credential field names.
-func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context) (map[string]string, string, error) {
+// header sources. Its slice of the hasher is namespaced with a NUL-bracketed
+// marker so it can't collide with credential field names.
+func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context, h hash.Hash) (map[string]string, error) {
 	if len(e.endpointHeaderSources) == 0 {
-		return nil, "", nil
+		return nil, nil
 	}
 	keys := make([]string, 0, len(e.endpointHeaderSources))
 	for k := range e.endpointHeaderSources {
@@ -103,22 +105,28 @@ func (e *tokenEntry) resolveEndpointHeaders(ctx context.Context) (map[string]str
 	sort.Strings(keys)
 
 	out := make(map[string]string, len(e.endpointHeaderSources))
-	var fp strings.Builder
-	fp.WriteByte(0)
-	fp.WriteString("endpoint_headers")
-	fp.WriteByte(0)
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte("endpoint_headers"))
+	_, _ = h.Write([]byte{0})
 	for _, k := range keys {
 		v, err := e.endpointHeaderSources[k].Get(ctx)
 		if err != nil {
-			return nil, "", fmt.Errorf("loading token_endpoint_headers[%q] from %q: %w", k, e.endpointHeaderSources[k].Name(), err)
+			return nil, fmt.Errorf("loading token_endpoint_headers[%q] from %q: %w", k, e.endpointHeaderSources[k].Name(), err)
 		}
 		out[k] = v
-		fp.WriteString(k)
-		fp.WriteByte('=')
-		fp.WriteString(v)
-		fp.WriteByte(0)
+		writeFingerprintField(h, k, v)
 	}
-	return out, fp.String(), nil
+	return out, nil
+}
+
+// writeFingerprintField streams a key/value pair into the hasher using the
+// same NUL-terminated `key=value\0` framing the previous string-builder
+// fingerprint used. hash.Hash writes never fail, so the errors are dropped.
+func writeFingerprintField(h hash.Hash, k, v string) {
+	_, _ = h.Write([]byte(k))
+	_, _ = h.Write([]byte{'='})
+	_, _ = h.Write([]byte(v))
+	_, _ = h.Write([]byte{0})
 }
 
 // headerInjectingTransport sets configured headers on every request before

--- a/internal/transform/oauth/oauth.go
+++ b/internal/transform/oauth/oauth.go
@@ -127,9 +127,10 @@ type tokenEntry struct {
 	// mu guards the lazily built token source and the fingerprint of the
 	// credential values it was built from. The token source is rebuilt when
 	// any source value changes (e.g. a credential's ttl expired and the secret
-	// store returned a new value).
+	// store returned a new value). The fingerprint is a BLAKE3 digest of the
+	// resolved values, so plaintext secrets aren't retained on the entry.
 	mu          sync.Mutex
-	fingerprint string
+	fingerprint [32]byte
 	tokenSource oauth2.TokenSource
 }
 


### PR DESCRIPTION
The oauth_token transform detects credential changes by fingerprinting the resolved values of every secret source on each token-source lookup. Until now that fingerprint was a `strings.Builder` of `key=value\0` pairs, which kept raw secret material on the entry indefinitely and grew with credential length.

Stream the same framing into a BLAKE3 hasher instead and store a fixed `[32]byte` digest. Plaintext secrets never land in an intermediate buffer, comparisons are array equality, and BLAKE3's SIMD paths (via `github.com/zeebo/blake3`) are faster than SHA-256 on both amd64 and arm64.