### PR TITLE
ci: use Namespace runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -27,7 +27,7 @@ jobs:
         if: always()
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -121,7 +121,7 @@ jobs:
         if: always()
 
   vet:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -140,7 +140,7 @@ jobs:
         if: always()
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -161,7 +161,7 @@ jobs:
         if: always()
 
   tidy:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-iron-proxy
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Switches all GitHub Actions jobs from `ubuntu-latest` to the `namespace-profile-iron-proxy` Namespace runner profile.