### PR TITLE
feat(oauth): add jwt_bearer grant

### DIFF
--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zeebo/blake3"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+	"golang.org/x/oauth2/jwt"
 )
 
 // mint returns a cached or freshly minted access token for the entry.
@@ -60,7 +61,7 @@ func (e *tokenEntry) tokenSourceFor(ctx context.Context) (oauth2.TokenSource, er
 	if len(headers) > 0 {
 		tsCtx = context.WithValue(ctx, oauth2.HTTPClient, newHeaderInjectingClient(headers))
 	}
-	ts, err := buildTokenSource(tsCtx, e.grant, vals, e.scopes, e.cfgEndpoint)
+	ts, err := buildTokenSource(tsCtx, e.grant, vals, e.scopes, e.cfgEndpoint, e.audience)
 	if err != nil {
 		return nil, err
 	}
@@ -161,8 +162,9 @@ func newHeaderInjectingClient(headers map[string]string) *http.Client {
 
 // buildTokenSource constructs an oauth2.TokenSource for one grant from its
 // resolved credential values. It performs no I/O: the token is exchanged
-// lazily on the first Token() call.
-func buildTokenSource(ctx context.Context, grant string, vals map[string]string, scopes []string, cfgEndpoint string) (oauth2.TokenSource, error) {
+// lazily on the first Token() call. audience is only consulted by the
+// jwt_bearer grant.
+func buildTokenSource(ctx context.Context, grant string, vals map[string]string, scopes []string, cfgEndpoint, audience string) (oauth2.TokenSource, error) {
 	switch grant {
 	case grantRefreshToken:
 		return refreshTokenTokenSource(ctx, vals, scopes, cfgEndpoint)
@@ -170,9 +172,49 @@ func buildTokenSource(ctx context.Context, grant string, vals map[string]string,
 		return clientCredentialsTokenSource(ctx, vals, scopes, cfgEndpoint)
 	case grantPassword:
 		return passwordTokenSource(ctx, vals, scopes, cfgEndpoint)
+	case grantJWTBearer:
+		return jwtBearerTokenSource(ctx, vals, scopes, cfgEndpoint, audience)
 	default:
 		return nil, fmt.Errorf("unknown grant %q", grant)
 	}
+}
+
+// jwtBearerTokenSource builds a token source for the RFC 7523 JWT-bearer grant.
+// The proxy mints a JWT signed with an RSA private key (PEM bytes from the
+// secret source) and POSTs it as the OAuth2 assertion. Covers DocuSign,
+// Salesforce, Box, Zoom Server-to-Server, etc. — the audience and token
+// endpoint distinguish providers.
+func jwtBearerTokenSource(ctx context.Context, vals map[string]string, scopes []string, cfgEndpoint, audience string) (oauth2.TokenSource, error) {
+	issuer := vals[fieldIssuer]
+	subject := vals[fieldSubject]
+	privateKey := vals[fieldPrivateKey]
+	privateKeyID := vals[fieldPrivateKeyID] // optional
+	if issuer == "" {
+		return nil, fmt.Errorf("jwt_bearer grant is missing the issuer")
+	}
+	if subject == "" {
+		return nil, fmt.Errorf("jwt_bearer grant is missing the subject")
+	}
+	if privateKey == "" {
+		return nil, fmt.Errorf("jwt_bearer grant is missing the private key")
+	}
+	if cfgEndpoint == "" {
+		return nil, fmt.Errorf("jwt_bearer grant needs a token endpoint: set \"token_endpoint\"")
+	}
+	if audience == "" {
+		return nil, fmt.Errorf("jwt_bearer grant needs an audience: set \"audience\"")
+	}
+
+	cfg := &jwt.Config{
+		Email:        issuer,
+		Subject:      subject,
+		PrivateKey:   []byte(privateKey),
+		PrivateKeyID: privateKeyID,
+		Audience:     audience,
+		Scopes:       scopes,
+		TokenURL:     cfgEndpoint,
+	}
+	return cfg.TokenSource(ctx), nil
 }
 
 // refreshTokenTokenSource builds a token source for the RFC 6749 refresh_token

--- a/internal/transform/oauth/oauth.go
+++ b/internal/transform/oauth/oauth.go
@@ -2,20 +2,22 @@
 // injects them as Authorization: Bearer headers on matching requests.
 //
 // One oauth_token transform carries a list of token entries. Each entry names
-// an OAuth2 grant (refresh_token, client_credentials, or password), the
-// credential fields it needs — each resolved from any secrets-package source
-// (env, 1password, 1password_connect, aws_sm, aws_ssm) — and host rules
-// selecting the requests it applies to. Token exchange, caching, refresh, and
-// single-flight are delegated to golang.org/x/oauth2 — the same code path the
-// official SDKs use.
+// an OAuth2 grant (refresh_token, client_credentials, password, or
+// jwt_bearer), the credential fields it needs — each resolved from any
+// secrets-package source (env, 1password, 1password_connect, aws_sm, aws_ssm)
+// — and host rules selecting the requests it applies to. Token exchange,
+// caching, refresh, and single-flight are delegated to golang.org/x/oauth2 —
+// the same code path the official SDKs use.
 //
 // Entries may also declare token_endpoint_headers: a map of header name to
 // secret source whose resolved values are sent on the token POST itself. Some
 // vendors require an api-key header on the token endpoint in addition to the
 // standard client_id / client_secret form fields.
 //
-// GCP service-account auth (the RFC 7523 JWT-bearer grant against a Google
-// keyfile) is handled by the separate gcp_auth transform.
+// The jwt_bearer grant (RFC 7523) covers vendors that authenticate with a
+// signed JWT assertion — DocuSign, Salesforce, Box, Zoom Server-to-Server,
+// etc. GCP service-account auth uses the same flow but has a vendor-specific
+// keyfile format and is handled by the separate gcp_auth transform.
 //
 // Like all header-injecting transforms, this requires MITM mode; sni-only
 // mode has no way to rewrite headers.
@@ -41,6 +43,7 @@ const (
 	grantRefreshToken      = "refresh_token"
 	grantClientCredentials = "client_credentials"
 	grantPassword          = "password"
+	grantJWTBearer         = "jwt_bearer"
 )
 
 // Credential field keys. They name both a config field and the corresponding
@@ -52,6 +55,10 @@ const (
 	fieldClientSecret = "client_secret"
 	fieldUsername     = "username"
 	fieldPassword     = "password"
+	fieldIssuer       = "issuer"
+	fieldSubject      = "subject"
+	fieldPrivateKey   = "private_key"
+	fieldPrivateKeyID = "private_key_id"
 )
 
 // stubAccessToken is the placeholder bearer returned to clients that fetch a
@@ -78,11 +85,22 @@ type tokenEntryConfig struct {
 	// the fields can live in different stores or be pulled out of one JSON
 	// secret with json_key. ClientSecret is optional for public refresh_token
 	// clients. Username and Password are only used by the password grant.
+	// Issuer/Subject/PrivateKey/PrivateKeyID are only used by the jwt_bearer
+	// grant.
 	RefreshToken yaml.Node `yaml:"refresh_token"`
 	ClientID     yaml.Node `yaml:"client_id"`
 	ClientSecret yaml.Node `yaml:"client_secret"`
 	Username     yaml.Node `yaml:"username"`
 	Password     yaml.Node `yaml:"password"`
+	Issuer       yaml.Node `yaml:"issuer"`
+	Subject      yaml.Node `yaml:"subject"`
+	PrivateKey   yaml.Node `yaml:"private_key"`
+	PrivateKeyID yaml.Node `yaml:"private_key_id"`
+
+	// Audience is the JWT "aud" claim for the jwt_bearer grant. It is a plain
+	// string because it is a per-provider constant (e.g. "account.docusign.com",
+	// "https://login.salesforce.com") and never rotated.
+	Audience string `yaml:"audience,omitempty"`
 
 	TokenEndpoint string                 `yaml:"token_endpoint,omitempty"`
 	Scopes        []string               `yaml:"scopes,omitempty"`
@@ -115,6 +133,7 @@ type tokenEntry struct {
 	header      string
 	valuePrefix string
 	cfgEndpoint string // config token_endpoint
+	audience    string // JWT "aud" claim, jwt_bearer grant only
 	logger      *slog.Logger
 
 	// sources holds the entry's credential secret sources, keyed by field.
@@ -173,12 +192,15 @@ func isSet(n yaml.Node) bool { return n.Kind != 0 }
 
 func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuilder) (*tokenEntry, *tokenEndpoint, error) {
 	switch tc.Grant {
-	case grantRefreshToken, grantClientCredentials, grantPassword:
+	case grantRefreshToken, grantClientCredentials, grantPassword, grantJWTBearer:
 	default:
-		return nil, nil, fmt.Errorf("\"grant\" must be one of refresh_token, client_credentials, password (got %q)", tc.Grant)
+		return nil, nil, fmt.Errorf("\"grant\" must be one of refresh_token, client_credentials, password, jwt_bearer (got %q)", tc.Grant)
 	}
 	if tc.TokenEndpoint == "" {
 		return nil, nil, fmt.Errorf("%s grant requires \"token_endpoint\"", tc.Grant)
+	}
+	if tc.Grant == grantJWTBearer && tc.Audience == "" {
+		return nil, nil, fmt.Errorf("jwt_bearer grant requires \"audience\"")
 	}
 
 	sources, err := buildCredentialSources(tc, logger, buildSource)
@@ -223,6 +245,7 @@ func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuil
 		header:                header,
 		valuePrefix:           valuePrefix,
 		cfgEndpoint:           tc.TokenEndpoint,
+		audience:              tc.Audience,
 		sources:               sources,
 		endpointHeaderSources: endpointHeaders,
 		logger:                logger,
@@ -291,6 +314,26 @@ func buildCredentialSources(tc tokenEntryConfig, logger *slog.Logger, buildSourc
 		}
 		if isSet(tc.ClientSecret) {
 			fields[fieldClientSecret] = tc.ClientSecret
+		}
+		return buildAll(fields)
+
+	case grantJWTBearer:
+		if !isSet(tc.Issuer) {
+			return nil, fmt.Errorf("jwt_bearer grant requires \"issuer\"")
+		}
+		if !isSet(tc.Subject) {
+			return nil, fmt.Errorf("jwt_bearer grant requires \"subject\"")
+		}
+		if !isSet(tc.PrivateKey) {
+			return nil, fmt.Errorf("jwt_bearer grant requires \"private_key\"")
+		}
+		fields := map[string]yaml.Node{
+			fieldIssuer:     tc.Issuer,
+			fieldSubject:    tc.Subject,
+			fieldPrivateKey: tc.PrivateKey,
+		}
+		if isSet(tc.PrivateKeyID) {
+			fields[fieldPrivateKeyID] = tc.PrivateKeyID
 		}
 		return buildAll(fields)
 	}

--- a/internal/transform/oauth/oauth_test.go
+++ b/internal/transform/oauth/oauth_test.go
@@ -2,13 +2,21 @@ package oauth
 
 import (
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -189,7 +197,7 @@ func TestValidation(t *testing.T) {
 			name: "unknown grant",
 			yaml: `
 tokens:
-  - grant: jwt_bearer
+  - grant: magic_beans
     client_id: {type: env, var: CID}
     rules:
       - host: "example.com"
@@ -292,6 +300,76 @@ tokens:
       - host: "example.com"
 `,
 			wantError: "password grant requires \"client_id\"",
+		},
+		{
+			name: "jwt_bearer missing audience",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    issuer:      {type: env, var: ISS}
+    subject:     {type: env, var: SUB}
+    private_key: {type: env, var: PK}
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "jwt_bearer grant requires \"audience\"",
+		},
+		{
+			name: "jwt_bearer missing issuer",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    subject:     {type: env, var: SUB}
+    private_key: {type: env, var: PK}
+    audience: "aud.example.com"
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "jwt_bearer grant requires \"issuer\"",
+		},
+		{
+			name: "jwt_bearer missing subject",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    issuer:      {type: env, var: ISS}
+    private_key: {type: env, var: PK}
+    audience: "aud.example.com"
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "jwt_bearer grant requires \"subject\"",
+		},
+		{
+			name: "jwt_bearer missing private_key",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    issuer:  {type: env, var: ISS}
+    subject: {type: env, var: SUB}
+    audience: "aud.example.com"
+    token_endpoint: "https://t.example.com/token"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "jwt_bearer grant requires \"private_key\"",
+		},
+		{
+			name: "jwt_bearer missing token_endpoint",
+			yaml: `
+tokens:
+  - grant: jwt_bearer
+    issuer:      {type: env, var: ISS}
+    subject:     {type: env, var: SUB}
+    private_key: {type: env, var: PK}
+    audience: "aud.example.com"
+    rules:
+      - host: "example.com"
+`,
+			wantError: "jwt_bearer grant requires \"token_endpoint\"",
 		},
 	}
 	for _, tc := range cases {
@@ -745,6 +823,191 @@ tokens:
 	_, err := o.TransformRequest(context.Background(), newContext(), req)
 	require.NoError(t, err)
 	require.Equal(t, "acme", srv.LastHeaders().Get("X-Tenant"))
+}
+
+// --- jwt_bearer grant ---
+
+// pemRSAKey generates an RSA private key and returns it both as a *rsa.PrivateKey
+// (for verifying the signature in the test) and as PEM bytes (to feed into the
+// transform as the private_key secret value).
+func pemRSAKey(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pemBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	return key, string(pem.EncodeToMemory(pemBlock))
+}
+
+// parseAssertion splits a compact-serialized JWS into decoded header and claim
+// maps plus the signing input and signature bytes — enough to verify both the
+// claim shape and the RS256 signature without pulling in a JWT library.
+func parseAssertion(t *testing.T, assertion string) (header, claims map[string]any, signingInput []byte, sig []byte) {
+	t.Helper()
+	parts := strings.Split(assertion, ".")
+	require.Len(t, parts, 3, "assertion must have three dot-separated segments")
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	claimsBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(headerBytes, &header))
+	require.NoError(t, json.Unmarshal(claimsBytes, &claims))
+	signingInput = []byte(parts[0] + "." + parts[1])
+	return header, claims, signingInput, sig
+}
+
+func TestJWTBearerGrant_InjectsBearer(t *testing.T) {
+	key, pemKey := pemRSAKey(t)
+
+	var observedAssertion string
+	srv := newTokenServer(t, func(form url.Values) (int, map[string]any) {
+		observedAssertion = form.Get("assertion")
+		return http.StatusOK, map[string]any{
+			"access_token": "minted-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+	})
+
+	o := buildTransformWith(t, `
+tokens:
+  - grant: jwt_bearer
+    issuer:         {type: env, var: ISS}
+    subject:        {type: env, var: SUB}
+    private_key:    {type: env, var: PK}
+    private_key_id: {type: env, var: KID}
+    audience: "account.docusign.com"
+    token_endpoint: "`+srv.URL+`/token"
+    scopes: ["signature", "impersonation"]
+    rules:
+      - host: "*.docusign.net"
+`, mapBuilder(map[string]secrets.Source{
+		"ISS": &staticSource{name: "iss", value: "integration-key"},
+		"SUB": &staticSource{name: "sub", value: "user-guid"},
+		"PK":  &staticSource{name: "pk", value: pemKey},
+		"KID": &staticSource{name: "kid", value: "key-1"},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://demo.docusign.net/restapi/v2.1/accounts/x/users")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer minted-token", req.Header.Get("Authorization"))
+
+	form := srv.LastForm()
+	require.Equal(t, "urn:ietf:params:oauth:grant-type:jwt-bearer", form.Get("grant_type"))
+	require.NotEmpty(t, observedAssertion)
+
+	header, claims, signingInput, sig := parseAssertion(t, observedAssertion)
+	require.Equal(t, "RS256", header["alg"])
+	require.Equal(t, "JWT", header["typ"])
+	require.Equal(t, "key-1", header["kid"])
+	require.Equal(t, "integration-key", claims["iss"])
+	require.Equal(t, "user-guid", claims["sub"])
+	require.Equal(t, "account.docusign.com", claims["aud"])
+	require.Equal(t, "signature impersonation", claims["scope"])
+	require.NotZero(t, claims["iat"])
+	require.NotZero(t, claims["exp"])
+
+	digest := sha256.Sum256(signingInput)
+	require.NoError(t, rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig),
+		"assertion signature must verify against the registered public key")
+}
+
+// A jwt_bearer entry without a private_key_id omits the JWT kid header.
+func TestJWTBearerGrant_NoKeyID(t *testing.T) {
+	_, pemKey := pemRSAKey(t)
+
+	var observedAssertion string
+	srv := newTokenServer(t, func(form url.Values) (int, map[string]any) {
+		observedAssertion = form.Get("assertion")
+		return http.StatusOK, map[string]any{
+			"access_token": "minted-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+	})
+
+	o := buildTransformWith(t, `
+tokens:
+  - grant: jwt_bearer
+    issuer:      {type: env, var: ISS}
+    subject:     {type: env, var: SUB}
+    private_key: {type: env, var: PK}
+    audience: "account.docusign.com"
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "*.docusign.net"
+`, mapBuilder(map[string]secrets.Source{
+		"ISS": &staticSource{name: "iss", value: "integration-key"},
+		"SUB": &staticSource{name: "sub", value: "user-guid"},
+		"PK":  &staticSource{name: "pk", value: pemKey},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://demo.docusign.net/restapi/v2.1/x")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	header, _, _, _ := parseAssertion(t, observedAssertion)
+	_, ok := header["kid"]
+	require.False(t, ok, "kid must be omitted when private_key_id is not set")
+}
+
+// Rotating the private_key value invalidates the cached token source so the
+// next mint signs with the new key. Other credentials behave the same; this
+// guards the jwt_bearer-specific wiring through resolveCredentials.
+func TestJWTBearerGrant_KeyRotationRebuildsTokenSource(t *testing.T) {
+	keyA, pemA := pemRSAKey(t)
+	keyB, pemB := pemRSAKey(t)
+
+	var observedAssertion string
+	mintCount := 0
+	srv := newTokenServer(t, func(form url.Values) (int, map[string]any) {
+		mintCount++
+		observedAssertion = form.Get("assertion")
+		return http.StatusOK, map[string]any{
+			"access_token": fmt.Sprintf("minted-token-%d", mintCount),
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+	})
+
+	pkSource := &staticSource{name: "pk", value: pemA}
+	o := buildTransformWith(t, `
+tokens:
+  - grant: jwt_bearer
+    issuer:      {type: env, var: ISS}
+    subject:     {type: env, var: SUB}
+    private_key: {type: env, var: PK}
+    audience: "account.docusign.com"
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "*.docusign.net"
+`, mapBuilder(map[string]secrets.Source{
+		"ISS": &staticSource{name: "iss", value: "integration-key"},
+		"SUB": &staticSource{name: "sub", value: "user-guid"},
+		"PK":  pkSource,
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://demo.docusign.net/v1/x")
+	_, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer minted-token-1", req.Header.Get("Authorization"))
+
+	_, _, signingInput, sig := parseAssertion(t, observedAssertion)
+	digest := sha256.Sum256(signingInput)
+	require.NoError(t, rsa.VerifyPKCS1v15(&keyA.PublicKey, crypto.SHA256, digest[:], sig))
+
+	pkSource.value = pemB
+	req2 := newRequest(t, http.MethodGet, "https://demo.docusign.net/v1/y")
+	_, err = o.TransformRequest(context.Background(), newContext(), req2)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer minted-token-2", req2.Header.Get("Authorization"),
+		"rotating the private key must rebuild the token source and force a remint")
+
+	_, _, signingInput, sig = parseAssertion(t, observedAssertion)
+	digest = sha256.Sum256(signingInput)
+	require.NoError(t, rsa.VerifyPKCS1v15(&keyB.PublicKey, crypto.SHA256, digest[:], sig))
 }
 
 // --- factory end-to-end through the real secrets package ---

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -287,9 +287,12 @@ transforms:
   #   password            RFC 6749 4.3 — username + password + client id
   #                       (+ optional client secret). Used by vendors that
   #                       trade a service-account login for a bearer.
+  #   jwt_bearer          RFC 7523 — a JWT signed with an RSA private key,
+  #                       posted as an assertion. Used by DocuSign,
+  #                       Salesforce, Box, Zoom Server-to-Server, etc.
   #
-  # (For GCP service-account auth — the RFC 7523 JWT-bearer grant — use the
-  # gcp_auth transform above instead.)
+  # (For GCP service-account auth — also an RFC 7523 JWT-bearer flow but with
+  # a Google-specific keyfile format — use the gcp_auth transform above.)
   #
   # Each credential field is a discrete secret source, the same shape as a
   # secrets transform source (env, aws_sm, aws_ssm, 1password,
@@ -336,6 +339,29 @@ transforms:
   #         token_endpoint: "https://login.example.com/oauth2/token"
   #         rules:
   #           - host: "api.example.com"
+  #
+  # DocuSign-style: JWT-bearer grant. The proxy mints a JWT signed with the
+  # integration's RSA private key, exchanges it at the token endpoint, and
+  # injects the resulting bearer on requests to DocuSign's API hosts.
+  # The same shape works for Salesforce (audience=https://login.salesforce.com,
+  # token_endpoint=https://login.salesforce.com/services/oauth2/token), Box,
+  # Zoom Server-to-Server, etc. — only audience, token_endpoint, and scopes
+  # change.
+  # - name: oauth_token
+  #   config:
+  #     tokens:
+  #       - grant: jwt_bearer
+  #         issuer:         {type: env, var: DOCUSIGN_INTEGRATION_KEY}   # iss
+  #         subject:        {type: env, var: DOCUSIGN_USER_GUID}         # sub
+  #         private_key:                                                 # PEM-encoded RSA private key
+  #           type: 1password_connect
+  #           secret_ref: "op://Engineering/DOCUSIGN/private-key.pem"
+  #         private_key_id: {type: env, var: DOCUSIGN_KEY_ID}            # optional; emitted as JWT kid header
+  #         audience: "account.docusign.com"                             # account-d.docusign.com for the dev sandbox
+  #         token_endpoint: "https://account.docusign.com/oauth/token"
+  #         scopes: ["signature", "impersonation"]
+  #         rules:
+  #           - host: "*.docusign.net"
   #
   # AlphaSense-style: password grant + an api-key header on both the token
   # endpoint and the resource endpoint. The bearer is minted here; the static


### PR DESCRIPTION
Adds `jwt_bearer` as a fourth grant type to the `oauth_token` transform, covering RFC 7523 JWT-bearer flows for DocuSign, Salesforce, Box, Zoom Server-to-Server, Adobe Sign, and similar. The proxy mints a JWT signed with an RSA private key (PEM from any secrets source), exchanges it at the token endpoint, and injects the resulting bearer on matching requests. Token caching, fingerprint-based credential rotation, token-endpoint stubbing, and `token_endpoint_headers` all reuse the existing oauth_token infrastructure; signing is delegated to `golang.org/x/oauth2/jwt` (already a transitive dep via gcp_auth) so no new modules are added. The separate `gcp_auth` transform stays as the convenience wrapper for Google's keyfile format.