### PR TITLE
feat(auth): workload identity for aws_auth and gcp_auth

### DIFF
--- a/integration_test/awsauth_test.go
+++ b/integration_test/awsauth_test.go
@@ -30,13 +30,11 @@ func TestAWSAuth(t *testing.T) {
 		mu      sync.Mutex
 		gotAuth string
 		gotDate string
-		gotTok  string
 	)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		gotAuth = r.Header.Get("Authorization")
 		gotDate = r.Header.Get("X-Amz-Date")
-		gotTok = r.Header.Get("X-Amz-Security-Token")
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -46,7 +44,6 @@ func TestAWSAuth(t *testing.T) {
 	env := []string{
 		"AWS_ACCESS_KEY_ID=AKIAEXAMPLE",
 		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-		"AWS_SESSION_TOKEN=test-session-token",
 	}
 	proxy := startProxy(t, binary, cfgPath, env)
 	upstreamHost := upstream.Listener.Addr().String()
@@ -87,5 +84,4 @@ func TestAWSAuth(t *testing.T) {
 	require.Contains(t, gotAuth, "SignedHeaders=")
 	require.Contains(t, gotAuth, "Signature=")
 	require.Regexp(t, `^\d{8}T\d{6}Z$`, gotDate)
-	require.Equal(t, "test-session-token", gotTok)
 }

--- a/integration_test/testdata/awsauth.yaml
+++ b/integration_test/testdata/awsauth.yaml
@@ -22,7 +22,6 @@ transforms:
     config:
       access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}
       secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
-      session_token:     {type: env, var: AWS_SESSION_TOKEN}
       rules:
         - host: "127.0.0.1"
 

--- a/internal/transform/awsauth/awsauth.go
+++ b/internal/transform/awsauth/awsauth.go
@@ -83,6 +83,12 @@ type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 // reaching for the real signer.
 type signFunc func(ctx context.Context, creds aws.Credentials, req *http.Request, payloadHash, service, region string, signingTime time.Time) error
 
+// Credential provider kinds, annotated on credential-unavailable rejections.
+const (
+	providerStatic           = "static"
+	providerWorkloadIdentity = "workload_identity"
+)
+
 // AWSAuth is the transform.
 type AWSAuth struct {
 	logger           *slog.Logger
@@ -90,12 +96,19 @@ type AWSAuth struct {
 	allowedRegions   map[string]struct{} // nil → allow any
 	allowedServices  map[string]struct{} // nil → allow any
 	creds            aws.CredentialsProvider
-	credsKind        string // "static" or "workload_identity" — annotated on credential failures
 	unsignedPayload  bool
 	allowChunkedBody bool
 
 	now  func() time.Time
 	sign signFunc
+}
+
+// credsKind reports which kind of provider backs the transform, for telemetry.
+func (a *AWSAuth) credsKind() string {
+	if _, ok := a.creds.(*staticSourceProvider); ok {
+		return providerStatic
+	}
+	return providerWorkloadIdentity
 }
 
 func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
@@ -116,17 +129,13 @@ func newFromConfig(c config, logger *slog.Logger, build sourceBuilder, buildCred
 		return nil, fmt.Errorf("aws_auth: requires either access_key_id+secret_access_key or credentials_provider")
 	}
 
-	var (
-		creds     aws.CredentialsProvider
-		credsKind string
-	)
+	var creds aws.CredentialsProvider
 	if hasProvider {
 		p, err := buildCreds(c.CredentialsProvider, logger)
 		if err != nil {
 			return nil, fmt.Errorf("aws_auth: building credentials_provider: %w", err)
 		}
 		creds = p
-		credsKind = "workload_identity"
 	} else {
 		if c.AccessKeyID.IsZero() {
 			return nil, fmt.Errorf("aws_auth: access_key_id is required")
@@ -143,7 +152,6 @@ func newFromConfig(c config, logger *slog.Logger, build sourceBuilder, buildCred
 			return nil, fmt.Errorf("aws_auth: building secret_access_key source: %w", err)
 		}
 		creds = &staticSourceProvider{accessKey: accessKey, secretKey: secretKey}
-		credsKind = "static"
 	}
 
 	rules, err := hostmatch.CompileRules(c.Rules, "aws_auth")
@@ -161,7 +169,6 @@ func newFromConfig(c config, logger *slog.Logger, build sourceBuilder, buildCred
 		allowedRegions:   buildAllowSet(c.AllowedRegions),
 		allowedServices:  buildAllowSet(c.AllowedServices),
 		creds:            creds,
-		credsKind:        credsKind,
 		unsignedPayload:  c.UnsignedPayload,
 		allowChunkedBody: c.AllowChunkedBody,
 		now:              time.Now,
@@ -171,9 +178,8 @@ func newFromConfig(c config, logger *slog.Logger, build sourceBuilder, buildCred
 	}, nil
 }
 
-// staticSourceProvider adapts two secrets.Source values (access key, secret
-// key) into an aws.CredentialsProvider. Each Retrieve calls Get on both
-// sources; the sources themselves cache via their own TTL settings.
+// staticSourceProvider adapts two secrets.Source values into an
+// aws.CredentialsProvider. The sources do their own TTL caching.
 type staticSourceProvider struct {
 	accessKey secrets.Source
 	secretKey secrets.Source
@@ -252,7 +258,7 @@ func (a *AWSAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 	creds, err := a.creds.Retrieve(ctx)
 	if err != nil {
-		return a.rejectCredentialUnavailable(tctx, req, a.credsKind, err), nil
+		return a.rejectCredentialUnavailable(tctx, req, a.credsKind(), err), nil
 	}
 
 	payloadHash, reject := a.payloadHash(tctx, req)

--- a/internal/transform/awsauth/awsauth.go
+++ b/internal/transform/awsauth/awsauth.go
@@ -3,9 +3,18 @@
 // signature produced by any AWS SDK using placeholder credentials. This
 // transform reads the region and service from the inbound credential scope,
 // strips the placeholder signature, and re-signs the request with real
-// credentials drawn from a registered secret source (env, aws_sm, aws_ssm,
-// 1password, ...). This lets a single transform entry handle every AWS
-// service a client speaks to without enumerating them in config.
+// credentials. This lets a single transform entry handle every AWS service a
+// client speaks to without enumerating them in config.
+//
+// Credentials come from one of two sources, mutually exclusive:
+//   - access_key_id + secret_access_key: each backed by any registered secret
+//     source (env, aws_sm, aws_ssm, 1password, ...). Best for calling AWS
+//     from outside AWS with long-lived static keys.
+//   - credentials_provider: a structured block dispatching on a type field.
+//     The "workload_identity" type defers to the AWS SDK default credential
+//     chain, which natively resolves IRSA, EKS Pod Identity, IMDSv2, env
+//     vars, shared profiles, and SSO. Best for pod-bound rotating creds the
+//     agent should never see.
 //
 // Like hmac_sign, this requires MITM mode: sni-only mode has no method, path,
 // or body to sign. A truncated body would produce an invalid signature, so
@@ -55,14 +64,14 @@ const (
 )
 
 type config struct {
-	AccessKeyID      yaml.Node              `yaml:"access_key_id"`
-	SecretAccessKey  yaml.Node              `yaml:"secret_access_key"`
-	SessionToken     yaml.Node              `yaml:"session_token,omitempty"`
-	AllowedRegions   []string               `yaml:"allowed_regions,omitempty"`
-	AllowedServices  []string               `yaml:"allowed_services,omitempty"`
-	UnsignedPayload  bool                   `yaml:"unsigned_payload,omitempty"`
-	AllowChunkedBody bool                   `yaml:"allow_chunked_body,omitempty"`
-	Rules            []hostmatch.RuleConfig `yaml:"rules"`
+	AccessKeyID         yaml.Node              `yaml:"access_key_id,omitempty"`
+	SecretAccessKey     yaml.Node              `yaml:"secret_access_key,omitempty"`
+	CredentialsProvider yaml.Node              `yaml:"credentials_provider,omitempty"`
+	AllowedRegions      []string               `yaml:"allowed_regions,omitempty"`
+	AllowedServices     []string               `yaml:"allowed_services,omitempty"`
+	UnsignedPayload     bool                   `yaml:"unsigned_payload,omitempty"`
+	AllowChunkedBody    bool                   `yaml:"allow_chunked_body,omitempty"`
+	Rules               []hostmatch.RuleConfig `yaml:"rules"`
 }
 
 // sourceBuilder is the signature of secrets.BuildSource, factored out so tests
@@ -80,9 +89,8 @@ type AWSAuth struct {
 	rules            []hostmatch.Rule
 	allowedRegions   map[string]struct{} // nil → allow any
 	allowedServices  map[string]struct{} // nil → allow any
-	accessKeyID      secrets.Source
-	secretAccessKey  secrets.Source
-	sessionToken     secrets.Source // nil when omitted
+	creds            aws.CredentialsProvider
+	credsKind        string // "static" or "workload_identity" — annotated on credential failures
 	unsignedPayload  bool
 	allowChunkedBody bool
 
@@ -95,31 +103,47 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing aws_auth config: %w", err)
 	}
-	return newFromConfig(c, logger, secrets.BuildSource)
+	return newFromConfig(c, logger, secrets.BuildSource, BuildCredentialsProvider)
 }
 
-func newFromConfig(c config, logger *slog.Logger, build sourceBuilder) (*AWSAuth, error) {
-	if c.AccessKeyID.IsZero() {
-		return nil, fmt.Errorf("aws_auth: access_key_id is required")
+func newFromConfig(c config, logger *slog.Logger, build sourceBuilder, buildCreds credentialsProviderBuilder) (*AWSAuth, error) {
+	hasStatic := !c.AccessKeyID.IsZero() || !c.SecretAccessKey.IsZero()
+	hasProvider := !c.CredentialsProvider.IsZero()
+	if hasStatic && hasProvider {
+		return nil, fmt.Errorf("aws_auth: set either access_key_id/secret_access_key or credentials_provider, not both")
 	}
-	if c.SecretAccessKey.IsZero() {
-		return nil, fmt.Errorf("aws_auth: secret_access_key is required")
+	if !hasStatic && !hasProvider {
+		return nil, fmt.Errorf("aws_auth: requires either access_key_id+secret_access_key or credentials_provider")
 	}
 
-	accessKey, err := build(c.AccessKeyID, logger)
-	if err != nil {
-		return nil, fmt.Errorf("aws_auth: building access_key_id source: %w", err)
-	}
-	secretKey, err := build(c.SecretAccessKey, logger)
-	if err != nil {
-		return nil, fmt.Errorf("aws_auth: building secret_access_key source: %w", err)
-	}
-	var sessionToken secrets.Source
-	if !c.SessionToken.IsZero() {
-		sessionToken, err = build(c.SessionToken, logger)
+	var (
+		creds     aws.CredentialsProvider
+		credsKind string
+	)
+	if hasProvider {
+		p, err := buildCreds(c.CredentialsProvider, logger)
 		if err != nil {
-			return nil, fmt.Errorf("aws_auth: building session_token source: %w", err)
+			return nil, fmt.Errorf("aws_auth: building credentials_provider: %w", err)
 		}
+		creds = p
+		credsKind = "workload_identity"
+	} else {
+		if c.AccessKeyID.IsZero() {
+			return nil, fmt.Errorf("aws_auth: access_key_id is required")
+		}
+		if c.SecretAccessKey.IsZero() {
+			return nil, fmt.Errorf("aws_auth: secret_access_key is required")
+		}
+		accessKey, err := build(c.AccessKeyID, logger)
+		if err != nil {
+			return nil, fmt.Errorf("aws_auth: building access_key_id source: %w", err)
+		}
+		secretKey, err := build(c.SecretAccessKey, logger)
+		if err != nil {
+			return nil, fmt.Errorf("aws_auth: building secret_access_key source: %w", err)
+		}
+		creds = &staticSourceProvider{accessKey: accessKey, secretKey: secretKey}
+		credsKind = "static"
 	}
 
 	rules, err := hostmatch.CompileRules(c.Rules, "aws_auth")
@@ -136,15 +160,38 @@ func newFromConfig(c config, logger *slog.Logger, build sourceBuilder) (*AWSAuth
 		rules:            rules,
 		allowedRegions:   buildAllowSet(c.AllowedRegions),
 		allowedServices:  buildAllowSet(c.AllowedServices),
-		accessKeyID:      accessKey,
-		secretAccessKey:  secretKey,
-		sessionToken:     sessionToken,
+		creds:            creds,
+		credsKind:        credsKind,
 		unsignedPayload:  c.UnsignedPayload,
 		allowChunkedBody: c.AllowChunkedBody,
 		now:              time.Now,
 		sign: func(ctx context.Context, creds aws.Credentials, req *http.Request, payloadHash, service, region string, signingTime time.Time) error {
 			return signer.SignHTTP(ctx, creds, req, payloadHash, service, region, signingTime)
 		},
+	}, nil
+}
+
+// staticSourceProvider adapts two secrets.Source values (access key, secret
+// key) into an aws.CredentialsProvider. Each Retrieve calls Get on both
+// sources; the sources themselves cache via their own TTL settings.
+type staticSourceProvider struct {
+	accessKey secrets.Source
+	secretKey secrets.Source
+}
+
+func (p *staticSourceProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	ak, err := p.accessKey.Get(ctx)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("access_key_id: %w", err)
+	}
+	sk, err := p.secretKey.Get(ctx)
+	if err != nil {
+		return aws.Credentials{}, fmt.Errorf("secret_access_key: %w", err)
+	}
+	return aws.Credentials{
+		AccessKeyID:     ak,
+		SecretAccessKey: sk,
+		Source:          "iron-proxy aws_auth static",
 	}, nil
 }
 
@@ -203,20 +250,9 @@ func (a *AWSAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 		}
 	}
 
-	accessKey, err := a.accessKeyID.Get(ctx)
+	creds, err := a.creds.Retrieve(ctx)
 	if err != nil {
-		return a.rejectCredentialUnavailable(tctx, req, "access_key_id", err), nil
-	}
-	secretKey, err := a.secretAccessKey.Get(ctx)
-	if err != nil {
-		return a.rejectCredentialUnavailable(tctx, req, "secret_access_key", err), nil
-	}
-	var token string
-	if a.sessionToken != nil {
-		token, err = a.sessionToken.Get(ctx)
-		if err != nil {
-			return a.rejectCredentialUnavailable(tctx, req, "session_token", err), nil
-		}
+		return a.rejectCredentialUnavailable(tctx, req, a.credsKind, err), nil
 	}
 
 	payloadHash, reject := a.payloadHash(tctx, req)
@@ -232,11 +268,6 @@ func (a *AWSAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	// services.
 	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
 
-	creds := aws.Credentials{
-		AccessKeyID:     accessKey,
-		SecretAccessKey: secretKey,
-		SessionToken:    token,
-	}
 	if err := a.sign(ctx, creds, req, payloadHash, scope.service, scope.region, a.now()); err != nil {
 		tctx.Annotate("rejected", "signing_failed")
 		tctx.Annotate("error", err.Error())
@@ -247,7 +278,7 @@ func (a *AWSAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	}
 
 	injected := []string{"header:Authorization", "header:X-Amz-Date", "header:X-Amz-Content-Sha256"}
-	if token != "" {
+	if creds.SessionToken != "" {
 		injected = append(injected, "header:X-Amz-Security-Token")
 	}
 	tctx.Annotate("injected", injected)

--- a/internal/transform/awsauth/awsauth_test.go
+++ b/internal/transform/awsauth/awsauth_test.go
@@ -172,7 +172,7 @@ secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
 
 	t.Run("valid minimal config", func(t *testing.T) {
 		a := buildTransformWith(t, minimalYAML, mapBuilder(srcs))
-		require.Equal(t, "static", a.credsKind)
+		require.Equal(t, "static", a.credsKind())
 		require.Nil(t, a.allowedRegions)
 		require.Nil(t, a.allowedServices)
 	})
@@ -215,7 +215,7 @@ rules:
 		stub := &stubCredsProvider{creds: aws.Credentials{AccessKeyID: "AKIA", SecretAccessKey: "shh"}}
 		a, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), stubCredBuilder(stub))
 		require.NoError(t, err)
-		require.Equal(t, "workload_identity", a.credsKind)
+		require.Equal(t, "workload_identity", a.credsKind())
 	})
 
 	t.Run("allow lists compiled into sets", func(t *testing.T) {

--- a/internal/transform/awsauth/awsauth_test.go
+++ b/internal/transform/awsauth/awsauth_test.go
@@ -99,12 +99,39 @@ func signedRequest(t *testing.T, method, rawURL, region, service string, body []
 
 func buildTransformWith(t *testing.T, cfgYAML string, build sourceBuilder) *AWSAuth {
 	t.Helper()
+	return buildTransformWithBoth(t, cfgYAML, build, errCredBuilder)
+}
+
+func buildTransformWithBoth(t *testing.T, cfgYAML string, build sourceBuilder, buildCreds credentialsProviderBuilder) *AWSAuth {
+	t.Helper()
 	var c config
 	node := yamlFromString(t, cfgYAML)
 	require.NoError(t, node.Decode(&c))
-	a, err := newFromConfig(c, slog.Default(), build)
+	a, err := newFromConfig(c, slog.Default(), build, buildCreds)
 	require.NoError(t, err)
 	return a
+}
+
+// errCredBuilder fails if invoked. Used in tests that exercise the legacy
+// static path so an accidental credentials_provider entry is caught.
+func errCredBuilder(yaml.Node, *slog.Logger) (aws.CredentialsProvider, error) {
+	return nil, fmt.Errorf("credentials_provider builder must not be called in this test")
+}
+
+// stubCredsProvider returns canned credentials.
+type stubCredsProvider struct {
+	creds aws.Credentials
+	err   error
+	calls atomic.Int64
+}
+
+func (p *stubCredsProvider) Retrieve(context.Context) (aws.Credentials, error) {
+	p.calls.Add(1)
+	return p.creds, p.err
+}
+
+func stubCredBuilder(p aws.CredentialsProvider) credentialsProviderBuilder {
+	return func(yaml.Node, *slog.Logger) (aws.CredentialsProvider, error) { return p, nil }
 }
 
 const minimalYAML = `
@@ -128,7 +155,7 @@ rules:
   - host: "*.amazonaws.com"
 `)
 		require.NoError(t, node.Decode(&c))
-		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs))
+		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), errCredBuilder)
 		require.ErrorContains(t, err, "access_key_id is required")
 	})
 
@@ -139,31 +166,56 @@ access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}
 secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
 `)
 		require.NoError(t, node.Decode(&c))
-		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs))
+		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), errCredBuilder)
 		require.ErrorContains(t, err, `at least one entry in "rules" is required`)
 	})
 
 	t.Run("valid minimal config", func(t *testing.T) {
 		a := buildTransformWith(t, minimalYAML, mapBuilder(srcs))
-		require.Nil(t, a.sessionToken)
+		require.Equal(t, "static", a.credsKind)
 		require.Nil(t, a.allowedRegions)
 		require.Nil(t, a.allowedServices)
 	})
 
-	t.Run("session token wired when present", func(t *testing.T) {
-		srcs := map[string]secrets.Source{
-			"AWS_ACCESS_KEY_ID":     &staticSource{name: "access", value: "AKIA"},
-			"AWS_SECRET_ACCESS_KEY": &staticSource{name: "secret", value: "shh"},
-			"AWS_SESSION_TOKEN":     &staticSource{name: "token", value: "tok"},
-		}
-		a := buildTransformWith(t, `
+	t.Run("rejects both static and credentials_provider", func(t *testing.T) {
+		var c config
+		node := yamlFromString(t, `
 access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}
 secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
-session_token:     {type: env, var: AWS_SESSION_TOKEN}
+credentials_provider:
+  type: workload_identity
 rules:
   - host: "*.amazonaws.com"
-`, mapBuilder(srcs))
-		require.NotNil(t, a.sessionToken)
+`)
+		require.NoError(t, node.Decode(&c))
+		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), errCredBuilder)
+		require.ErrorContains(t, err, "not both")
+	})
+
+	t.Run("rejects neither static nor credentials_provider", func(t *testing.T) {
+		var c config
+		node := yamlFromString(t, `
+rules:
+  - host: "*.amazonaws.com"
+`)
+		require.NoError(t, node.Decode(&c))
+		_, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), errCredBuilder)
+		require.ErrorContains(t, err, "requires either")
+	})
+
+	t.Run("credentials_provider builds workload_identity path", func(t *testing.T) {
+		var c config
+		node := yamlFromString(t, `
+credentials_provider:
+  type: workload_identity
+rules:
+  - host: "*.amazonaws.com"
+`)
+		require.NoError(t, node.Decode(&c))
+		stub := &stubCredsProvider{creds: aws.Credentials{AccessKeyID: "AKIA", SecretAccessKey: "shh"}}
+		a, err := newFromConfig(c, slog.Default(), mapBuilder(srcs), stubCredBuilder(stub))
+		require.NoError(t, err)
+		require.Equal(t, "workload_identity", a.credsKind)
 	})
 
 	t.Run("allow lists compiled into sets", func(t *testing.T) {
@@ -290,24 +342,25 @@ func TestTransformRequest(t *testing.T) {
 		require.Contains(t, req.Header.Get("Authorization"), "/eu-west-1/s3/aws4_request")
 	})
 
-	t.Run("session token populates security-token header", func(t *testing.T) {
-		srcs := map[string]secrets.Source{
-			"AWS_ACCESS_KEY_ID":     &staticSource{name: "access", value: "AKIA"},
-			"AWS_SECRET_ACCESS_KEY": &staticSource{name: "secret", value: "shh"},
-			"AWS_SESSION_TOKEN":     &staticSource{name: "token", value: "IQoJb3JpZ2luX2VjE..."},
-		}
-		a := buildTransformWith(t, `
-access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}
-secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
-session_token:     {type: env, var: AWS_SESSION_TOKEN}
+	t.Run("workload_identity provider session token populates security-token header", func(t *testing.T) {
+		stub := &stubCredsProvider{creds: aws.Credentials{
+			AccessKeyID:     "ASIAEXAMPLE",
+			SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			SessionToken:    "IQoJb3JpZ2luX2VjE...",
+		}}
+		a := buildTransformWithBoth(t, `
+credentials_provider:
+  type: workload_identity
 rules:
   - host: "*.amazonaws.com"
-`, mapBuilder(srcs))
+`, mapBuilder(srcs), stubCredBuilder(stub))
 
 		req := signedRequest(t, http.MethodGet, "https://bucket.s3.us-east-1.amazonaws.com/key", "us-east-1", "s3", nil, 1<<20)
 		_, err := a.TransformRequest(context.Background(), newContext(), req)
 		require.NoError(t, err)
 		require.Equal(t, "IQoJb3JpZ2luX2VjE...", req.Header.Get("X-Amz-Security-Token"))
+		require.Contains(t, req.Header.Get("Authorization"), "ASIAEXAMPLE")
+		require.Equal(t, int64(1), stub.calls.Load())
 	})
 
 	t.Run("placeholder signature is stripped before re-signing", func(t *testing.T) {

--- a/internal/transform/awsauth/credprovider.go
+++ b/internal/transform/awsauth/credprovider.go
@@ -11,19 +11,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// credentialsProviderBuilder turns a credentials_provider config node into an
-// aws.CredentialsProvider. Tests substitute a stub builder.
 type credentialsProviderBuilder func(yaml.Node, *slog.Logger) (aws.CredentialsProvider, error)
 
-// providerTypeHint is used to peek at the type field before dispatching.
 type providerTypeHint struct {
 	Type string `yaml:"type"`
 }
 
 // BuildCredentialsProvider dispatches a credentials_provider node through the
-// default registry. Mirrors secrets.BuildSource. Returns an aws.CredentialsProvider
-// suitable for handing directly to a SigV4 signer; refresh and caching are
-// delegated to the AWS SDK.
+// default registry. Mirrors secrets.BuildSource.
 func BuildCredentialsProvider(node yaml.Node, logger *slog.Logger) (aws.CredentialsProvider, error) {
 	var hint providerTypeHint
 	if err := node.Decode(&hint); err != nil {
@@ -32,34 +27,28 @@ func BuildCredentialsProvider(node yaml.Node, logger *slog.Logger) (aws.Credenti
 	if hint.Type == "" {
 		return nil, fmt.Errorf("credentials_provider.type is required")
 	}
-	registry := defaultCredentialsProviderRegistry()
-	builder, ok := registry[hint.Type]
+	builder, ok := defaultCredentialsProviderRegistry()[hint.Type]
 	if !ok {
 		return nil, fmt.Errorf("unsupported credentials_provider type %q", hint.Type)
 	}
 	return builder(node, logger)
 }
 
-// defaultCredentialsProviderRegistry returns the standard provider builders.
-// New types (assume_role, static, ...) are additive: register them here.
 func defaultCredentialsProviderRegistry() map[string]credentialsProviderBuilder {
 	return map[string]credentialsProviderBuilder{
-		"workload_identity": buildWorkloadIdentity,
+		providerWorkloadIdentity: buildWorkloadIdentity,
 	}
 }
 
-// workloadIdentityConfig is the YAML shape for the workload_identity provider.
 type workloadIdentityConfig struct {
 	Type   string `yaml:"type"`
 	Region string `yaml:"region,omitempty"`
 }
 
 // buildWorkloadIdentity returns a provider that defers to the AWS SDK default
-// credential chain. The chain natively resolves IRSA, EKS Pod Identity, IMDSv2,
-// environment variables, shared profiles, and SSO. Loading the SDK config is
-// deferred to the first Retrieve so factory-time validation does not require a
-// reachable metadata server. The result is wrapped in aws.CredentialsCache so
-// refresh respects the provider's reported expiry.
+// credential chain (IRSA, EKS Pod Identity, IMDSv2, env, profiles, SSO). The
+// SDK config load is deferred to the first Retrieve so factory-time validation
+// does not require a reachable metadata server.
 func buildWorkloadIdentity(node yaml.Node, _ *slog.Logger) (aws.CredentialsProvider, error) {
 	var cfg workloadIdentityConfig
 	if err := node.Decode(&cfg); err != nil {
@@ -68,10 +57,9 @@ func buildWorkloadIdentity(node yaml.Node, _ *slog.Logger) (aws.CredentialsProvi
 	return aws.NewCredentialsCache(&lazyDefaultChainProvider{region: cfg.Region}), nil
 }
 
-// lazyDefaultChainProvider loads the AWS default credential chain on first
-// Retrieve and reuses the resulting provider thereafter. The inner provider
-// (returned by awsconfig.LoadDefaultConfig) already handles its own expiry, so
-// callers wrap this in aws.NewCredentialsCache rather than caching here.
+// lazyDefaultChainProvider loads awsconfig.LoadDefaultConfig on first Retrieve.
+// The inner provider tracks its own expiry; aws.NewCredentialsCache wraps this
+// at the call site to normalize refresh.
 type lazyDefaultChainProvider struct {
 	region string
 
@@ -81,35 +69,23 @@ type lazyDefaultChainProvider struct {
 
 func (p *lazyDefaultChainProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	p.mu.Lock()
+	if p.inner == nil {
+		var opts []func(*awsconfig.LoadOptions) error
+		if p.region != "" {
+			opts = append(opts, awsconfig.WithRegion(p.region))
+		}
+		cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+		if err != nil {
+			p.mu.Unlock()
+			return aws.Credentials{}, fmt.Errorf("loading AWS default credential chain: %w", err)
+		}
+		if cfg.Credentials == nil {
+			p.mu.Unlock()
+			return aws.Credentials{}, fmt.Errorf("AWS default credential chain returned no credentials provider")
+		}
+		p.inner = cfg.Credentials
+	}
 	inner := p.inner
 	p.mu.Unlock()
-	if inner == nil {
-		loaded, err := p.load(ctx)
-		if err != nil {
-			return aws.Credentials{}, err
-		}
-		inner = loaded
-	}
 	return inner.Retrieve(ctx)
-}
-
-func (p *lazyDefaultChainProvider) load(ctx context.Context) (aws.CredentialsProvider, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.inner != nil {
-		return p.inner, nil
-	}
-	var opts []func(*awsconfig.LoadOptions) error
-	if p.region != "" {
-		opts = append(opts, awsconfig.WithRegion(p.region))
-	}
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("loading AWS default credential chain: %w", err)
-	}
-	if cfg.Credentials == nil {
-		return nil, fmt.Errorf("AWS default credential chain returned no credentials provider")
-	}
-	p.inner = cfg.Credentials
-	return p.inner, nil
 }

--- a/internal/transform/awsauth/credprovider.go
+++ b/internal/transform/awsauth/credprovider.go
@@ -1,0 +1,115 @@
+package awsauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"gopkg.in/yaml.v3"
+)
+
+// credentialsProviderBuilder turns a credentials_provider config node into an
+// aws.CredentialsProvider. Tests substitute a stub builder.
+type credentialsProviderBuilder func(yaml.Node, *slog.Logger) (aws.CredentialsProvider, error)
+
+// providerTypeHint is used to peek at the type field before dispatching.
+type providerTypeHint struct {
+	Type string `yaml:"type"`
+}
+
+// BuildCredentialsProvider dispatches a credentials_provider node through the
+// default registry. Mirrors secrets.BuildSource. Returns an aws.CredentialsProvider
+// suitable for handing directly to a SigV4 signer; refresh and caching are
+// delegated to the AWS SDK.
+func BuildCredentialsProvider(node yaml.Node, logger *slog.Logger) (aws.CredentialsProvider, error) {
+	var hint providerTypeHint
+	if err := node.Decode(&hint); err != nil {
+		return nil, fmt.Errorf("parsing credentials_provider type: %w", err)
+	}
+	if hint.Type == "" {
+		return nil, fmt.Errorf("credentials_provider.type is required")
+	}
+	registry := defaultCredentialsProviderRegistry()
+	builder, ok := registry[hint.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported credentials_provider type %q", hint.Type)
+	}
+	return builder(node, logger)
+}
+
+// defaultCredentialsProviderRegistry returns the standard provider builders.
+// New types (assume_role, static, ...) are additive: register them here.
+func defaultCredentialsProviderRegistry() map[string]credentialsProviderBuilder {
+	return map[string]credentialsProviderBuilder{
+		"workload_identity": buildWorkloadIdentity,
+	}
+}
+
+// workloadIdentityConfig is the YAML shape for the workload_identity provider.
+type workloadIdentityConfig struct {
+	Type   string `yaml:"type"`
+	Region string `yaml:"region,omitempty"`
+}
+
+// buildWorkloadIdentity returns a provider that defers to the AWS SDK default
+// credential chain. The chain natively resolves IRSA, EKS Pod Identity, IMDSv2,
+// environment variables, shared profiles, and SSO. Loading the SDK config is
+// deferred to the first Retrieve so factory-time validation does not require a
+// reachable metadata server. The result is wrapped in aws.CredentialsCache so
+// refresh respects the provider's reported expiry.
+func buildWorkloadIdentity(node yaml.Node, _ *slog.Logger) (aws.CredentialsProvider, error) {
+	var cfg workloadIdentityConfig
+	if err := node.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing workload_identity provider: %w", err)
+	}
+	return aws.NewCredentialsCache(&lazyDefaultChainProvider{region: cfg.Region}), nil
+}
+
+// lazyDefaultChainProvider loads the AWS default credential chain on first
+// Retrieve and reuses the resulting provider thereafter. The inner provider
+// (returned by awsconfig.LoadDefaultConfig) already handles its own expiry, so
+// callers wrap this in aws.NewCredentialsCache rather than caching here.
+type lazyDefaultChainProvider struct {
+	region string
+
+	mu    sync.Mutex
+	inner aws.CredentialsProvider
+}
+
+func (p *lazyDefaultChainProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	p.mu.Lock()
+	inner := p.inner
+	p.mu.Unlock()
+	if inner == nil {
+		loaded, err := p.load(ctx)
+		if err != nil {
+			return aws.Credentials{}, err
+		}
+		inner = loaded
+	}
+	return inner.Retrieve(ctx)
+}
+
+func (p *lazyDefaultChainProvider) load(ctx context.Context) (aws.CredentialsProvider, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.inner != nil {
+		return p.inner, nil
+	}
+	var opts []func(*awsconfig.LoadOptions) error
+	if p.region != "" {
+		opts = append(opts, awsconfig.WithRegion(p.region))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS default credential chain: %w", err)
+	}
+	if cfg.Credentials == nil {
+		return nil, fmt.Errorf("AWS default credential chain returned no credentials provider")
+	}
+	p.inner = cfg.Credentials
+	return p.inner, nil
+}

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -159,13 +159,9 @@ func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte,
 }
 
 // tokenSourceFromKeyfile parses a service-account JSON keyfile and returns a
-// token source plus the service-account email. JWTConfigFromJSON is the
-// narrowed, non-deprecated form of credential loading. It only accepts
-// service-account JSON keyfiles, which is what the keyfile path is designed
-// for; we don't want to silently accept the broader set of credential
-// configurations (workload identity federation, external_account, etc.) that
-// CredentialsFromJSON allows. Use credentials_provider: workload_identity for
-// those.
+// token source plus the service-account email. Uses JWTConfigFromJSON (not
+// CredentialsFromJSON) to reject broader credential shapes here; those go
+// through credentials_provider: workload_identity instead.
 func tokenSourceFromKeyfile(ctx context.Context, keyJSON []byte, scopes []string, subject string) (oauth2.TokenSource, string, error) {
 	cfg, err := google.JWTConfigFromJSON(keyJSON, scopes...)
 	if err != nil {

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -1,16 +1,24 @@
 // Package gcpauth implements a transform that mints short-lived GCP OAuth2
-// access tokens from a service account keyfile and injects them as
-// Authorization: Bearer headers on matching requests.
+// access tokens and injects them as Authorization: Bearer headers on matching
+// requests.
 //
-// The keyfile can be loaded from disk (keyfile_path) or from any secret
-// source registered with the secrets package (env, aws_sm, aws_ssm,
-// 1password, 1password_connect) via a nested keyfile block. Token minting,
-// caching, and refresh are delegated to golang.org/x/oauth2/google — the same
-// code path the official GCP SDKs use.
+// Credentials come from one of three sources, mutually exclusive:
+//   - keyfile_path: a service account JSON keyfile loaded from disk.
+//   - keyfile: a service account JSON keyfile loaded from any registered
+//     secret source (env, aws_sm, aws_ssm, 1password, 1password_connect).
+//   - credentials_provider: a structured block dispatching on a type field.
+//     The "workload_identity" type defers to Google Application Default
+//     Credentials, which resolves GKE Workload Identity via the metadata
+//     server, GOOGLE_APPLICATION_CREDENTIALS keyfiles, and Workload Identity
+//     Federation external_account JSON.
+//
+// Token minting, caching, and refresh are delegated to
+// golang.org/x/oauth2/google — the same code path the official GCP SDKs use.
 //
 // A non-empty subject impersonates that Workspace user via domain-wide
 // delegation: the minted token acts as the subject rather than the service
-// account itself.
+// account itself. Only valid with the keyfile sources; credentials_provider
+// rejects subject because metadata-server credentials cannot impersonate.
 //
 // Like all header-injecting transforms, this requires MITM mode; sni-only
 // mode has no way to rewrite headers.
@@ -49,25 +57,28 @@ func init() {
 }
 
 type config struct {
-	KeyfilePath string                 `yaml:"keyfile_path,omitempty"`
-	Keyfile     yaml.Node              `yaml:"keyfile,omitempty"`
-	Subject     string                 `yaml:"subject,omitempty"`
-	Scopes      []string               `yaml:"scopes"`
-	Rules       []hostmatch.RuleConfig `yaml:"rules"`
+	KeyfilePath         string                 `yaml:"keyfile_path,omitempty"`
+	Keyfile             yaml.Node              `yaml:"keyfile,omitempty"`
+	CredentialsProvider yaml.Node              `yaml:"credentials_provider,omitempty"`
+	Subject             string                 `yaml:"subject,omitempty"`
+	Scopes              []string               `yaml:"scopes"`
+	Rules               []hostmatch.RuleConfig `yaml:"rules"`
 }
 
 // GCPAuth is the transform.
 type GCPAuth struct {
-	scopes  []string
-	subject string           // Workspace user to impersonate; "" for none
-	rules   []hostmatch.Rule // empty = apply to all requests
-	loadKey func(ctx context.Context) ([]byte, error)
-	logger  *slog.Logger
+	rules    []hostmatch.Rule // empty = apply to all requests
+	tsLoader tokenSourceLoader
+	logger   *slog.Logger
 
 	mu          sync.Mutex
 	tokenSource oauth2.TokenSource
-	email       string
+	principal   string
 }
+
+// tokenSourceLoader returns a fresh token source for one transform instance,
+// plus a best-effort principal identifier for audit annotations.
+type tokenSourceLoader func(ctx context.Context) (oauth2.TokenSource, string, error)
 
 // sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
 // can inject a stub instead of constructing real source backends.
@@ -78,54 +89,97 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 	if err := cfg.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parsing gcp_auth config: %w", err)
 	}
-	return newFromConfig(c, logger, os.ReadFile, secrets.BuildSource)
+	return newFromConfig(c, logger, os.ReadFile, secrets.BuildSource, BuildTokenSource)
 }
 
-func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte, error), buildSource sourceBuilder) (*GCPAuth, error) {
+func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte, error), buildSource sourceBuilder, buildTS tokenSourceBuilder) (*GCPAuth, error) {
 	hasPath := c.KeyfilePath != ""
 	hasNested := c.Keyfile.Kind != 0
-	if hasPath == hasNested {
-		return nil, fmt.Errorf("gcp_auth: requires exactly one of \"keyfile_path\" or \"keyfile\"")
+	hasProvider := c.CredentialsProvider.Kind != 0
+	sources := 0
+	for _, b := range []bool{hasPath, hasNested, hasProvider} {
+		if b {
+			sources++
+		}
+	}
+	if sources != 1 {
+		return nil, fmt.Errorf("gcp_auth: requires exactly one of \"keyfile_path\", \"keyfile\", or \"credentials_provider\"")
 	}
 	if len(c.Scopes) == 0 {
 		return nil, fmt.Errorf("gcp_auth: at least one entry in \"scopes\" is required")
+	}
+	if hasProvider && c.Subject != "" {
+		return nil, fmt.Errorf("gcp_auth: \"subject\" cannot be combined with \"credentials_provider\" (only keyfile sources support domain-wide delegation)")
 	}
 	rules, err := hostmatch.CompileRules(c.Rules, "gcp_auth")
 	if err != nil {
 		return nil, err
 	}
 
-	var load func(context.Context) ([]byte, error)
-	if hasPath {
+	var tsLoader tokenSourceLoader
+	switch {
+	case hasPath:
 		path := c.KeyfilePath
-		load = func(context.Context) ([]byte, error) {
+		subject := c.Subject
+		scopes := c.Scopes
+		tsLoader = func(ctx context.Context) (oauth2.TokenSource, string, error) {
 			data, err := readFile(path)
 			if err != nil {
-				return nil, fmt.Errorf("reading GCP keyfile %q: %w", path, err)
+				return nil, "", fmt.Errorf("reading GCP keyfile %q: %w", path, err)
 			}
-			return data, nil
+			return tokenSourceFromKeyfile(ctx, data, scopes, subject)
 		}
-	} else {
+	case hasNested:
 		nested, err := buildSource(c.Keyfile, logger)
 		if err != nil {
 			return nil, fmt.Errorf("gcp_auth: building keyfile source: %w", err)
 		}
-		load = func(ctx context.Context) ([]byte, error) {
+		subject := c.Subject
+		scopes := c.Scopes
+		tsLoader = func(ctx context.Context) (oauth2.TokenSource, string, error) {
 			v, err := nested.Get(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("loading GCP keyfile from %q: %w", nested.Name(), err)
+				return nil, "", fmt.Errorf("loading GCP keyfile from %q: %w", nested.Name(), err)
 			}
-			return []byte(v), nil
+			return tokenSourceFromKeyfile(ctx, []byte(v), scopes, subject)
+		}
+	case hasProvider:
+		providerNode := c.CredentialsProvider
+		scopes := c.Scopes
+		tsLoader = func(ctx context.Context) (oauth2.TokenSource, string, error) {
+			return buildTS(ctx, providerNode, scopes, logger)
 		}
 	}
 
 	return &GCPAuth{
-		scopes:  c.Scopes,
-		subject: c.Subject,
-		rules:   rules,
-		loadKey: load,
-		logger:  logger,
+		rules:    rules,
+		tsLoader: tsLoader,
+		logger:   logger,
 	}, nil
+}
+
+// tokenSourceFromKeyfile parses a service-account JSON keyfile and returns a
+// token source plus the service-account email. JWTConfigFromJSON is the
+// narrowed, non-deprecated form of credential loading. It only accepts
+// service-account JSON keyfiles, which is what the keyfile path is designed
+// for; we don't want to silently accept the broader set of credential
+// configurations (workload identity federation, external_account, etc.) that
+// CredentialsFromJSON allows. Use credentials_provider: workload_identity for
+// those.
+func tokenSourceFromKeyfile(ctx context.Context, keyJSON []byte, scopes []string, subject string) (oauth2.TokenSource, string, error) {
+	cfg, err := google.JWTConfigFromJSON(keyJSON, scopes...)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing GCP service account keyfile: %w", err)
+	}
+	cfg.Subject = subject
+	var meta struct {
+		ClientEmail string `json:"client_email"`
+	}
+	email := ""
+	if err := json.Unmarshal(keyJSON, &meta); err == nil {
+		email = meta.ClientEmail
+	}
+	return cfg.TokenSource(ctx), email, nil
 }
 
 func (g *GCPAuth) Name() string { return "gcp_auth" }
@@ -155,8 +209,8 @@ func (g *GCPAuth) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	}
 
 	req.Header.Set("Authorization", "Bearer "+tok)
-	if g.email != "" {
-		tctx.Annotate("service_account", g.email)
+	if g.principal != "" {
+		tctx.Annotate("service_account", g.principal)
 	}
 	tctx.Annotate("injected", []string{"header:Authorization"})
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
@@ -187,27 +241,12 @@ func (g *GCPAuth) loadTokenSource(ctx context.Context) (oauth2.TokenSource, erro
 	if g.tokenSource != nil {
 		return g.tokenSource, nil
 	}
-	keyJSON, err := g.loadKey(ctx)
+	ts, principal, err := g.tsLoader(ctx)
 	if err != nil {
 		return nil, err
 	}
-	// JWTConfigFromJSON is the narrowed, non-deprecated form of credential
-	// loading. It only accepts service-account JSON keyfiles, which is what
-	// gcp_auth is designed for; we don't want to silently accept the broader
-	// set of credential configurations (workload identity federation,
-	// external_account, etc.) that CredentialsFromJSON allows.
-	cfg, err := google.JWTConfigFromJSON(keyJSON, g.scopes...)
-	if err != nil {
-		return nil, fmt.Errorf("parsing GCP service account keyfile: %w", err)
-	}
-	cfg.Subject = g.subject
-	var meta struct {
-		ClientEmail string `json:"client_email"`
-	}
-	if err := json.Unmarshal(keyJSON, &meta); err == nil {
-		g.email = meta.ClientEmail
-	}
-	g.tokenSource = cfg.TokenSource(ctx)
+	g.tokenSource = ts
+	g.principal = principal
 	return g.tokenSource, nil
 }
 

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/transform"
@@ -46,6 +47,18 @@ func staticBuilder(src secrets.Source) sourceBuilder {
 
 func failingBuilder(err error) sourceBuilder {
 	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return nil, err }
+}
+
+// errTokenSourceBuilder fails if invoked. Used in tests that exercise the
+// keyfile paths so an accidental credentials_provider entry is caught.
+func errTokenSourceBuilder(context.Context, yaml.Node, []string, *slog.Logger) (oauth2.TokenSource, string, error) {
+	return nil, "", fmt.Errorf("tokenSourceBuilder must not be called in this test")
+}
+
+func staticTokenSourceBuilder(ts oauth2.TokenSource, principal string) tokenSourceBuilder {
+	return func(context.Context, yaml.Node, []string, *slog.Logger) (oauth2.TokenSource, string, error) {
+		return ts, principal, nil
+	}
 }
 
 // testKeyfileJSON generates a service-account JSON keyfile pointing token
@@ -143,16 +156,65 @@ rules:
 `,
 			wantError: "scopes",
 		},
+		{
+			name: "keyfile_path and credentials_provider both set",
+			yaml: `
+keyfile_path: /tmp/k.json
+credentials_provider:
+  type: workload_identity
+scopes: [a]
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "exactly one of",
+		},
+		{
+			name: "subject combined with credentials_provider",
+			yaml: `
+credentials_provider:
+  type: workload_identity
+subject: user@workspace.example.com
+scopes: [a]
+rules:
+  - host: "*.googleapis.com"
+`,
+			wantError: "subject",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var c config
 			node := yamlFromString(t, tc.yaml)
 			require.NoError(t, node.Decode(&c))
-			_, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+			_, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 			require.ErrorContains(t, err, tc.wantError)
 		})
 	}
+}
+
+func TestGCPAuth_InjectsBearerFromCredentialsProvider(t *testing.T) {
+	cfgYAML := `
+credentials_provider:
+  type: workload_identity
+scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+rules:
+  - host: "*.googleapis.com"
+`
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "wi-token", TokenType: "Bearer"})
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), staticTokenSourceBuilder(ts, "wi-principal@example.com"))
+	require.NoError(t, err)
+
+	req := newRequest(t, "storage.googleapis.com")
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer wi-token", req.Header.Get("Authorization"))
+	require.Equal(t, "wi-principal@example.com", tctx.DrainAnnotations()["service_account"])
 }
 
 func TestGCPAuth_InjectsBearerFromKeyfilePath(t *testing.T) {
@@ -165,7 +227,7 @@ func TestGCPAuth_InjectsBearerFromKeyfilePath(t *testing.T) {
 		KeyfilePath: path,
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	req := newRequest(t, "storage.googleapis.com")
@@ -188,7 +250,7 @@ secret_ref: "op://vault/gcp-sa/credential"
 `),
 		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(nested))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(nested), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	req := newRequest(t, "storage.googleapis.com")
@@ -214,7 +276,7 @@ rules:
 	var c config
 	node := yamlFromString(t, cfgYAML)
 	require.NoError(t, node.Decode(&c))
-	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	// Matching host gets the header.
@@ -241,7 +303,7 @@ func TestGCPAuth_CachesTokenAcrossRequests(t *testing.T) {
 		KeyfilePath: path,
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	for i := 0; i < 5; i++ {
@@ -258,7 +320,7 @@ func TestGCPAuth_KeyfileMissing_Rejects(t *testing.T) {
 		KeyfilePath: "/does/not/exist.json",
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	req := newRequest(t, "storage.googleapis.com")
@@ -276,7 +338,7 @@ secret_ref: "op://vault/missing"
 `),
 		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	_, err := newFromConfig(cfg, slog.Default(), os.ReadFile, failingBuilder(fmt.Errorf("not configured")))
+	_, err := newFromConfig(cfg, slog.Default(), os.ReadFile, failingBuilder(fmt.Errorf("not configured")), errTokenSourceBuilder)
 	require.ErrorContains(t, err, "building keyfile source")
 	require.ErrorContains(t, err, "not configured")
 }
@@ -318,7 +380,7 @@ rules:
 	var c config
 	node := yamlFromString(t, cfgYAML)
 	require.NoError(t, node.Decode(&c))
-	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", nil)
@@ -350,7 +412,7 @@ func TestGCPAuth_StubsMetadataServerToken(t *testing.T) {
 		KeyfilePath: path,
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	urls := []string{
@@ -387,7 +449,7 @@ func TestGCPAuth_DoesNotStubNonTokenPaths(t *testing.T) {
 		KeyfilePath: path,
 		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
-	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 	require.NoError(t, err)
 
 	cases := []string{
@@ -477,7 +539,7 @@ func TestGCPAuth_Subject(t *testing.T) {
 				Subject:     tc.subject,
 				Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
 			}
-			g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+			g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
 			require.NoError(t, err)
 
 			req := newRequest(t, "storage.googleapis.com")

--- a/internal/transform/gcpauth/tokensource.go
+++ b/internal/transform/gcpauth/tokensource.go
@@ -11,20 +11,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// tokenSourceBuilder turns a credentials_provider config node into a token
-// source plus a best-effort principal identifier (email / unique id) for
-// audit logging. Tests substitute a stub builder.
+// tokenSourceBuilder turns a credentials_provider node into a token source
+// plus a best-effort principal identifier (email / unique id) for audit logs.
 type tokenSourceBuilder func(ctx context.Context, node yaml.Node, scopes []string, logger *slog.Logger) (oauth2.TokenSource, string, error)
 
-// providerTypeHint is used to peek at the type field before dispatching.
 type providerTypeHint struct {
 	Type string `yaml:"type"`
 }
 
+// Credential provider kinds.
+const providerWorkloadIdentity = "workload_identity"
+
 // BuildTokenSource dispatches a credentials_provider node through the default
-// registry. Mirrors secrets.BuildSource. Refresh and caching are delegated to
-// the returned oauth2.TokenSource (typically google.Credentials.TokenSource,
-// which is internally cached).
+// registry. Mirrors secrets.BuildSource.
 func BuildTokenSource(ctx context.Context, node yaml.Node, scopes []string, logger *slog.Logger) (oauth2.TokenSource, string, error) {
 	var hint providerTypeHint
 	if err := node.Decode(&hint); err != nil {
@@ -33,31 +32,27 @@ func BuildTokenSource(ctx context.Context, node yaml.Node, scopes []string, logg
 	if hint.Type == "" {
 		return nil, "", fmt.Errorf("credentials_provider.type is required")
 	}
-	registry := defaultTokenSourceRegistry()
-	builder, ok := registry[hint.Type]
+	builder, ok := defaultTokenSourceRegistry()[hint.Type]
 	if !ok {
 		return nil, "", fmt.Errorf("unsupported credentials_provider type %q", hint.Type)
 	}
 	return builder(ctx, node, scopes, logger)
 }
 
-// defaultTokenSourceRegistry returns the standard token-source builders.
-// Additional types (e.g. impersonated_service_account) are additive.
 func defaultTokenSourceRegistry() map[string]tokenSourceBuilder {
 	return map[string]tokenSourceBuilder{
-		"workload_identity": buildWorkloadIdentity,
+		providerWorkloadIdentity: buildWorkloadIdentity,
 	}
 }
 
-// workloadIdentityConfig is the YAML shape for the workload_identity provider.
 type workloadIdentityConfig struct {
 	Type string `yaml:"type"`
 }
 
-// buildWorkloadIdentity defers to Google Application Default Credentials.
-// This resolves GKE Workload Identity (via the metadata server), the
-// GOOGLE_APPLICATION_CREDENTIALS keyfile, Workload Identity Federation
-// external_account JSON, and gcloud user credentials, in that order.
+// buildWorkloadIdentity defers to Google Application Default Credentials,
+// which resolves GKE Workload Identity (metadata server),
+// GOOGLE_APPLICATION_CREDENTIALS keyfiles, Workload Identity Federation
+// external_account JSON, and gcloud user credentials.
 func buildWorkloadIdentity(ctx context.Context, node yaml.Node, scopes []string, _ *slog.Logger) (oauth2.TokenSource, string, error) {
 	var cfg workloadIdentityConfig
 	if err := node.Decode(&cfg); err != nil {
@@ -74,9 +69,8 @@ func buildWorkloadIdentity(ctx context.Context, node yaml.Node, scopes []string,
 	return creds.TokenSource, principal, nil
 }
 
-// principalFromCredentialsJSON extracts a human-readable identifier from a
-// credentials JSON blob. Returns "" if no recognized field is present (e.g.
-// metadata-server credentials carry no JSON).
+// principalFromCredentialsJSON returns a human-readable identifier from a
+// credentials JSON blob, or "" if none is present (metadata-server creds).
 func principalFromCredentialsJSON(raw []byte) string {
 	if len(raw) == 0 {
 		return ""

--- a/internal/transform/gcpauth/tokensource.go
+++ b/internal/transform/gcpauth/tokensource.go
@@ -1,0 +1,95 @@
+package gcpauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"gopkg.in/yaml.v3"
+)
+
+// tokenSourceBuilder turns a credentials_provider config node into a token
+// source plus a best-effort principal identifier (email / unique id) for
+// audit logging. Tests substitute a stub builder.
+type tokenSourceBuilder func(ctx context.Context, node yaml.Node, scopes []string, logger *slog.Logger) (oauth2.TokenSource, string, error)
+
+// providerTypeHint is used to peek at the type field before dispatching.
+type providerTypeHint struct {
+	Type string `yaml:"type"`
+}
+
+// BuildTokenSource dispatches a credentials_provider node through the default
+// registry. Mirrors secrets.BuildSource. Refresh and caching are delegated to
+// the returned oauth2.TokenSource (typically google.Credentials.TokenSource,
+// which is internally cached).
+func BuildTokenSource(ctx context.Context, node yaml.Node, scopes []string, logger *slog.Logger) (oauth2.TokenSource, string, error) {
+	var hint providerTypeHint
+	if err := node.Decode(&hint); err != nil {
+		return nil, "", fmt.Errorf("parsing credentials_provider type: %w", err)
+	}
+	if hint.Type == "" {
+		return nil, "", fmt.Errorf("credentials_provider.type is required")
+	}
+	registry := defaultTokenSourceRegistry()
+	builder, ok := registry[hint.Type]
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported credentials_provider type %q", hint.Type)
+	}
+	return builder(ctx, node, scopes, logger)
+}
+
+// defaultTokenSourceRegistry returns the standard token-source builders.
+// Additional types (e.g. impersonated_service_account) are additive.
+func defaultTokenSourceRegistry() map[string]tokenSourceBuilder {
+	return map[string]tokenSourceBuilder{
+		"workload_identity": buildWorkloadIdentity,
+	}
+}
+
+// workloadIdentityConfig is the YAML shape for the workload_identity provider.
+type workloadIdentityConfig struct {
+	Type string `yaml:"type"`
+}
+
+// buildWorkloadIdentity defers to Google Application Default Credentials.
+// This resolves GKE Workload Identity (via the metadata server), the
+// GOOGLE_APPLICATION_CREDENTIALS keyfile, Workload Identity Federation
+// external_account JSON, and gcloud user credentials, in that order.
+func buildWorkloadIdentity(ctx context.Context, node yaml.Node, scopes []string, _ *slog.Logger) (oauth2.TokenSource, string, error) {
+	var cfg workloadIdentityConfig
+	if err := node.Decode(&cfg); err != nil {
+		return nil, "", fmt.Errorf("parsing workload_identity provider: %w", err)
+	}
+	creds, err := google.FindDefaultCredentials(ctx, scopes...)
+	if err != nil {
+		return nil, "", fmt.Errorf("loading GCP default credentials: %w", err)
+	}
+	if creds.TokenSource == nil {
+		return nil, "", fmt.Errorf("GCP default credentials returned no token source")
+	}
+	principal := principalFromCredentialsJSON(creds.JSON)
+	return creds.TokenSource, principal, nil
+}
+
+// principalFromCredentialsJSON extracts a human-readable identifier from a
+// credentials JSON blob. Returns "" if no recognized field is present (e.g.
+// metadata-server credentials carry no JSON).
+func principalFromCredentialsJSON(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var meta struct {
+		ClientEmail                    string `json:"client_email"`
+		ServiceAccountImpersonationURL string `json:"service_account_impersonation_url"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	if meta.ClientEmail != "" {
+		return meta.ClientEmail
+	}
+	return meta.ServiceAccountImpersonationURL
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -274,6 +274,23 @@ transforms:
   #       - "https://www.googleapis.com/auth/cloud-platform"
   #     rules:
   #       - host: "*.googleapis.com"
+  #
+  # Workload identity: ironproxy holds the pod credentials via Google
+  # Application Default Credentials (GKE Workload Identity through the
+  # metadata server, GOOGLE_APPLICATION_CREDENTIALS, Workload Identity
+  # Federation, etc.) and the agent never sees them. The agent SDK can run
+  # with any stub credentials: gcp_auth stubs the OAuth2 token endpoint and
+  # the metadata server, then injects the real bearer token on outbound
+  # requests. The subject field is rejected with this provider because
+  # metadata-server credentials cannot perform domain-wide delegation.
+  # - name: gcp_auth
+  #   config:
+  #     credentials_provider:
+  #       type: workload_identity
+  #     scopes:
+  #       - "https://www.googleapis.com/auth/cloud-platform"
+  #     rules:
+  #       - host: "*.googleapis.com"
 
   # OAuth2 token injection. Mints short-lived OAuth2 access tokens and sets
   # Authorization: Bearer on matching requests. Each entry under tokens names
@@ -458,11 +475,24 @@ transforms:
   #   config:
   #     access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}
   #     secret_access_key: {type: env, var: AWS_SECRET_ACCESS_KEY}
-  #     # session_token:   {type: env, var: AWS_SESSION_TOKEN}  # optional, for STS / role creds
   #     # allowed_regions:  ["us-east-1", "eu-west-1"]           # optional safety gate; default allows any region
   #     # allowed_services: ["bedrock", "s3", "dynamodb"]        # optional safety gate; default allows any service
   #     # unsigned_payload: false
   #     # allow_chunked_body: false
+  #     rules:
+  #       - host: "*.amazonaws.com"
+  #
+  # Workload identity: ironproxy holds the rotating pod credentials (EKS IRSA,
+  # Pod Identity, IMDSv2, or any source the AWS SDK default chain understands)
+  # and the agent never sees them. Configure the agent's AWS SDK with any
+  # placeholder credentials so it produces a signed request; aws_auth strips
+  # the placeholder signature and re-signs with the real workload identity.
+  # - name: aws_auth
+  #   config:
+  #     credentials_provider:
+  #       type: workload_identity
+  #       # region: us-east-1     # optional; overrides AWS_REGION discovery
+  #     allowed_services: ["bedrock"]
   #     rules:
   #       - host: "*.amazonaws.com"
 


### PR DESCRIPTION
Adds a `credentials_provider:` block to `aws_auth` and `gcp_auth` with a `workload_identity` type, so ironproxy can hold a pod's rotating cloud identity (EKS IRSA / Pod Identity / IMDS, GKE Workload Identity, Workload Identity Federation) while the agent SDK runs on dummy credentials. The placeholder signature/bearer is stripped and re-authorized on the way out, so the real credentials never reach the agent.

AWS delegates to `awsconfig.LoadDefaultConfig` wrapped in `aws.NewCredentialsCache`; GCP delegates to `google.FindDefaultCredentials`. Existing static-keyfile and static-keypair paths are unchanged for the "call from outside the cloud" use case. The flat `session_token` field on `aws_auth` is removed since workload identity is the right way to get rotating STS creds. `subject` is rejected when combined with `credentials_provider` because metadata-server credentials cannot do domain-wide delegation.

Sample config in `iron-proxy.example.yaml`.