### PR TITLE
test(integration): integration tests for workload_identity provider

### DIFF
--- a/integration_test/awsauth_workload_identity_test.go
+++ b/integration_test/awsauth_workload_identity_test.go
@@ -18,13 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAWSAuthWorkloadIdentity boots the proxy with the aws_auth transform
-// configured via credentials_provider: workload_identity. The proxy's env
-// carries AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN, which
-// the AWS SDK default credential chain resolves at first Retrieve. This
-// exercises the full workload_identity → lazyDefaultChainProvider →
-// awsconfig.LoadDefaultConfig path without requiring real IRSA / IMDS infra,
-// and confirms that a session token flows through to the outbound request.
+// TestAWSAuthWorkloadIdentity drives credentials_provider: workload_identity
+// end-to-end via the env leg of the AWS SDK default chain. Also covers that
+// AWS_SESSION_TOKEN flows through to the outbound X-Amz-Security-Token header.
 func TestAWSAuthWorkloadIdentity(t *testing.T) {
 	tmpDir := t.TempDir()
 	binary := proxyBinary(t)
@@ -50,10 +46,9 @@ func TestAWSAuthWorkloadIdentity(t *testing.T) {
 		"AWS_ACCESS_KEY_ID=AKIAEXAMPLE",
 		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"AWS_SESSION_TOKEN=test-workload-session-token",
-		// Skip the default-region IMDS lookup in CI: the AWS SDK only reads
-		// region from env (not creds), and the signer takes its region from
-		// the inbound credential scope, but LoadDefaultConfig probes IMDS for
-		// region metadata otherwise.
+		// Set AWS_REGION so LoadDefaultConfig does not probe IMDS for region
+		// metadata in CI (we don't sign with this region — the signer takes
+		// it from the inbound credential scope).
 		"AWS_REGION=us-east-1",
 	}
 	proxy := startProxy(t, binary, cfgPath, env)

--- a/integration_test/awsauth_workload_identity_test.go
+++ b/integration_test/awsauth_workload_identity_test.go
@@ -1,0 +1,97 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAWSAuthWorkloadIdentity boots the proxy with the aws_auth transform
+// configured via credentials_provider: workload_identity. The proxy's env
+// carries AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN, which
+// the AWS SDK default credential chain resolves at first Retrieve. This
+// exercises the full workload_identity → lazyDefaultChainProvider →
+// awsconfig.LoadDefaultConfig path without requiring real IRSA / IMDS infra,
+// and confirms that a session token flows through to the outbound request.
+func TestAWSAuthWorkloadIdentity(t *testing.T) {
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+
+	var (
+		mu      sync.Mutex
+		gotAuth string
+		gotDate string
+		gotTok  string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		gotDate = r.Header.Get("X-Amz-Date")
+		gotTok = r.Header.Get("X-Amz-Security-Token")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfgPath := renderConfig(t, tmpDir, "awsauth_workload_identity.yaml", nil)
+	env := []string{
+		"AWS_ACCESS_KEY_ID=AKIAEXAMPLE",
+		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"AWS_SESSION_TOKEN=test-workload-session-token",
+		// Skip the default-region IMDS lookup in CI: the AWS SDK only reads
+		// region from env (not creds), and the signer takes its region from
+		// the inbound credential scope, but LoadDefaultConfig probes IMDS for
+		// region metadata otherwise.
+		"AWS_REGION=us-east-1",
+	}
+	proxy := startProxy(t, binary, cfgPath, env)
+	upstreamHost := upstream.Listener.Addr().String()
+
+	body := []byte(`{"prompt":"hi"}`)
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s/model/foo/invoke", proxy.HTTPAddr), strings.NewReader(string(body)))
+	require.NoError(t, err)
+	req.Host = upstreamHost
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(body))
+
+	// Pre-sign with placeholder credentials, as a sandboxed AWS SDK would. The
+	// proxy is expected to strip this signature and re-sign with the real env
+	// credentials it resolved through the workload_identity provider.
+	placeholder := aws.Credentials{
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	}
+	sum := sha256.Sum256(body)
+	require.NoError(t, v4.NewSigner().SignHTTP(
+		context.Background(), placeholder, req, hex.EncodeToString(sum[:]),
+		"bedrock", "us-east-1", time.Now().UTC(),
+	))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 "), "Authorization = %q", gotAuth)
+	require.Contains(t, gotAuth, "Credential=AKIAEXAMPLE/")
+	require.NotContains(t, gotAuth, "AKIAIOSFODNN7EXAMPLE", "placeholder credential must not appear in outbound Authorization header")
+	require.Contains(t, gotAuth, "/us-east-1/bedrock/aws4_request")
+	require.Regexp(t, `^\d{8}T\d{6}Z$`, gotDate)
+	require.Equal(t, "test-workload-session-token", gotTok, "session token from env must flow through workload_identity")
+}

--- a/integration_test/gcp_auth_bigquery_cli_test.go
+++ b/integration_test/gcp_auth_bigquery_cli_test.go
@@ -3,11 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,17 +116,11 @@ func TestGCPAuthBigQueryGcloudCLI(t *testing.T) {
 // gcloud auth activate-service-account but corresponds to no real identity.
 func writeDummyServiceAccountKeyfile(t *testing.T, dir string) string {
 	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	der, err := x509.MarshalPKCS8PrivateKey(key)
-	require.NoError(t, err)
-	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-
 	keyfile := map[string]string{
 		"type":                        "service_account",
 		"project_id":                  "iron-proxy-stub",
 		"private_key_id":              "stub-private-key-id",
-		"private_key":                 string(pemBytes),
+		"private_key":                 generateServiceAccountKeyPEM(t),
 		"client_email":                "stub@iron-proxy-stub.iam.gserviceaccount.com",
 		"client_id":                   "000000000000000000000",
 		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",

--- a/integration_test/gcp_auth_workload_identity_test.go
+++ b/integration_test/gcp_auth_workload_identity_test.go
@@ -1,0 +1,117 @@
+package integration_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCPAuthWorkloadIdentity boots the proxy with gcp_auth configured via
+// credentials_provider: workload_identity. ADC is steered to a generated
+// service-account JSON keyfile via GOOGLE_APPLICATION_CREDENTIALS, with its
+// token_uri pointing at a local httptest server that mints a fake bearer.
+// This exercises the full workload_identity → google.FindDefaultCredentials →
+// TokenSource path without requiring GKE Workload Identity or a real GCP
+// metadata server, and confirms the minted bearer reaches the upstream.
+func TestGCPAuthWorkloadIdentity(t *testing.T) {
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+
+	const wantToken = "workload-identity-bearer"
+	var tokenCalls atomic.Int64
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": wantToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	var (
+		mu      sync.Mutex
+		gotAuth string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	keyfile := writeWorkloadIdentityKeyfile(t, tmpDir, tokenSrv.URL)
+
+	cfgPath := renderConfig(t, tmpDir, "gcp_auth_workload_identity.yaml", nil)
+	env := []string{
+		"GOOGLE_APPLICATION_CREDENTIALS=" + keyfile,
+	}
+	proxy := startProxy(t, binary, cfgPath, env)
+	upstreamHost := upstream.Listener.Addr().String()
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/v1/projects", proxy.HTTPAddr), nil)
+	require.NoError(t, err)
+	req.Host = upstreamHost
+	// The agent SDK would have a placeholder bearer of its own. gcp_auth
+	// overwrites Authorization unconditionally, so the placeholder is not
+	// load-bearing for the assertion; we set one anyway to mirror the agent
+	// flow and confirm it is replaced.
+	req.Header.Set("Authorization", "Bearer agent-placeholder")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "Bearer "+wantToken, gotAuth, "minted workload-identity bearer must reach upstream")
+	require.NotContains(t, gotAuth, "agent-placeholder", "agent placeholder bearer must be replaced")
+	require.Equal(t, int64(1), tokenCalls.Load(), "token endpoint should be hit exactly once and then cached")
+}
+
+// writeWorkloadIdentityKeyfile generates a service-account JSON keyfile with a
+// freshly minted RSA key and a tokenURI pointing at the test's fake token
+// server. google.FindDefaultCredentials accepts this via the
+// GOOGLE_APPLICATION_CREDENTIALS env leg of the ADC chain.
+func writeWorkloadIdentityKeyfile(t *testing.T, dir, tokenURI string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	keyfile := map[string]string{
+		"type":         "service_account",
+		"project_id":   "iron-proxy-workload-identity-test",
+		"private_key":  string(pemBytes),
+		"client_email": "workload-identity@iron-proxy-test.iam.gserviceaccount.com",
+		"token_uri":    tokenURI,
+	}
+	data, err := json.MarshalIndent(keyfile, "", "  ")
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "workload-identity-sa.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+

--- a/integration_test/gcp_auth_workload_identity_test.go
+++ b/integration_test/gcp_auth_workload_identity_test.go
@@ -1,11 +1,7 @@
 package integration_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,13 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGCPAuthWorkloadIdentity boots the proxy with gcp_auth configured via
-// credentials_provider: workload_identity. ADC is steered to a generated
-// service-account JSON keyfile via GOOGLE_APPLICATION_CREDENTIALS, with its
-// token_uri pointing at a local httptest server that mints a fake bearer.
-// This exercises the full workload_identity → google.FindDefaultCredentials →
-// TokenSource path without requiring GKE Workload Identity or a real GCP
-// metadata server, and confirms the minted bearer reaches the upstream.
+// TestGCPAuthWorkloadIdentity drives credentials_provider: workload_identity
+// end-to-end without real GCP infra by steering ADC at a synthetic
+// service-account JSON whose token_uri is a local httptest server.
 func TestGCPAuthWorkloadIdentity(t *testing.T) {
 	tmpDir := t.TempDir()
 	binary := proxyBinary(t)
@@ -88,22 +80,14 @@ func TestGCPAuthWorkloadIdentity(t *testing.T) {
 	require.Equal(t, int64(1), tokenCalls.Load(), "token endpoint should be hit exactly once and then cached")
 }
 
-// writeWorkloadIdentityKeyfile generates a service-account JSON keyfile with a
-// freshly minted RSA key and a tokenURI pointing at the test's fake token
-// server. google.FindDefaultCredentials accepts this via the
-// GOOGLE_APPLICATION_CREDENTIALS env leg of the ADC chain.
+// writeWorkloadIdentityKeyfile writes a minimal service-account JSON whose
+// token_uri points at a local fake. Loadable via GOOGLE_APPLICATION_CREDENTIALS.
 func writeWorkloadIdentityKeyfile(t *testing.T, dir, tokenURI string) string {
 	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	der, err := x509.MarshalPKCS8PrivateKey(key)
-	require.NoError(t, err)
-	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-
 	keyfile := map[string]string{
 		"type":         "service_account",
 		"project_id":   "iron-proxy-workload-identity-test",
-		"private_key":  string(pemBytes),
+		"private_key":  generateServiceAccountKeyPEM(t),
 		"client_email": "workload-identity@iron-proxy-test.iam.gserviceaccount.com",
 		"token_uri":    tokenURI,
 	}

--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -3,7 +3,11 @@ package integration_test
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"os"
 	"os/exec"
@@ -16,6 +20,18 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// generateServiceAccountKeyPEM returns a freshly-minted RSA private key in
+// PEM (PKCS#8) form, suitable for embedding in a service-account JSON keyfile.
+// Used by tests that construct synthetic GCP credentials.
+func generateServiceAccountKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
 
 // proxyInstance holds information about a running iron-proxy process.
 type proxyInstance struct {

--- a/integration_test/testdata/awsauth_workload_identity.yaml
+++ b/integration_test/testdata/awsauth_workload_identity.yaml
@@ -20,11 +20,6 @@ transforms:
 
   - name: aws_auth
     config:
-      # workload_identity defers to the AWS SDK default credential chain. The
-      # chain's first leg reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
-      # AWS_SESSION_TOKEN from the proxy's env, so this exercises the
-      # workload_identity provider end-to-end without needing real IRSA or
-      # IMDS.
       credentials_provider:
         type: workload_identity
       rules:

--- a/integration_test/testdata/awsauth_workload_identity.yaml
+++ b/integration_test/testdata/awsauth_workload_identity.yaml
@@ -1,0 +1,37 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+  - name: aws_auth
+    config:
+      # workload_identity defers to the AWS SDK default credential chain. The
+      # chain's first leg reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+      # AWS_SESSION_TOKEN from the proxy's env, so this exercises the
+      # workload_identity provider end-to-end without needing real IRSA or
+      # IMDS.
+      credentials_provider:
+        type: workload_identity
+      rules:
+        - host: "127.0.0.1"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/integration_test/testdata/gcp_auth_workload_identity.yaml
+++ b/integration_test/testdata/gcp_auth_workload_identity.yaml
@@ -1,0 +1,39 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+  - name: gcp_auth
+    config:
+      # workload_identity defers to Google Application Default Credentials. In
+      # this test ADC is steered to a generated service-account JSON via
+      # GOOGLE_APPLICATION_CREDENTIALS so the test runs without GKE / metadata
+      # server infrastructure. The keyfile's token_uri points at a local
+      # httptest server that mints a fake bearer.
+      credentials_provider:
+        type: workload_identity
+      scopes:
+        - "https://www.googleapis.com/auth/cloud-platform"
+      rules:
+        - host: "127.0.0.1"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/integration_test/testdata/gcp_auth_workload_identity.yaml
+++ b/integration_test/testdata/gcp_auth_workload_identity.yaml
@@ -20,11 +20,6 @@ transforms:
 
   - name: gcp_auth
     config:
-      # workload_identity defers to Google Application Default Credentials. In
-      # this test ADC is steered to a generated service-account JSON via
-      # GOOGLE_APPLICATION_CREDENTIALS so the test runs without GKE / metadata
-      # server infrastructure. The keyfile's token_uri points at a local
-      # httptest server that mints a fake bearer.
       credentials_provider:
         type: workload_identity
       scopes:


### PR DESCRIPTION
Adds end-to-end integration tests for the `workload_identity` credentials provider on both `aws_auth` and `gcp_auth`, modeled on the existing `TestAWSAuth` and `TestGCPAuthBigQuery` patterns. Neither test needs real cloud infra: AWS exercises the env-vars leg of the SDK default credential chain, and GCP steers ADC at a generated service-account JSON whose `token_uri` points at a local httptest server.

Also extracts shared RSA service-account keygen into `helpers_test.go` and rewires `writeDummyServiceAccountKeyfile` to use it.