### PR TITLE
feat: add codex login auth transport

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
 	_ "github.com/ironsh/iron-proxy/internal/transform/awsauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/bodycapture"
+	_ "github.com/ironsh/iron-proxy/internal/transform/codexlogin"
 	_ "github.com/ironsh/iron-proxy/internal/transform/gcpauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"

--- a/internal/transform/codexlogin/codexlogin.go
+++ b/internal/transform/codexlogin/codexlogin.go
@@ -1,0 +1,429 @@
+package codexlogin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+const (
+	defaultClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
+	defaultTokenEndpoint = "https://auth.openai.com/oauth/token"
+	defaultRefreshSkew   = 5 * time.Minute
+
+	stubAccessToken  = "iron-proxy-codex-stub-token"
+	stubRefreshToken = "iron-proxy-codex-stub-refresh-token"
+	stubIDToken      = "iron-proxy-codex-stub-id-token"
+)
+
+var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","refresh_token":"` + stubRefreshToken + `","id_token":"` + stubIDToken + `","expires_in":3600,"token_type":"Bearer"}`)
+
+func init() {
+	transform.Register("codex_login", factory)
+}
+
+type config struct {
+	AuthJSON      authJSONConfig         `yaml:"auth_json"`
+	Rules         []hostmatch.RuleConfig `yaml:"rules"`
+	ClientID      string                 `yaml:"client_id,omitempty"`
+	TokenEndpoint string                 `yaml:"token_endpoint,omitempty"`
+	RefreshSkew   string                 `yaml:"refresh_skew,omitempty"`
+}
+
+type authJSONConfig struct {
+	Source    yaml.Node `yaml:"source"`
+	Writeback yaml.Node `yaml:"writeback"`
+}
+
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+type writerBuilder func(yaml.Node, *slog.Logger) (authJSONWriter, error)
+
+type authJSONWriter interface {
+	CompareAndSwap(ctx context.Context, oldRefreshToken, newValue string) (currentValue string, swapped bool, err error)
+}
+
+type CodexLogin struct {
+	auth          *authEntry
+	rules         []hostmatch.Rule
+	tokenEndpoint tokenEndpoint
+	clientID      string
+	refreshSkew   time.Duration
+	now           func() time.Time
+	httpClient    *http.Client
+}
+
+type authEntry struct {
+	source    secrets.Source
+	writer    authJSONWriter
+	mu        sync.Mutex
+	cachedRaw string
+}
+
+type tokenEndpoint struct {
+	scheme    string
+	host      string
+	matchHost string
+	path      string
+}
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing codex_login config: %w", err)
+	}
+	return newFromConfig(c, logger, secrets.BuildSource, buildAuthJSONWriter)
+}
+
+func newFromConfig(c config, logger *slog.Logger, buildSource sourceBuilder, buildWriter writerBuilder) (*CodexLogin, error) {
+	if c.AuthJSON.Source.Kind == 0 {
+		return nil, fmt.Errorf("codex_login: auth_json.source is required")
+	}
+	if c.AuthJSON.Writeback.Kind == 0 {
+		return nil, fmt.Errorf("codex_login: auth_json.writeback is required")
+	}
+	src, err := buildSource(c.AuthJSON.Source, logger)
+	if err != nil {
+		return nil, fmt.Errorf("codex_login: building auth_json.source: %w", err)
+	}
+	writer, err := buildWriter(c.AuthJSON.Writeback, logger)
+	if err != nil {
+		return nil, fmt.Errorf("codex_login: building auth_json.writeback: %w", err)
+	}
+	rules, err := hostmatch.CompileRules(c.Rules, "codex_login")
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("codex_login: at least one entry in \"rules\" is required")
+	}
+	tokenURL := c.TokenEndpoint
+	if tokenURL == "" {
+		tokenURL = defaultTokenEndpoint
+	}
+	endpoint, err := parseTokenEndpoint(tokenURL)
+	if err != nil {
+		return nil, fmt.Errorf("codex_login: invalid token_endpoint: %w", err)
+	}
+	clientID := c.ClientID
+	if clientID == "" {
+		clientID = defaultClientID
+	}
+	refreshSkew := defaultRefreshSkew
+	if c.RefreshSkew != "" {
+		refreshSkew, err = time.ParseDuration(c.RefreshSkew)
+		if err != nil {
+			return nil, fmt.Errorf("codex_login: parsing refresh_skew: %w", err)
+		}
+	}
+	return &CodexLogin{
+		auth:          &authEntry{source: src, writer: writer},
+		rules:         rules,
+		tokenEndpoint: *endpoint,
+		clientID:      clientID,
+		refreshSkew:   refreshSkew,
+		now:           time.Now,
+		httpClient:    http.DefaultClient,
+	}, nil
+}
+
+func (c *CodexLogin) Name() string { return "codex_login" }
+
+func (c *CodexLogin) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if c.matchesTokenEndpoint(req) {
+		tctx.Annotate("stubbed", "codex_token_endpoint")
+		return &transform.TransformResult{
+			Action:   transform.ActionStub,
+			Response: jsonResponse(req, http.StatusOK, "200 OK", stubTokenJSON),
+		}, nil
+	}
+	if !hostmatch.MatchAnyRule(c.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	auth, err := c.authForRequest(ctx)
+	if err != nil {
+		tctx.Annotate("error", "codex_auth_unavailable")
+		tctx.Annotate("rejected", "token_unavailable")
+		return &transform.TransformResult{
+			Action:   transform.ActionReject,
+			Response: jsonResponse(req, http.StatusBadGateway, "502 Bad Gateway", []byte(`{"error":"codex_login failed to load auth"}`)),
+		}, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+auth.accessToken)
+	req.Header.Set("ChatGPT-Account-ID", auth.accountID)
+	tctx.Annotate("injected", []string{"header:Authorization", "header:ChatGPT-Account-ID"})
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (c *CodexLogin) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (c *CodexLogin) authForRequest(ctx context.Context) (*codexAuth, error) {
+	c.auth.mu.Lock()
+	defer c.auth.mu.Unlock()
+
+	raw, err := c.auth.source.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := parseAuthJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	if c.auth.cachedRaw != "" {
+		if cachedAuth, cacheErr := parseAuthJSON(c.auth.cachedRaw); cacheErr == nil {
+			if auth.refreshToken != cachedAuth.refreshToken && auth.needsRefresh(c.now(), c.refreshSkew) {
+				raw = c.auth.cachedRaw
+				auth = cachedAuth
+			} else {
+				c.auth.cachedRaw = raw
+			}
+		}
+	}
+	if !auth.needsRefresh(c.now(), c.refreshSkew) {
+		return auth, nil
+	}
+	refreshed, err := c.refreshWithCAS(ctx, raw, auth)
+	if err != nil {
+		return nil, err
+	}
+	c.auth.cachedRaw = refreshed.rawString
+	return refreshed, nil
+}
+
+func (c *CodexLogin) refreshWithCAS(ctx context.Context, raw string, auth *codexAuth) (*codexAuth, error) {
+	currentRaw := raw
+	currentAuth := auth
+	for attempt := 0; attempt < 2; attempt++ {
+		if currentAuth.refreshToken == "" {
+			return nil, fmt.Errorf("auth_json tokens.refresh_token is required")
+		}
+		updatedRaw, updatedAuth, err := c.refresh(ctx, currentAuth)
+		if err != nil {
+			return nil, err
+		}
+		storedRaw, swapped, err := c.auth.writer.CompareAndSwap(ctx, currentAuth.refreshToken, updatedRaw)
+		if err != nil {
+			return nil, err
+		}
+		if swapped {
+			return updatedAuth, nil
+		}
+		currentRaw = storedRaw
+		currentAuth, err = parseAuthJSON(currentRaw)
+		if err != nil {
+			return nil, err
+		}
+		if !currentAuth.needsRefresh(c.now(), c.refreshSkew) {
+			return currentAuth, nil
+		}
+	}
+	return nil, fmt.Errorf("auth_json refresh token changed during writeback")
+}
+
+func (c *CodexLogin) refresh(ctx context.Context, auth *codexAuth) (string, *codexAuth, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {auth.refreshToken},
+		"client_id":     {c.clientID},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenEndpoint.scheme+"://"+c.tokenEndpoint.host+c.tokenEndpoint.path, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("refreshing codex auth: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", nil, fmt.Errorf("reading codex refresh response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", nil, fmt.Errorf("codex refresh returned %d", resp.StatusCode)
+	}
+	var tokenResp map[string]any
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", nil, fmt.Errorf("parsing codex refresh response: %w", err)
+	}
+	updatedRaw, err := auth.updatedRaw(tokenResp, c.now())
+	if err != nil {
+		return "", nil, err
+	}
+	updatedAuth, err := parseAuthJSON(updatedRaw)
+	if err != nil {
+		return "", nil, err
+	}
+	return updatedRaw, updatedAuth, nil
+}
+
+func (c *CodexLogin) matchesTokenEndpoint(req *http.Request) bool {
+	host := hostmatch.StripPort(req.Host)
+	path := ""
+	if req.URL != nil {
+		path = req.URL.Path
+	}
+	return host == c.tokenEndpoint.matchHost && path == c.tokenEndpoint.path
+}
+
+type codexAuth struct {
+	raw          map[string]any
+	rawString    string
+	accessToken  string
+	refreshToken string
+	accountID    string
+}
+
+func parseAuthJSON(raw string) (*codexAuth, error) {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return nil, fmt.Errorf("parsing auth_json: %w", err)
+	}
+	auth := &codexAuth{
+		rawString:    raw,
+		raw:          doc,
+		accessToken:  nestedString(doc, "tokens", "access_token"),
+		refreshToken: nestedString(doc, "tokens", "refresh_token"),
+		accountID:    nestedString(doc, "tokens", "account_id"),
+	}
+	if auth.accountID == "" {
+		auth.accountID = stringValue(doc["account_id"])
+	}
+	if auth.accountID == "" {
+		return nil, fmt.Errorf("auth_json tokens.account_id is required")
+	}
+	return auth, nil
+}
+
+func (a *codexAuth) needsRefresh(now time.Time, skew time.Duration) bool {
+	if a.accessToken == "" {
+		return true
+	}
+	exp, ok := jwtExpiry(a.accessToken)
+	return ok && !now.Add(skew).Before(exp)
+}
+
+func (a *codexAuth) updatedRaw(tokenResp map[string]any, now time.Time) (string, error) {
+	accessToken := stringValue(tokenResp["access_token"])
+	if accessToken == "" {
+		return "", fmt.Errorf("codex refresh response missing access_token")
+	}
+	clone := cloneMap(a.raw)
+	tokens, _ := clone["tokens"].(map[string]any)
+	if tokens == nil {
+		tokens = make(map[string]any)
+		clone["tokens"] = tokens
+	}
+	tokens["access_token"] = accessToken
+	if refreshToken := stringValue(tokenResp["refresh_token"]); refreshToken != "" {
+		tokens["refresh_token"] = refreshToken
+	}
+	if idToken := stringValue(tokenResp["id_token"]); idToken != "" {
+		tokens["id_token"] = idToken
+	}
+	clone["last_refresh"] = now.UTC().Format(time.RFC3339)
+	out, err := json.Marshal(clone)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func nestedString(doc map[string]any, path ...string) string {
+	var current any = doc
+	for _, part := range path {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = m[part]
+	}
+	return stringValue(current)
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if m, ok := v.(map[string]any); ok {
+			out[k] = cloneMap(m)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func jwtExpiry(token string) (time.Time, bool) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	var claims struct {
+		Exp float64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(int64(claims.Exp), 0), true
+}
+
+func parseTokenEndpoint(raw string) (*tokenEndpoint, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("%q has no host", raw)
+	}
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	scheme := u.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	return &tokenEndpoint{scheme: scheme, host: u.Host, matchHost: hostmatch.StripPort(u.Host), path: path}, nil
+}
+
+func jsonResponse(req *http.Request, status int, statusText string, body []byte) *http.Response {
+	return &http.Response{
+		StatusCode:    status,
+		Status:        statusText,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          transform.NewBufferedBodyFromBytes(body),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}

--- a/internal/transform/codexlogin/codexlogin.go
+++ b/internal/transform/codexlogin/codexlogin.go
@@ -189,7 +189,6 @@ func (c *CodexLogin) authForRequest(ctx context.Context) (*codexAuth, error) {
 	if c.auth.cachedRaw != "" {
 		if cachedAuth, cacheErr := parseAuthJSON(c.auth.cachedRaw); cacheErr == nil {
 			if auth.refreshToken != cachedAuth.refreshToken && auth.needsRefresh(c.now(), c.refreshSkew) {
-				raw = c.auth.cachedRaw
 				auth = cachedAuth
 			} else {
 				c.auth.cachedRaw = raw
@@ -199,7 +198,7 @@ func (c *CodexLogin) authForRequest(ctx context.Context) (*codexAuth, error) {
 	if !auth.needsRefresh(c.now(), c.refreshSkew) {
 		return auth, nil
 	}
-	refreshed, err := c.refreshWithCAS(ctx, raw, auth)
+	refreshed, err := c.refreshWithCAS(ctx, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -207,8 +206,7 @@ func (c *CodexLogin) authForRequest(ctx context.Context) (*codexAuth, error) {
 	return refreshed, nil
 }
 
-func (c *CodexLogin) refreshWithCAS(ctx context.Context, raw string, auth *codexAuth) (*codexAuth, error) {
-	currentRaw := raw
+func (c *CodexLogin) refreshWithCAS(ctx context.Context, auth *codexAuth) (*codexAuth, error) {
 	currentAuth := auth
 	for attempt := 0; attempt < 2; attempt++ {
 		if currentAuth.refreshToken == "" {
@@ -225,8 +223,7 @@ func (c *CodexLogin) refreshWithCAS(ctx context.Context, raw string, auth *codex
 		if swapped {
 			return updatedAuth, nil
 		}
-		currentRaw = storedRaw
-		currentAuth, err = parseAuthJSON(currentRaw)
+		currentAuth, err = parseAuthJSON(storedRaw)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transform/codexlogin/codexlogin.go
+++ b/internal/transform/codexlogin/codexlogin.go
@@ -54,6 +54,7 @@ type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 type writerBuilder func(yaml.Node, *slog.Logger) (authJSONWriter, error)
 
 type authJSONWriter interface {
+	Current(ctx context.Context) (currentValue string, err error)
 	CompareAndSwap(ctx context.Context, oldRefreshToken, newValue string) (currentValue string, swapped bool, err error)
 }
 
@@ -212,8 +213,25 @@ func (c *CodexLogin) refreshWithCAS(ctx context.Context, auth *codexAuth) (*code
 		if currentAuth.refreshToken == "" {
 			return nil, fmt.Errorf("auth_json tokens.refresh_token is required")
 		}
+		attemptedRefreshToken := currentAuth.refreshToken
 		updatedRaw, updatedAuth, err := c.refresh(ctx, currentAuth)
 		if err != nil {
+			if isRefreshTokenReused(err) {
+				storedRaw, currentErr := c.auth.writer.Current(ctx)
+				if currentErr != nil {
+					return nil, fmt.Errorf("refresh token reused and loading latest auth_json failed: %w", currentErr)
+				}
+				currentAuth, currentErr = parseAuthJSON(storedRaw)
+				if currentErr != nil {
+					return nil, currentErr
+				}
+				if !currentAuth.needsRefresh(c.now(), c.refreshSkew) {
+					return currentAuth, nil
+				}
+				if currentAuth.refreshToken != attemptedRefreshToken {
+					continue
+				}
+			}
 			return nil, err
 		}
 		storedRaw, swapped, err := c.auth.writer.CompareAndSwap(ctx, currentAuth.refreshToken, updatedRaw)
@@ -257,6 +275,10 @@ func (c *CodexLogin) refresh(ctx context.Context, auth *codexAuth) (string, *cod
 		return "", nil, fmt.Errorf("reading codex refresh response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err == nil && isRefreshTokenReusedPayload(payload) {
+			return "", nil, refreshTokenReusedError{status: resp.StatusCode}
+		}
 		return "", nil, fmt.Errorf("codex refresh returned %d", resp.StatusCode)
 	}
 	var tokenResp map[string]any
@@ -272,6 +294,34 @@ func (c *CodexLogin) refresh(ctx context.Context, auth *codexAuth) (string, *cod
 		return "", nil, err
 	}
 	return updatedRaw, updatedAuth, nil
+}
+
+type refreshTokenReusedError struct {
+	status int
+}
+
+func (e refreshTokenReusedError) Error() string {
+	return fmt.Sprintf("codex refresh returned %d refresh_token_reused", e.status)
+}
+
+func isRefreshTokenReused(err error) bool {
+	_, ok := err.(refreshTokenReusedError)
+	return ok
+}
+
+func isRefreshTokenReusedPayload(payload map[string]any) bool {
+	if stringValue(payload["error"]) == "refresh_token_reused" {
+		return true
+	}
+	if stringValue(payload["code"]) == "refresh_token_reused" {
+		return true
+	}
+	if errorBody, ok := payload["error"].(map[string]any); ok {
+		if stringValue(errorBody["code"]) == "refresh_token_reused" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *CodexLogin) matchesTokenEndpoint(req *http.Request) bool {

--- a/internal/transform/codexlogin/codexlogin.go
+++ b/internal/transform/codexlogin/codexlogin.go
@@ -25,9 +25,10 @@ const (
 	defaultTokenEndpoint = "https://auth.openai.com/oauth/token"
 	defaultRefreshSkew   = 5 * time.Minute
 
-	stubAccessToken  = "iron-proxy-codex-stub-token"
+	stubJWT          = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJleHAiOjQxMDI0NDQ4MDAsImVtYWlsIjoiaXJvbi1wcm94eS1jb2RleC1zdHViQGV4YW1wbGUuaW52YWxpZCIsImh0dHBzOi8vYXBpLm9wZW5haS5jb20vcHJvZmlsZSI6eyJlbWFpbCI6Imlyb24tcHJveHktY29kZXgtc3R1YkBleGFtcGxlLmludmFsaWQifSwiaHR0cHM6Ly9hcGkub3BlbmFpLmNvbS9hdXRoIjp7InVzZXJfaWQiOiJpcm9uLXByb3h5LWNvZGV4LXN0dWItdXNlciIsImNoYXRncHRfdXNlcl9pZCI6Imlyb24tcHJveHktY29kZXgtc3R1Yi11c2VyIiwiY2hhdGdwdF9hY2NvdW50X2lkIjoiaXJvbi1wcm94eS1jb2RleC1zdHViLWFjY291bnQiLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6ZmFsc2V9fQ.stub-signature"
+	stubAccessToken  = stubJWT
 	stubRefreshToken = "iron-proxy-codex-stub-refresh-token"
-	stubIDToken      = "iron-proxy-codex-stub-id-token"
+	stubIDToken      = stubJWT
 )
 
 var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","refresh_token":"` + stubRefreshToken + `","id_token":"` + stubIDToken + `","expires_in":3600,"token_type":"Bearer"}`)

--- a/internal/transform/codexlogin/codexlogin_test.go
+++ b/internal/transform/codexlogin/codexlogin_test.go
@@ -34,9 +34,15 @@ func (s *fakeSource) Get(context.Context) (string, error) {
 
 type fakeWriter struct {
 	current      string
+	reads        int
 	swaps        int
 	seenOld      string
 	seenNewValue string
+}
+
+func (w *fakeWriter) Current(context.Context) (string, error) {
+	w.reads++
+	return w.current, nil
 }
 
 func (w *fakeWriter) CompareAndSwap(_ context.Context, oldRefreshToken, newValue string) (string, bool, error) {
@@ -92,6 +98,45 @@ func TestCodexLoginRefreshesAndWritesBack(t *testing.T) {
 	require.Equal(t, "refresh-old", writer.seenOld)
 	require.Equal(t, "refresh-new", mustRefresh(t, writer.current))
 	require.Equal(t, "id-new", nestedString(mustDoc(t, writer.current), "tokens", "id_token"))
+}
+
+func TestCodexLoginPreservesRefreshTokenWhenRefreshOmitsRotation(t *testing.T) {
+	expired := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + validJWT(t, time.Now().Add(time.Hour)) + `","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	writer := &fakeWriter{current: expired}
+	tr := newTestTransform(t, expired, writer, &testOptions{tokenEndpoint: server.URL})
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "refresh-old", mustRefresh(t, writer.current))
+}
+
+func TestCodexLoginReloadsWritebackOnRefreshTokenReuse(t *testing.T) {
+	expired := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	newer := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-new", "acct_123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"Your refresh token has already been used to generate a new access token. Please try signing in again.","code":"refresh_token_reused"}}`))
+	}))
+	defer server.Close()
+	writer := &fakeWriter{current: newer}
+	tr := newTestTransform(t, expired, writer, &testOptions{tokenEndpoint: server.URL})
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+mustAccess(t, newer), req.Header.Get("Authorization"))
+	require.Equal(t, 1, writer.reads)
+	require.Equal(t, 0, writer.swaps)
 }
 
 func TestCodexLoginReloadsOnCASMismatch(t *testing.T) {

--- a/internal/transform/codexlogin/codexlogin_test.go
+++ b/internal/transform/codexlogin/codexlogin_test.go
@@ -140,6 +140,8 @@ func TestCodexLoginStubsTokenEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(body), stubAccessToken)
 	require.Contains(t, string(body), stubRefreshToken)
+	requireStubJWT(t, stubAccessToken)
+	requireStubJWT(t, stubIDToken)
 }
 
 func TestOPConnectWriterCompareAndSwapUpdatesOnlyConfiguredField(t *testing.T) {
@@ -288,6 +290,25 @@ func validJWT(t *testing.T, exp time.Time) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"exp":` + jsonNumber(exp.Unix()) + `}`))
 	return header + "." + payload + ".sig"
+}
+
+func requireStubJWT(t *testing.T, token string) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	for _, part := range parts {
+		require.NotEmpty(t, part)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	exp, ok := claims["exp"].(float64)
+	require.True(t, ok)
+	require.Greater(t, int64(exp), time.Now().Add(24*time.Hour).Unix())
+	auth, ok := claims["https://api.openai.com/auth"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "iron-proxy-codex-stub-account", auth["chatgpt_account_id"])
 }
 
 func jsonNumber(v int64) string {

--- a/internal/transform/codexlogin/codexlogin_test.go
+++ b/internal/transform/codexlogin/codexlogin_test.go
@@ -1,0 +1,317 @@
+package codexlogin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	connectop "github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+type fakeSource struct {
+	name  string
+	value string
+}
+
+func (s *fakeSource) Name() string { return s.name }
+func (s *fakeSource) Get(context.Context) (string, error) {
+	return s.value, nil
+}
+
+type fakeWriter struct {
+	current      string
+	swaps        int
+	seenOld      string
+	seenNewValue string
+}
+
+func (w *fakeWriter) CompareAndSwap(_ context.Context, oldRefreshToken, newValue string) (string, bool, error) {
+	w.swaps++
+	w.seenOld = oldRefreshToken
+	w.seenNewValue = newValue
+	currentRefresh, err := refreshTokenFromRaw(w.current)
+	if err != nil {
+		return "", false, err
+	}
+	if currentRefresh != oldRefreshToken {
+		return w.current, false, nil
+	}
+	w.current = newValue
+	return newValue, true, nil
+}
+
+func TestCodexLoginInjectsExistingAuth(t *testing.T) {
+	raw := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-old", "acct_123")
+	tr := newTestTransform(t, raw, &fakeWriter{current: raw}, nil)
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+mustAccess(t, raw), req.Header.Get("Authorization"))
+	require.Equal(t, "acct_123", req.Header.Get("Chatgpt-Account-Id"))
+}
+
+func TestCodexLoginRefreshesAndWritesBack(t *testing.T) {
+	expired := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotForm, err = url.ParseQuery(string(body))
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + validJWT(t, time.Now().Add(time.Hour)) + `","refresh_token":"refresh-new","id_token":"id-new","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+
+	writer := &fakeWriter{current: expired}
+	tr := newTestTransform(t, expired, writer, &testOptions{tokenEndpoint: server.URL})
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "refresh_token", gotForm.Get("grant_type"))
+	require.Equal(t, "refresh-old", gotForm.Get("refresh_token"))
+	require.Equal(t, defaultClientID, gotForm.Get("client_id"))
+	require.Equal(t, "refresh-old", writer.seenOld)
+	require.Equal(t, "refresh-new", mustRefresh(t, writer.current))
+	require.Equal(t, "id-new", nestedString(mustDoc(t, writer.current), "tokens", "id_token"))
+}
+
+func TestCodexLoginReloadsOnCASMismatch(t *testing.T) {
+	expired := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	newer := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-newer", "acct_123")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + validJWT(t, time.Now().Add(time.Hour)) + `","refresh_token":"unused-new","expires_in":3600,"token_type":"Bearer"}`))
+	}))
+	defer server.Close()
+	writer := &fakeWriter{current: newer}
+	tr := newTestTransform(t, expired, writer, &testOptions{tokenEndpoint: server.URL})
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+mustAccess(t, newer), req.Header.Get("Authorization"))
+	require.Equal(t, 1, writer.swaps)
+}
+
+func TestCodexLoginUsesCachedWritebackWhenSourceTTLIsStale(t *testing.T) {
+	expired := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	newer := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-new", "acct_123")
+	writer := &fakeWriter{current: newer}
+	tr := newTestTransform(t, expired, writer, nil)
+	tr.auth.cachedRaw = newer
+
+	req := newRequest(t, "https://chatgpt.com/backend-api/codex/responses")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+mustAccess(t, newer), req.Header.Get("Authorization"))
+	require.Equal(t, 0, writer.swaps)
+}
+
+func TestCodexLoginStubsTokenEndpoint(t *testing.T) {
+	raw := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-old", "acct_123")
+	tr := newTestTransform(t, raw, &fakeWriter{current: raw}, nil)
+
+	req := newRequest(t, "https://auth.openai.com/oauth/token")
+	res, err := tr.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionStub, res.Action)
+	body, err := io.ReadAll(res.Response.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(body), stubAccessToken)
+	require.Contains(t, string(body), stubRefreshToken)
+}
+
+func TestOPConnectWriterCompareAndSwapUpdatesOnlyConfiguredField(t *testing.T) {
+	current := authJSON(t, validJWT(t, time.Now().Add(-time.Hour)), "refresh-old", "acct_123")
+	next := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-new", "acct_123")
+	item := &connectop.Item{
+		ID:    "item-uuid",
+		Vault: connectop.ItemVault{ID: "vault-uuid"},
+		Fields: []*connectop.ItemField{
+			{ID: "target", Label: "auth_json", Value: current},
+			{ID: "other", Label: "other", Value: "preserve-me"},
+		},
+	}
+	client := &fakeOPConnectClient{
+		vault: &connectop.Vault{ID: "vault-uuid", Name: "Engineering"},
+		item:  item,
+	}
+	writer := &opConnectWriter{
+		ref:    opRef{vault: "Engineering", item: "Codex", field: "auth_json"},
+		client: client,
+	}
+
+	got, swapped, err := writer.CompareAndSwap(context.Background(), "refresh-old", next)
+	require.NoError(t, err)
+	require.True(t, swapped)
+	require.Equal(t, next, got)
+	require.Equal(t, next, item.Fields[0].Value)
+	require.Equal(t, "preserve-me", item.Fields[1].Value)
+	require.Equal(t, 1, client.updates)
+}
+
+func TestOPConnectWriterCompareAndSwapMismatchReturnsCurrent(t *testing.T) {
+	current := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-other", "acct_123")
+	next := authJSON(t, validJWT(t, time.Now().Add(time.Hour)), "refresh-new", "acct_123")
+	item := &connectop.Item{
+		ID:    "item-uuid",
+		Vault: connectop.ItemVault{ID: "vault-uuid"},
+		Fields: []*connectop.ItemField{
+			{ID: "target", Label: "auth_json", Value: current},
+		},
+	}
+	client := &fakeOPConnectClient{
+		vault: &connectop.Vault{ID: "vault-uuid", Name: "Engineering"},
+		item:  item,
+	}
+	writer := &opConnectWriter{
+		ref:    opRef{vault: "Engineering", item: "Codex", field: "auth_json"},
+		client: client,
+	}
+
+	got, swapped, err := writer.CompareAndSwap(context.Background(), "refresh-old", next)
+	require.NoError(t, err)
+	require.False(t, swapped)
+	require.Equal(t, current, got)
+	require.Equal(t, 0, client.updates)
+}
+
+type fakeOPConnectClient struct {
+	vault   *connectop.Vault
+	item    *connectop.Item
+	updates int
+}
+
+func (c *fakeOPConnectClient) GetVault(string) (*connectop.Vault, error) {
+	return c.vault, nil
+}
+
+func (c *fakeOPConnectClient) GetItem(string, string) (*connectop.Item, error) {
+	return c.item, nil
+}
+
+func (c *fakeOPConnectClient) UpdateItem(item *connectop.Item, _ string) (*connectop.Item, error) {
+	c.updates++
+	c.item = item
+	return item, nil
+}
+
+type testOptions struct {
+	tokenEndpoint string
+}
+
+func newTestTransform(t *testing.T, raw string, writer authJSONWriter, opts *testOptions) *CodexLogin {
+	t.Helper()
+	tokenEndpoint := defaultTokenEndpoint
+	if opts != nil && opts.tokenEndpoint != "" {
+		tokenEndpoint = opts.tokenEndpoint
+	}
+	cfg := config{
+		AuthJSON: authJSONConfig{
+			Source:    yamlNode(t, map[string]string{"type": "env", "var": "IGNORED"}),
+			Writeback: yamlNode(t, map[string]string{"type": "1password_connect", "secret_ref": "op://v/i/f"}),
+		},
+		Rules:         []hostmatch.RuleConfig{{Host: "chatgpt.com", Paths: []string{"/backend-api/codex/*"}}},
+		TokenEndpoint: tokenEndpoint,
+	}
+	tr, err := newFromConfig(cfg, slog.Default(),
+		func(yaml.Node, *slog.Logger) (secrets.Source, error) {
+			return &fakeSource{name: "fake", value: raw}, nil
+		},
+		func(yaml.Node, *slog.Logger) (authJSONWriter, error) {
+			return writer, nil
+		},
+	)
+	require.NoError(t, err)
+	tr.now = time.Now
+	return tr
+}
+
+func yamlNode(t *testing.T, v any) yaml.Node {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal(data, &node))
+	if len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func newRequest(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, rawURL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	return req
+}
+
+func authJSON(t *testing.T, accessToken, refreshToken, accountID string) string {
+	t.Helper()
+	doc := map[string]any{
+		"auth_mode":    "chatgpt",
+		"last_refresh": "2026-05-01T00:00:00Z",
+		"tokens": map[string]any{
+			"access_token":  accessToken,
+			"refresh_token": refreshToken,
+			"account_id":    accountID,
+		},
+	}
+	out, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return string(out)
+}
+
+func validJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"exp":` + jsonNumber(exp.Unix()) + `}`))
+	return header + "." + payload + ".sig"
+}
+
+func jsonNumber(v int64) string {
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(jsonMarshal(v), "\n"), "\r"))
+}
+
+func jsonMarshal(v any) string {
+	out, _ := json.Marshal(v)
+	return string(out)
+}
+
+func mustDoc(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+	return doc
+}
+
+func mustAccess(t *testing.T, raw string) string {
+	t.Helper()
+	return nestedString(mustDoc(t, raw), "tokens", "access_token")
+}
+
+func mustRefresh(t *testing.T, raw string) string {
+	t.Helper()
+	return nestedString(mustDoc(t, raw), "tokens", "refresh_token")
+}

--- a/internal/transform/codexlogin/writeback.go
+++ b/internal/transform/codexlogin/writeback.go
@@ -1,0 +1,345 @@
+package codexlogin
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	connectsdk "github.com/1Password/connect-sdk-go/connect"
+	connectop "github.com/1Password/connect-sdk-go/onepassword"
+	opsdk "github.com/1password/onepassword-sdk-go"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/version"
+)
+
+const (
+	defaultOPTokenEnv        = "OP_SERVICE_ACCOUNT_TOKEN"
+	defaultOPConnectHostEnv  = "OP_CONNECT_HOST"
+	defaultOPConnectTokenEnv = "OP_CONNECT_TOKEN"
+)
+
+type writerTypeHint struct {
+	Type string `yaml:"type"`
+}
+
+type opRef struct {
+	vault   string
+	item    string
+	section string
+	field   string
+}
+
+func buildAuthJSONWriter(raw yaml.Node, _ *slog.Logger) (authJSONWriter, error) {
+	var hint writerTypeHint
+	if err := raw.Decode(&hint); err != nil {
+		return nil, fmt.Errorf("parsing writeback source type: %w", err)
+	}
+	switch hint.Type {
+	case "1password":
+		return newOPWriter(raw)
+	case "1password_connect":
+		return newOPConnectWriter(raw)
+	case "":
+		return nil, fmt.Errorf("writeback source requires \"type\" field")
+	default:
+		return nil, fmt.Errorf("unsupported writeback source type %q", hint.Type)
+	}
+}
+
+func parseOPRef(ref string) (opRef, error) {
+	rest, ok := strings.CutPrefix(ref, "op://")
+	if !ok {
+		return opRef{}, fmt.Errorf("secret_ref %q must start with \"op://\"", ref)
+	}
+	parts := strings.Split(rest, "/")
+	if len(parts) < 3 || len(parts) > 4 {
+		return opRef{}, fmt.Errorf("secret_ref %q must have 3 or 4 path segments (op://vault/item/[section/]field)", ref)
+	}
+	for _, p := range parts {
+		if p == "" {
+			return opRef{}, fmt.Errorf("secret_ref %q has an empty path segment", ref)
+		}
+	}
+	out := opRef{vault: parts[0], item: parts[1]}
+	if len(parts) == 3 {
+		out.field = parts[2]
+	} else {
+		out.section = parts[2]
+		out.field = parts[3]
+	}
+	return out, nil
+}
+
+func refreshTokenFromRaw(raw string) (string, error) {
+	auth, err := parseAuthJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	return auth.refreshToken, nil
+}
+
+type opWriterConfig struct {
+	Type      string `yaml:"type"`
+	SecretRef string `yaml:"secret_ref"`
+	TokenEnv  string `yaml:"token_env,omitempty"`
+}
+
+type opWriter struct {
+	ref      opRef
+	tokenEnv string
+	mu       sync.Mutex
+	client   *opsdk.Client
+}
+
+func newOPWriter(raw yaml.Node) (*opWriter, error) {
+	var cfg opWriterConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing 1password writeback config: %w", err)
+	}
+	if cfg.SecretRef == "" {
+		return nil, fmt.Errorf("1password writeback requires \"secret_ref\" field")
+	}
+	ref, err := parseOPRef(cfg.SecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("1password writeback: %w", err)
+	}
+	if cfg.TokenEnv == "" {
+		cfg.TokenEnv = defaultOPTokenEnv
+	}
+	return &opWriter{ref: ref, tokenEnv: cfg.TokenEnv}, nil
+}
+
+func (w *opWriter) CompareAndSwap(ctx context.Context, oldRefreshToken, newValue string) (string, bool, error) {
+	client, err := w.clientFor(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	vaultID, err := resolveOPVaultID(ctx, client, w.ref.vault)
+	if err != nil {
+		return "", false, err
+	}
+	itemID, err := resolveOPItemID(ctx, client, vaultID, w.ref.item)
+	if err != nil {
+		return "", false, err
+	}
+	item, err := client.Items().Get(ctx, vaultID, itemID)
+	if err != nil {
+		return "", false, fmt.Errorf("loading 1password item: %w", err)
+	}
+	field, err := selectOPField(&item, w.ref)
+	if err != nil {
+		return "", false, err
+	}
+	current := field.Value
+	currentRefresh, err := refreshTokenFromRaw(current)
+	if err != nil {
+		return current, false, err
+	}
+	if currentRefresh != oldRefreshToken {
+		return current, false, nil
+	}
+	field.Value = newValue
+	if _, err := client.Items().Put(ctx, item); err != nil {
+		return "", false, fmt.Errorf("updating 1password item: %w", err)
+	}
+	return newValue, true, nil
+}
+
+func (w *opWriter) clientFor(ctx context.Context) (*opsdk.Client, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.client != nil {
+		return w.client, nil
+	}
+	token := os.Getenv(w.tokenEnv)
+	if token == "" {
+		return nil, fmt.Errorf("env var %q is not set or empty", w.tokenEnv)
+	}
+	client, err := opsdk.NewClient(ctx,
+		opsdk.WithServiceAccountToken(token),
+		opsdk.WithIntegrationInfo("iron-proxy", version.Version),
+	)
+	if err != nil {
+		return nil, err
+	}
+	w.client = client
+	return client, nil
+}
+
+func resolveOPVaultID(ctx context.Context, client *opsdk.Client, ref string) (string, error) {
+	vaults, err := client.Vaults().List(ctx)
+	if err != nil {
+		return "", fmt.Errorf("listing 1password vaults: %w", err)
+	}
+	for _, vault := range vaults {
+		if vault.ID == ref || vault.Title == ref {
+			return vault.ID, nil
+		}
+	}
+	return "", fmt.Errorf("1password vault %q not found", ref)
+}
+
+func resolveOPItemID(ctx context.Context, client *opsdk.Client, vaultID, ref string) (string, error) {
+	items, err := client.Items().List(ctx, vaultID)
+	if err != nil {
+		return "", fmt.Errorf("listing 1password items: %w", err)
+	}
+	for _, item := range items {
+		if item.ID == ref || item.Title == ref {
+			return item.ID, nil
+		}
+	}
+	return "", fmt.Errorf("1password item %q not found", ref)
+}
+
+func selectOPField(item *opsdk.Item, ref opRef) (*opsdk.ItemField, error) {
+	sectionID := ""
+	if ref.section != "" {
+		for _, section := range item.Sections {
+			if section.ID == ref.section || section.Title == ref.section {
+				sectionID = section.ID
+				break
+			}
+		}
+		if sectionID == "" {
+			return nil, fmt.Errorf("section %q not found on item", ref.section)
+		}
+	}
+	for i := range item.Fields {
+		field := &item.Fields[i]
+		if field.ID != ref.field && field.Title != ref.field {
+			continue
+		}
+		if ref.section != "" {
+			if field.SectionID == nil || *field.SectionID != sectionID {
+				continue
+			}
+		}
+		return field, nil
+	}
+	if ref.section != "" {
+		return nil, fmt.Errorf("field %q in section %q not found on item", ref.field, ref.section)
+	}
+	return nil, fmt.Errorf("field %q not found on item", ref.field)
+}
+
+type opConnectWriterConfig struct {
+	Type      string `yaml:"type"`
+	SecretRef string `yaml:"secret_ref"`
+	HostEnv   string `yaml:"host_env,omitempty"`
+	TokenEnv  string `yaml:"token_env,omitempty"`
+}
+
+type opConnectClient interface {
+	GetVault(ref string) (*connectop.Vault, error)
+	GetItem(itemRef, vaultRef string) (*connectop.Item, error)
+	UpdateItem(item *connectop.Item, vaultRef string) (*connectop.Item, error)
+}
+
+type opConnectWriter struct {
+	ref      opRef
+	hostEnv  string
+	tokenEnv string
+	mu       sync.Mutex
+	client   opConnectClient
+}
+
+func newOPConnectWriter(raw yaml.Node) (*opConnectWriter, error) {
+	var cfg opConnectWriterConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing 1password_connect writeback config: %w", err)
+	}
+	if cfg.SecretRef == "" {
+		return nil, fmt.Errorf("1password_connect writeback requires \"secret_ref\" field")
+	}
+	ref, err := parseOPRef(cfg.SecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("1password_connect writeback: %w", err)
+	}
+	if cfg.HostEnv == "" {
+		cfg.HostEnv = defaultOPConnectHostEnv
+	}
+	if cfg.TokenEnv == "" {
+		cfg.TokenEnv = defaultOPConnectTokenEnv
+	}
+	return &opConnectWriter{ref: ref, hostEnv: cfg.HostEnv, tokenEnv: cfg.TokenEnv}, nil
+}
+
+func (w *opConnectWriter) CompareAndSwap(ctx context.Context, oldRefreshToken, newValue string) (string, bool, error) {
+	client, err := w.clientFor(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	vault, err := client.GetVault(w.ref.vault)
+	if err != nil {
+		return "", false, fmt.Errorf("loading 1password_connect vault %q: %w", w.ref.vault, err)
+	}
+	item, err := client.GetItem(w.ref.item, vault.ID)
+	if err != nil {
+		return "", false, fmt.Errorf("loading 1password_connect item %q: %w", w.ref.item, err)
+	}
+	item.Vault.ID = vault.ID
+	field, err := selectOPConnectField(item, w.ref)
+	if err != nil {
+		return "", false, err
+	}
+	current := field.Value
+	currentRefresh, err := refreshTokenFromRaw(current)
+	if err != nil {
+		return current, false, err
+	}
+	if currentRefresh != oldRefreshToken {
+		return current, false, nil
+	}
+	field.Value = newValue
+	if _, err := client.UpdateItem(item, vault.ID); err != nil {
+		return "", false, fmt.Errorf("updating 1password_connect item: %w", err)
+	}
+	return newValue, true, nil
+}
+
+func (w *opConnectWriter) clientFor(context.Context) (opConnectClient, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.client != nil {
+		return w.client, nil
+	}
+	host := os.Getenv(w.hostEnv)
+	if host == "" {
+		return nil, fmt.Errorf("env var %q is not set or empty", w.hostEnv)
+	}
+	token := os.Getenv(w.tokenEnv)
+	if token == "" {
+		return nil, fmt.Errorf("env var %q is not set or empty", w.tokenEnv)
+	}
+	w.client = connectsdk.NewClientWithUserAgent(host, token, "iron-proxy/"+version.Version)
+	return w.client, nil
+}
+
+func selectOPConnectField(item *connectop.Item, ref opRef) (*connectop.ItemField, error) {
+	for _, field := range item.Fields {
+		if field == nil {
+			continue
+		}
+		if field.ID != ref.field && field.Label != ref.field {
+			continue
+		}
+		if ref.section != "" {
+			if field.Section == nil {
+				continue
+			}
+			if field.Section.ID != ref.section && field.Section.Label != ref.section {
+				continue
+			}
+		}
+		return field, nil
+	}
+	if ref.section != "" {
+		return nil, fmt.Errorf("field %q in section %q not found on item", ref.field, ref.section)
+	}
+	return nil, fmt.Errorf("field %q not found on item", ref.field)
+}

--- a/internal/transform/codexlogin/writeback.go
+++ b/internal/transform/codexlogin/writeback.go
@@ -149,6 +149,30 @@ func (w *opWriter) CompareAndSwap(ctx context.Context, oldRefreshToken, newValue
 	return newValue, true, nil
 }
 
+func (w *opWriter) Current(ctx context.Context) (string, error) {
+	client, err := w.clientFor(ctx)
+	if err != nil {
+		return "", err
+	}
+	vaultID, err := resolveOPVaultID(ctx, client, w.ref.vault)
+	if err != nil {
+		return "", err
+	}
+	itemID, err := resolveOPItemID(ctx, client, vaultID, w.ref.item)
+	if err != nil {
+		return "", err
+	}
+	item, err := client.Items().Get(ctx, vaultID, itemID)
+	if err != nil {
+		return "", fmt.Errorf("loading 1password item: %w", err)
+	}
+	field, err := selectOPField(&item, w.ref)
+	if err != nil {
+		return "", err
+	}
+	return field.Value, nil
+}
+
 func (w *opWriter) clientFor(ctx context.Context) (*opsdk.Client, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -300,6 +324,26 @@ func (w *opConnectWriter) CompareAndSwap(ctx context.Context, oldRefreshToken, n
 		return "", false, fmt.Errorf("updating 1password_connect item: %w", err)
 	}
 	return newValue, true, nil
+}
+
+func (w *opConnectWriter) Current(ctx context.Context) (string, error) {
+	client, err := w.clientFor(ctx)
+	if err != nil {
+		return "", err
+	}
+	vault, err := client.GetVault(w.ref.vault)
+	if err != nil {
+		return "", fmt.Errorf("loading 1password_connect vault %q: %w", w.ref.vault, err)
+	}
+	item, err := client.GetItem(w.ref.item, vault.ID)
+	if err != nil {
+		return "", fmt.Errorf("loading 1password_connect item %q: %w", w.ref.item, err)
+	}
+	field, err := selectOPConnectField(item, w.ref)
+	if err != nil {
+		return "", err
+	}
+	return field.Value, nil
 }
 
 func (w *opConnectWriter) clientFor(context.Context) (opConnectClient, error) {


### PR DESCRIPTION
## Summary

Adds a Codex-specific `codex_login` auth transport to iron-proxy so Centaur can run Codex subscription auth without passing real Codex credentials into sandbox containers.

The transform owns the real Codex `auth.json`, refreshes it through OpenAI’s OAuth endpoint, injects real auth only for matching Codex backend requests, and writes rotated auth state back to the configured 1Password field.

## Behavior

- Adds the `codex_login` transform.
- Supports 1Password SDK and 1Password Connect sources.
- Requires field-scoped writeback for the full Codex `auth.json`.
- Refreshes using Codex’s ChatGPT OAuth client id.
- Injects `Authorization: Bearer <real_access_token>` and `ChatGPT-Account-ID: <account_id>`.
- Stubs Codex token-refresh responses with non-secret JWT-shaped placeholder tokens.
- Uses singleflight plus compare-before-write so concurrent refreshes reload/retry when the stored refresh token has already rotated.

## Security Notes

This transport centralizes real Codex auth inside iron-proxy instead of exposing it to workloads. Workloads should only receive a synthetic local auth stub that makes Codex choose ChatGPT-login mode.

Writeback is intentionally limited to the configured 1Password field. The transform rejects missing or non-field refs and preserves the rest of the 1Password item.

This is still subscription-login state, not ordinary API-key auth. It should be treated as an explicit opt-in path with narrow 1Password write permissions.

## Verification

- `go test -race -count=1 ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run`
- `go mod tidy && git diff --exit-code go.mod go.sum`
- `git diff --check`
