### PR TITLE
build: release iron-token-broker alongside iron-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /iron-token-broker
 *.exe
 
+# GoReleaser
+/dist/
+
 # IDE
 .idea/
 .vscode/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 version: 2
 
 builds:
-  - main: ./cmd/iron-proxy
+  - id: iron-proxy
+    main: ./cmd/iron-proxy
     binary: iron-proxy
     env:
       - CGO_ENABLED=0
@@ -14,17 +15,53 @@ builds:
     ldflags:
       - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
 
+  - id: iron-token-broker
+    main: ./cmd/iron-token-broker
+    binary: iron-token-broker
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
+
 archives:
-  - formats: ["tar.gz"]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - id: iron-proxy
+    ids:
+      - iron-proxy
+    formats: ["tar.gz"]
+    name_template: "iron-proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  - id: iron-token-broker
+    ids:
+      - iron-token-broker
+    formats: ["tar.gz"]
+    name_template: "iron-token-broker_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 dockers_v2:
-  - images:
+  - id: iron-proxy
+    ids:
+      - iron-proxy
+    images:
       - "ironsh/iron-proxy"
     tags:
       - "{{ .Version }}"
       - "latest"
     dockerfile: Dockerfile.release
+
+  - id: iron-token-broker
+    ids:
+      - iron-token-broker
+    images:
+      - "ironsh/iron-token-broker"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    dockerfile: Dockerfile.broker.release
 
 checksum:
   name_template: "checksums.txt"

--- a/Dockerfile.broker.release
+++ b/Dockerfile.broker.release
@@ -1,0 +1,5 @@
+FROM alpine:latest
+ARG TARGETARCH
+RUN apk add --no-cache ca-certificates openssl
+COPY linux/${TARGETARCH}/iron-token-broker /usr/local/bin/iron-token-broker
+ENTRYPOINT ["iron-token-broker"]


### PR DESCRIPTION
Adds goreleaser plumbing to ship `iron-token-broker` from the same release tag as `iron-proxy`: a second build, a second archive (`iron-token-broker_<ver>_<os>_<arch>.tar.gz`), a `ironsh/iron-token-broker` Docker image built from a new `Dockerfile.broker.release`, and both binaries' hashes in the single `checksums.txt`. Verified locally with `goreleaser check` and a `release --snapshot` run. Also gitignores `/dist/`.