### PR TITLE
feat(secrets): add token_broker source backed by iron-token-broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build iron-proxy
         run: go build -o iron-proxy ./cmd/iron-proxy
 
+      - name: Build iron-token-broker
+        run: go build -o iron-token-broker ./cmd/iron-token-broker
+
       - name: Generate test CA
         run: ./iron-proxy generate-ca -outdir tmp -alg ed25519
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,14 @@ Secret sources:
   is read from `OP_CONNECT_HOST` and the API token from `OP_CONNECT_TOKEN` by
   default; override with `host_env` and `token_env`. Optional `ttl` and
   `failure_ttl` are supported.
+- **`token_broker`:** fetches a current OAuth access token for `credential_id`
+  from an `iron-token-broker` deployment. The broker URL is read from
+  `IRON_BROKER_URL` and the bearer API key from `IRON_BROKER_TOKEN`. Optional
+  `ttl` (defaults to `1m`; must be less than the remaining lifetime the broker
+  reports for each token) and `failure_ttl` are supported. Use this for OAuth
+  credentials shared across multiple iron-proxy instances; see
+  [README.iron-token-broker.md](README.iron-token-broker.md) for the broker
+  itself.
 
 Every source also accepts an optional `json_key`. When set, the resolved value
 is parsed as a JSON object and the single top-level string field at that key is

--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -169,6 +169,54 @@ func proxyBinary(t *testing.T) string {
 	return binary
 }
 
+// brokerBinary returns the path to the pre-built iron-token-broker binary at
+// the repo root. It fails the test immediately if the binary does not exist.
+func brokerBinary(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(repoRoot(t), "iron-token-broker")
+	_, err := os.Stat(binary)
+	if err != nil {
+		t.Fatal("iron-token-broker binary not found at repo root; build it first with: go build -o iron-token-broker ./cmd/iron-token-broker")
+	}
+	return binary
+}
+
+// startBroker compiles (if needed) and starts the iron-token-broker binary with
+// the given config and environment. It scans the JSON log output to discover
+// the bound HTTP API address (supports :0). The broker is killed when the
+// test completes. Reuses proxyInstance because the address-discovery flow is
+// identical to the proxy — only the binary, flag name, and starting-log
+// message differ.
+func startBroker(t *testing.T, binary, cfgPath string, env []string) *proxyInstance {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stderrR, stderrW := io.Pipe()
+
+	cmd := exec.CommandContext(ctx, binary, "--config", cfgPath)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = stderrW
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+		_ = stderrW.Close()
+	})
+
+	p := &proxyInstance{
+		cmd:        cmd,
+		addrs:      make(map[string]string),
+		namedAddrs: make(map[string]string),
+	}
+
+	go scanLogs(stderrR, p)
+
+	p.HTTPAddr = p.AddrFor(t, "broker HTTP API starting")
+	return p
+}
+
 // repoRoot walks up from the current directory to find the go.mod file.
 func repoRoot(t *testing.T) string {
 	t.Helper()

--- a/integration_test/testdata/token_broker_broker.yaml
+++ b/integration_test/testdata/token_broker_broker.yaml
@@ -1,0 +1,23 @@
+listen: "127.0.0.1:0"
+metrics_listen: "127.0.0.1:0"
+bearer_auth_env: TEST_BROKER_BEARER
+
+log:
+  level: info
+  format: json
+
+defaults:
+  early_refresh_slack: "1s"
+  early_refresh_fraction: 0.1
+  max_refresh_interval: "10m"
+  refresh_timeout: "5s"
+
+credentials:
+  - id: openai-codex
+    token_endpoint: "{{.TokenEndpoint}}"
+    client_id:
+      type: env
+      var: TEST_OAUTH_CLIENT_ID
+    store:
+      type: file
+      path: "{{.BlobPath}}"

--- a/integration_test/testdata/token_broker_proxy.yaml
+++ b/integration_test/testdata/token_broker_proxy.yaml
@@ -1,0 +1,40 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+  - name: secrets
+    config:
+      secrets:
+        - source:
+            type: token_broker
+            credential_id: openai-codex
+            ttl: "5s"
+          inject:
+            header: Authorization
+            # {{`...`}} escapes the inner expression so renderConfig leaves
+            # the secrets-transform formatter template intact.
+            formatter: "Bearer {{`{{.Value}}`}}"
+          rules:
+            - host: "127.0.0.1"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/integration_test/token_broker_test.go
+++ b/integration_test/token_broker_test.go
@@ -1,0 +1,189 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBrokerBearer  = "test-broker-bearer"
+	testOAuthClientID = "test-client-id"
+	testRefreshToken  = "test-refresh-token-1"
+)
+
+// TestTokenBroker boots iron-token-broker and iron-proxy against an in-process
+// fake OAuth provider, then verifies a proxy request comes out with an
+// Authorization header carrying the broker-issued access token. A second
+// request within the cache TTL must not produce a second token-endpoint hit.
+func TestTokenBroker(t *testing.T) {
+	tmpDir := t.TempDir()
+	proxyBin := proxyBinary(t)
+	brokerBin := brokerBinary(t)
+
+	// Fake OAuth provider — accepts a refresh_token grant, rotates the
+	// refresh_token on every call, and returns a unique access_token so the
+	// upstream assertion can distinguish requests.
+	oauth := newFakeOAuthProvider(t)
+	defer oauth.Close()
+
+	// Upstream echoes back the Authorization header for assertion.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Got-Authorization", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamHost := upstream.Listener.Addr().String()
+
+	// Bootstrap the broker's file store with a refresh_token blob.
+	blobPath := filepath.Join(tmpDir, "openai-codex.json")
+	require.NoError(t, writeBootstrapBlob(blobPath, testRefreshToken))
+
+	brokerCfg := renderConfig(t, tmpDir, "token_broker_broker.yaml", map[string]string{
+		"TokenEndpoint": oauth.URL() + "/token",
+		"BlobPath":      blobPath,
+	})
+	// renderConfig writes to <tmpDir>/config.yaml; rename so we can render the
+	// proxy config into the same directory without collision.
+	brokerCfgPath := filepath.Join(tmpDir, "broker.yaml")
+	require.NoError(t, os.Rename(brokerCfg, brokerCfgPath))
+
+	broker := startBroker(t, brokerBin, brokerCfgPath, []string{
+		"TEST_BROKER_BEARER=" + testBrokerBearer,
+		"TEST_OAUTH_CLIENT_ID=" + testOAuthClientID,
+	})
+
+	proxyCfgPath := renderConfig(t, tmpDir, "token_broker_proxy.yaml", nil)
+	proxy := startProxy(t, proxyBin, proxyCfgPath, []string{
+		"IRON_BROKER_URL=http://" + broker.HTTPAddr,
+		"IRON_BROKER_TOKEN=" + testBrokerBearer,
+	})
+
+	// The broker bootstraps its first refresh asynchronously. Poll the
+	// access-token endpoint directly until it returns 200, so the proxy
+	// test below isn't racing the bootstrap.
+	require.Eventually(t, func() bool {
+		req, _ := http.NewRequest("GET", "http://"+broker.HTTPAddr+"/credentials/openai-codex/access_token", nil)
+		req.Header.Set("Authorization", "Bearer "+testBrokerBearer)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond, "broker never finished bootstrap refresh")
+
+	refreshesAfterBootstrap := oauth.Refreshes()
+	require.GreaterOrEqual(t, refreshesAfterBootstrap, int64(1), "broker should have refreshed at least once during bootstrap")
+
+	t.Run("proxy injects broker-issued token", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://"+proxy.HTTPAddr+"/", nil)
+		require.NoError(t, err)
+		req.Host = upstreamHost
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		got := resp.Header.Get("X-Got-Authorization")
+		require.Truef(t, len(got) > len("Bearer ") && got[:len("Bearer ")] == "Bearer ", "expected Bearer access token in Authorization header, got %q", got)
+		require.Containsf(t, got, "access-token-", "expected fake OAuth access token in Authorization header, got %q", got)
+	})
+
+	t.Run("second request within TTL does not trigger another OAuth refresh", func(t *testing.T) {
+		before := oauth.Refreshes()
+		req, err := http.NewRequest("GET", "http://"+proxy.HTTPAddr+"/", nil)
+		require.NoError(t, err)
+		req.Host = upstreamHost
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, before, oauth.Refreshes(), "second proxy request must not trigger another OAuth refresh within the broker's early-refresh window")
+	})
+}
+
+// fakeOAuthProvider implements just enough of RFC 6749 4.5 (refresh_token
+// grant) for the broker's refresh loop. It rotates the refresh_token on
+// every call so the broker's persistence path is exercised, and assigns
+// each access_token a unique suffix so callers can distinguish requests.
+type fakeOAuthProvider struct {
+	server         *httptest.Server
+	refreshes      atomic.Int64
+	currentRefresh atomic.Value // string
+}
+
+func newFakeOAuthProvider(t *testing.T) *fakeOAuthProvider {
+	t.Helper()
+	fp := &fakeOAuthProvider{}
+	fp.currentRefresh.Store(testRefreshToken)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("grant_type") != "refresh_token" {
+			http.Error(w, `{"error":"unsupported_grant_type"}`, http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("client_id") != testOAuthClientID {
+			http.Error(w, `{"error":"invalid_client"}`, http.StatusUnauthorized)
+			return
+		}
+		want := fp.currentRefresh.Load().(string)
+		if got := r.PostForm.Get("refresh_token"); got != want {
+			http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+			return
+		}
+
+		n := fp.refreshes.Add(1)
+		nextRefresh := fmt.Sprintf("refresh-token-%d", n+1)
+		fp.currentRefresh.Store(nextRefresh)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  fmt.Sprintf("access-token-%d", n),
+			"refresh_token": nextRefresh,
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+		})
+	})
+
+	fp.server = httptest.NewServer(mux)
+	return fp
+}
+
+func (fp *fakeOAuthProvider) Close()              { fp.server.Close() }
+func (fp *fakeOAuthProvider) URL() string         { return fp.server.URL }
+func (fp *fakeOAuthProvider) Refreshes() int64    { return fp.refreshes.Load() }
+
+// writeBootstrapBlob writes the JSON document the broker expects in its
+// store on startup. Only refresh_token is required; the broker mints
+// access_token and expires_at on its first refresh.
+func writeBootstrapBlob(path, refreshToken string) error {
+	blob := map[string]string{"refresh_token": refreshToken}
+	raw, err := json.MarshalIndent(blob, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o600)
+}

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -103,11 +103,10 @@ func (b *Broker) Wait() {
 // ListenAndServe starts the HTTP API server. Blocks until Shutdown is
 // called or the server errors. Errors after ListenAndServe returns are
 // non-nil only on a true failure (http.ErrServerClosed is filtered).
+// The "broker HTTP API starting" log line is emitted from inside the
+// server after the listener binds, so the resolved address is logged
+// even when the operator configured port 0.
 func (b *Broker) ListenAndServe() error {
-	b.log.Info("broker HTTP API starting",
-		slog.String("addr", b.api.Addr()),
-		slog.Int("credentials", len(b.creds)),
-	)
 	if err := b.api.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("broker http: %w", err)
 	}

--- a/internal/broker/http.go
+++ b/internal/broker/http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -59,7 +60,16 @@ func newHTTPServer(opts httpOptions) *httpServer {
 func (s *httpServer) Addr() string { return s.listenAddr }
 
 func (s *httpServer) ListenAndServe() error {
-	return s.server.ListenAndServe()
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.listenAddr = ln.Addr().String()
+	s.log.Info("broker HTTP API starting",
+		slog.String("addr", s.listenAddr),
+		slog.Int("credentials", len(s.creds)),
+	)
+	return s.server.Serve(ln)
 }
 
 func (s *httpServer) Shutdown(ctx context.Context) error {

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -147,6 +147,7 @@ func defaultRegistry(logger *slog.Logger) sourceBuilderRegistry {
 		"aws_ssm":           newAWSSSMBuilder(logger),
 		"1password":         newOPBuilder(logger),
 		"1password_connect": newOPConnectBuilder(logger),
+		"token_broker":      newTokenBrokerBuilder(logger),
 	}
 }
 

--- a/internal/transform/secrets/token_broker_resolver.go
+++ b/internal/transform/secrets/token_broker_resolver.go
@@ -1,0 +1,187 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/version"
+)
+
+const (
+	defaultBrokerURLEnv      = "IRON_BROKER_URL"
+	defaultBrokerTokenEnv    = "IRON_BROKER_TOKEN"
+	defaultBrokerTTL         = time.Minute
+	brokerHTTPClientTimeout  = 30 * time.Second
+	brokerErrorBodyMaxBytes  = 512
+)
+
+// brokerHTTPClient is the subset of *http.Client used by the broker resolver,
+// narrowed for testability.
+type brokerHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// tokenBrokerBuilder reads OAuth access tokens from a running iron-token-broker.
+type tokenBrokerBuilder struct {
+	clientFor func() (brokerHTTPClient, string, string, error)
+	logger    *slog.Logger
+	now       func() time.Time
+}
+
+type tokenBrokerConfig struct {
+	Type         string `yaml:"type"`
+	CredentialID string `yaml:"credential_id"`
+	TTL          string `yaml:"ttl,omitempty"`
+	FailureTTL   string `yaml:"failure_ttl,omitempty"`
+}
+
+func newTokenBrokerBuilder(logger *slog.Logger) *tokenBrokerBuilder {
+	cache := &brokerClientCache{
+		getenv: os.Getenv,
+		newClient: func() brokerHTTPClient {
+			return &http.Client{Timeout: brokerHTTPClientTimeout}
+		},
+	}
+	return &tokenBrokerBuilder{clientFor: cache.get, logger: logger, now: time.Now}
+}
+
+func (r *tokenBrokerBuilder) Build(raw yaml.Node) (secretSource, error) {
+	var cfg tokenBrokerConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing token_broker source config: %w", err)
+	}
+	if cfg.CredentialID == "" {
+		return nil, fmt.Errorf("token_broker source requires \"credential_id\" field")
+	}
+	ttl := defaultBrokerTTL
+	if cfg.TTL != "" {
+		parsed, err := time.ParseDuration(cfg.TTL)
+		if err != nil {
+			return nil, fmt.Errorf("parsing ttl %q: %w", cfg.TTL, err)
+		}
+		if parsed <= 0 {
+			return nil, fmt.Errorf("token_broker source requires ttl > 0 (got %q); cache-forever does not make sense for broker-issued tokens", cfg.TTL)
+		}
+		ttl = parsed
+	}
+	name := "token_broker:" + cfg.CredentialID
+	return buildLazySource(name, ttl.String(), cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
+		return r.fetchToken(ctx, cfg.CredentialID, ttl)
+	})
+}
+
+func (r *tokenBrokerBuilder) fetchToken(ctx context.Context, credentialID string, ttl time.Duration) (string, error) {
+	client, baseURL, bearer, err := r.clientFor()
+	if err != nil {
+		return "", err
+	}
+	endpoint, err := brokerAccessTokenURL(baseURL, credentialID)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("building broker request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "iron-proxy/"+version.Version)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling broker %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, brokerErrorBodyMaxBytes))
+		return "", fmt.Errorf("broker %s returned %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var body struct {
+		AccessToken string    `json:"access_token"`
+		ExpiresAt   time.Time `json:"expires_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decoding broker response: %w", err)
+	}
+	if body.AccessToken == "" {
+		return "", fmt.Errorf("broker returned empty access_token for credential %q", credentialID)
+	}
+	if body.ExpiresAt.IsZero() {
+		return "", fmt.Errorf("broker returned no expires_at for credential %q", credentialID)
+	}
+	remaining := body.ExpiresAt.Sub(r.now())
+	if remaining <= ttl {
+		return "", fmt.Errorf("broker token for credential %q has remaining lifetime %s, which is not greater than cache ttl %s; lower the configured ttl or check broker token-endpoint settings", credentialID, remaining, ttl)
+	}
+	return body.AccessToken, nil
+}
+
+// brokerAccessTokenURL joins the broker base URL and the credential ID to
+// form the access-token endpoint. The credential ID is escaped as a single
+// opaque path segment, so IDs containing slashes or other URL-unsafe
+// characters reach the broker without being mistaken for path separators.
+func brokerAccessTokenURL(baseURL, credentialID string) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing broker base url %q: %w", baseURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("broker base url %q must include scheme and host", baseURL)
+	}
+	basePath := strings.TrimRight(u.Path, "/")
+	baseRaw := strings.TrimRight(u.EscapedPath(), "/")
+	escaped := url.PathEscape(credentialID)
+	u.Path = basePath + "/credentials/" + credentialID + "/access_token"
+	u.RawPath = baseRaw + "/credentials/" + escaped + "/access_token"
+	return u.String(), nil
+}
+
+// brokerClientCache reads the broker URL and bearer token from env once on
+// first successful call and caches them with a shared *http.Client. Reading
+// at fetch time (not Build) matches the 1password_connect pattern:
+// misconfiguration surfaces on the first request, not at startup. Errors are
+// not cached, so an env var that gets set after a failed call recovers on
+// the next attempt.
+type brokerClientCache struct {
+	mu        sync.Mutex
+	getenv    func(string) string
+	newClient func() brokerHTTPClient
+
+	client  brokerHTTPClient
+	baseURL string
+	bearer  string
+}
+
+func (c *brokerClientCache) get() (brokerHTTPClient, string, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.client != nil {
+		return c.client, c.baseURL, c.bearer, nil
+	}
+	baseURL := c.getenv(defaultBrokerURLEnv)
+	if baseURL == "" {
+		return nil, "", "", fmt.Errorf("env var %q is not set or empty", defaultBrokerURLEnv)
+	}
+	bearer := c.getenv(defaultBrokerTokenEnv)
+	if bearer == "" {
+		return nil, "", "", fmt.Errorf("env var %q is not set or empty", defaultBrokerTokenEnv)
+	}
+	c.client = c.newClient()
+	c.baseURL = baseURL
+	c.bearer = bearer
+	return c.client, c.baseURL, c.bearer, nil
+}

--- a/internal/transform/secrets/token_broker_resolver_test.go
+++ b/internal/transform/secrets/token_broker_resolver_test.go
@@ -1,0 +1,423 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testBrokerBearer = "test-bearer-token"
+
+// newTestTokenBrokerBuilder wires the builder against a real httptest.Server.
+// The returned baseURL/bearer are what the cache would read from env in
+// production. now lets tests freeze time so expires_at validation is
+// deterministic.
+func newTestTokenBrokerBuilder(t *testing.T, baseURL, bearer string, now func() time.Time) *tokenBrokerBuilder {
+	t.Helper()
+	return &tokenBrokerBuilder{
+		clientFor: func() (brokerHTTPClient, string, string, error) {
+			return http.DefaultClient, baseURL, bearer, nil
+		},
+		logger: slog.Default(),
+		now:    now,
+	}
+}
+
+// fakeBroker is a configurable test double for the broker's HTTP API. Each
+// test wires its own handler via respond. The server tracks call counts and
+// captured request paths/headers so assertions can verify caching behavior
+// and auth wiring.
+type fakeBroker struct {
+	server   *httptest.Server
+	calls    atomic.Int64
+	lastAuth atomic.Value // string
+	lastPath atomic.Value // string
+}
+
+func newFakeBroker(t *testing.T, respond http.HandlerFunc) *fakeBroker {
+	t.Helper()
+	fb := &fakeBroker{}
+	fb.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fb.calls.Add(1)
+		fb.lastAuth.Store(r.Header.Get("Authorization"))
+		fb.lastPath.Store(r.URL.Path)
+		respond(w, r)
+	}))
+	t.Cleanup(fb.server.Close)
+	return fb
+}
+
+func (fb *fakeBroker) URL() string  { return fb.server.URL }
+func (fb *fakeBroker) Calls() int64 { return fb.calls.Load() }
+
+func (fb *fakeBroker) LastAuth() string {
+	v := fb.lastAuth.Load()
+	if v == nil {
+		return ""
+	}
+	return v.(string)
+}
+
+func (fb *fakeBroker) LastPath() string {
+	v := fb.lastPath.Load()
+	if v == nil {
+		return ""
+	}
+	return v.(string)
+}
+
+// respondAccessToken returns a handler that writes a 200 with the given
+// access_token and expires_at.
+func respondAccessToken(token string, expiresAt time.Time) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": token,
+			"expires_at":   expiresAt.Format(time.RFC3339Nano),
+		})
+	}
+}
+
+// respondError returns a handler that writes the given status and a JSON
+// error body shaped like the broker's real responses.
+func respondError(status int, errMsg, reason string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		body := map[string]string{"error": errMsg}
+		if reason != "" {
+			body["reason"] = reason
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+func TestTokenBrokerBuilder_HappyPath(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	fb := newFakeBroker(t, respondAccessToken("the-token", now.Add(time.Hour)))
+
+	r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, func() time.Time { return now })
+	src, err := r.Build(yamlNode(t, map[string]string{
+		"type":          "token_broker",
+		"credential_id": "openai-codex",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "token_broker:openai-codex", src.Name())
+
+	val, err := src.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "the-token", val)
+	require.Equal(t, "Bearer "+testBrokerBearer, fb.LastAuth())
+	require.Equal(t, "/credentials/openai-codex/access_token", fb.LastPath())
+	require.Equal(t, int64(1), fb.Calls())
+}
+
+func TestTokenBrokerBuilder_CachesWithinTTL(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	fb := newFakeBroker(t, respondAccessToken("the-token", now.Add(time.Hour)))
+
+	r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, func() time.Time { return now })
+	src, err := r.Build(yamlNode(t, map[string]string{
+		"type":          "token_broker",
+		"credential_id": "openai-codex",
+		"ttl":           "1m",
+	}))
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		val, err := src.Get(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "the-token", val)
+	}
+	require.Equal(t, int64(1), fb.Calls(), "second and subsequent gets should be served from cache")
+}
+
+func TestTokenBrokerBuilder_RejectsResponseWithExpiresAtAtOrBelowTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		remaining time.Duration
+	}{
+		{"expires before ttl elapses", 30 * time.Second},
+		{"expires exactly at ttl", time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+			fb := newFakeBroker(t, respondAccessToken("the-token", now.Add(tt.remaining)))
+
+			r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, func() time.Time { return now })
+			src, err := r.Build(yamlNode(t, map[string]string{
+				"type":          "token_broker",
+				"credential_id": "openai-codex",
+				"ttl":           "1m",
+			}))
+			require.NoError(t, err)
+
+			_, err = src.Get(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "remaining lifetime")
+		})
+	}
+}
+
+func TestTokenBrokerBuilder_HTTPErrorsArePropagated(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		errMsg      string
+		reason      string
+		wantContains string
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, "unauthorized", "", "401"},
+		{"404 not found", http.StatusNotFound, "credential not found", "", "404"},
+		{"422 credential dead", http.StatusUnprocessableEntity, "credential dead", "invalid_grant", "422"},
+		{"503 bootstrapping", http.StatusServiceUnavailable, "bootstrapping", "", "503"},
+		{"500 internal", http.StatusInternalServerError, "internal error", "", "500"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fb := newFakeBroker(t, respondError(tt.status, tt.errMsg, tt.reason))
+			r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, time.Now)
+			src, err := r.Build(yamlNode(t, map[string]string{
+				"type":          "token_broker",
+				"credential_id": "openai-codex",
+			}))
+			require.NoError(t, err)
+
+			_, err = src.Get(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantContains)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestTokenBrokerBuilder_RejectsMalformedJSON(t *testing.T) {
+	fb := newFakeBroker(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	})
+	r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, time.Now)
+	src, err := r.Build(yamlNode(t, map[string]string{
+		"type":          "token_broker",
+		"credential_id": "openai-codex",
+	}))
+	require.NoError(t, err)
+
+	_, err = src.Get(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decoding broker response")
+}
+
+func TestTokenBrokerBuilder_RejectsEmptyAccessToken(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	fb := newFakeBroker(t, respondAccessToken("", now.Add(time.Hour)))
+	r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, func() time.Time { return now })
+	src, err := r.Build(yamlNode(t, map[string]string{
+		"type":          "token_broker",
+		"credential_id": "openai-codex",
+	}))
+	require.NoError(t, err)
+
+	_, err = src.Get(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty access_token")
+}
+
+func TestTokenBrokerBuilder_RejectsZeroExpiresAt(t *testing.T) {
+	fb := newFakeBroker(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "tok"})
+	})
+	r := newTestTokenBrokerBuilder(t, fb.URL(), testBrokerBearer, time.Now)
+	src, err := r.Build(yamlNode(t, map[string]string{
+		"type":          "token_broker",
+		"credential_id": "openai-codex",
+	}))
+	require.NoError(t, err)
+
+	_, err = src.Get(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no expires_at")
+}
+
+func TestTokenBrokerBuilder_BuildErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		errMsg string
+	}{
+		{
+			name:   "missing credential_id",
+			input:  map[string]string{"type": "token_broker"},
+			errMsg: "\"credential_id\" field",
+		},
+		{
+			name:   "ttl zero rejected",
+			input:  map[string]string{"type": "token_broker", "credential_id": "foo", "ttl": "0s"},
+			errMsg: "ttl > 0",
+		},
+		{
+			name:   "ttl negative rejected",
+			input:  map[string]string{"type": "token_broker", "credential_id": "foo", "ttl": "-1s"},
+			errMsg: "ttl > 0",
+		},
+		{
+			name:   "ttl malformed rejected",
+			input:  map[string]string{"type": "token_broker", "credential_id": "foo", "ttl": "not-a-duration"},
+			errMsg: "parsing ttl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestTokenBrokerBuilder(t, "http://example.invalid", testBrokerBearer, time.Now)
+			_, err := r.Build(yamlNode(t, tt.input))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestBrokerAccessTokenURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		credID  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:    "no path",
+			baseURL: "https://broker.example.com",
+			credID:  "openai-codex",
+			want:    "https://broker.example.com/credentials/openai-codex/access_token",
+		},
+		{
+			name:    "trailing slash trimmed",
+			baseURL: "https://broker.example.com/",
+			credID:  "openai-codex",
+			want:    "https://broker.example.com/credentials/openai-codex/access_token",
+		},
+		{
+			name:    "with subpath",
+			baseURL: "https://gateway.example.com/broker",
+			credID:  "openai-codex",
+			want:    "https://gateway.example.com/broker/credentials/openai-codex/access_token",
+		},
+		{
+			name:    "credential id escaped",
+			baseURL: "https://broker.example.com",
+			credID:  "foo/bar baz",
+			want:    "https://broker.example.com/credentials/foo%2Fbar%20baz/access_token",
+		},
+		{
+			name:    "missing scheme",
+			baseURL: "broker.example.com",
+			credID:  "x",
+			wantErr: "must include scheme and host",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := brokerAccessTokenURL(tt.baseURL, tt.credID)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- brokerClientCache tests ---
+
+func TestBrokerClientCache_ReadsEnvOnFirstUse(t *testing.T) {
+	calls := 0
+	cache := &brokerClientCache{
+		getenv: func(key string) string {
+			switch key {
+			case defaultBrokerURLEnv:
+				return "https://broker.example.com"
+			case defaultBrokerTokenEnv:
+				return "tok"
+			}
+			return ""
+		},
+		newClient: func() brokerHTTPClient { calls++; return http.DefaultClient },
+	}
+	client, baseURL, bearer, err := cache.get()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	require.Equal(t, "https://broker.example.com", baseURL)
+	require.Equal(t, "tok", bearer)
+	require.Equal(t, 1, calls)
+
+	// Second call reuses the cached client.
+	_, _, _, err = cache.get()
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestBrokerClientCache_ErrorOnMissingURL(t *testing.T) {
+	cache := &brokerClientCache{
+		getenv:    func(string) string { return "" },
+		newClient: func() brokerHTTPClient { return http.DefaultClient },
+	}
+	_, _, _, err := cache.get()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("%q is not set or empty", defaultBrokerURLEnv))
+}
+
+func TestBrokerClientCache_ErrorOnMissingToken(t *testing.T) {
+	cache := &brokerClientCache{
+		getenv: func(key string) string {
+			if key == defaultBrokerURLEnv {
+				return "https://broker.example.com"
+			}
+			return ""
+		},
+		newClient: func() brokerHTTPClient { return http.DefaultClient },
+	}
+	_, _, _, err := cache.get()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("%q is not set or empty", defaultBrokerTokenEnv))
+}
+
+func TestDefaultRegistry_IncludesTokenBroker(t *testing.T) {
+	reg := defaultRegistry(slog.Default())
+	_, ok := reg["token_broker"]
+	require.True(t, ok, "token_broker must be registered in defaultRegistry")
+}
+
+func TestBrokerClientCache_ErrorNotCached(t *testing.T) {
+	var url string
+	cache := &brokerClientCache{
+		getenv: func(key string) string {
+			switch key {
+			case defaultBrokerURLEnv:
+				return url
+			case defaultBrokerTokenEnv:
+				return "tok"
+			}
+			return ""
+		},
+		newClient: func() brokerHTTPClient { return http.DefaultClient },
+	}
+	_, _, _, err := cache.get()
+	require.Error(t, err)
+
+	url = "https://broker.example.com"
+	_, baseURL, _, err := cache.get()
+	require.NoError(t, err)
+	require.Equal(t, "https://broker.example.com", baseURL)
+}


### PR DESCRIPTION
Adds a `token_broker` secrets source so iron-proxy can pull OAuth access tokens from a running `iron-token-broker` over HTTP. Configure per source with `credential_id`; broker URL and bearer key come from `IRON_BROKER_URL` and `IRON_BROKER_TOKEN`. The fetch closure rejects responses whose remaining lifetime is not greater than the configured cache `ttl` so stale tokens are never served.

Incidental fix in the broker's HTTP server: explicit `net.Listen` so the resolved address lands in the "broker HTTP API starting" log line (otherwise `:0` configs log `addr=":0"`).

End-to-end coverage in `integration_test/token_broker_test.go`: boots the real broker binary against an in-process fake OAuth provider, runs requests through the real proxy binary, asserts the upstream sees the broker-issued token and that a second request within the TTL does not trigger another OAuth refresh.