### PR TITLE
refactor(secrets): drop env-name overrides for 1password and 1password_connect

### DIFF
--- a/README.iron-token-broker.md
+++ b/README.iron-token-broker.md
@@ -136,11 +136,11 @@ store:
 # 1Password via SDK (service account token). vault and item segments of
 # secret_ref must be UUIDs: the SDK takes raw IDs and looking names up
 # would cost a list call per refresh. Copy UUIDs with the 1Password
-# app's right-click "Copy Item UUID" / "Copy Vault UUID" actions.
+# app's right-click "Copy Item UUID" / "Copy Vault UUID" actions. Reads
+# OP_SERVICE_ACCOUNT_TOKEN from the environment.
 store:
   type: 1password
   secret_ref: "op://abcd1234efgh5678ijkl9012mn/1234abcd5678efgh9012ijkl3m/credential_blob"
-  token_env: OP_SERVICE_ACCOUNT_TOKEN   # default
 
 # 1Password via Connect server. Accepts UUIDs or human titles (Connect
 # resolves them server-side). Reads OP_CONNECT_HOST and OP_CONNECT_TOKEN

--- a/README.iron-token-broker.md
+++ b/README.iron-token-broker.md
@@ -143,12 +143,11 @@ store:
   token_env: OP_SERVICE_ACCOUNT_TOKEN   # default
 
 # 1Password via Connect server. Accepts UUIDs or human titles (Connect
-# resolves them server-side).
+# resolves them server-side). Reads OP_CONNECT_HOST and OP_CONNECT_TOKEN
+# from the environment.
 store:
   type: 1password_connect
   secret_ref: "op://Engineering/openai-codex/credential_blob"
-  host_env: OP_CONNECT_HOST             # default
-  token_env: OP_CONNECT_TOKEN           # default
 
 # AWS Secrets Manager.
 store:

--- a/README.md
+++ b/README.md
@@ -449,9 +449,8 @@ Secret sources:
   `ttl` and `failure_ttl` are supported.
 - **`1password_connect`:** resolves the same `op://vault/item/[section/]field`
   `secret_ref` against a self-hosted 1Password Connect server. The server URL
-  is read from `OP_CONNECT_HOST` and the API token from `OP_CONNECT_TOKEN` by
-  default; override with `host_env` and `token_env`. Optional `ttl` and
-  `failure_ttl` are supported.
+  is read from `OP_CONNECT_HOST` and the API token from `OP_CONNECT_TOKEN`.
+  Optional `ttl` and `failure_ttl` are supported.
 - **`token_broker`:** fetches a current OAuth access token for `credential_id`
   from an `iron-token-broker` deployment. The broker URL is read from
   `IRON_BROKER_URL` and the bearer API key from `IRON_BROKER_TOKEN`. Optional

--- a/README.md
+++ b/README.md
@@ -445,8 +445,7 @@ Secret sources:
   `SecureString` parameters.
 - **`1password`:** resolves `secret_ref` (an `op://vault/item/[section/]field`
   reference) using a 1Password service account token. The token is read from
-  `OP_SERVICE_ACCOUNT_TOKEN` by default; override with `token_env`. Optional
-  `ttl` and `failure_ttl` are supported.
+  `OP_SERVICE_ACCOUNT_TOKEN`. Optional `ttl` and `failure_ttl` are supported.
 - **`1password_connect`:** resolves the same `op://vault/item/[section/]field`
   `secret_ref` against a self-hosted 1Password Connect server. The server URL
   is read from `OP_CONNECT_HOST` and the API token from `OP_CONNECT_TOKEN`.

--- a/internal/broker/store/op.go
+++ b/internal/broker/store/op.go
@@ -15,18 +15,15 @@ import (
 	"github.com/ironsh/iron-proxy/internal/version"
 )
 
-// defaultOPTokenEnv mirrors the constant used by the read-side resolver in
-// internal/transform/secrets so operators don't have to maintain two
-// environment variables when they use 1Password for both the broker store
-// and other secrets.
-const defaultOPTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
+// opTokenEnv mirrors the constant used by the read-side resolver in
+// internal/transform/secrets.
+const opTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
 
 type opBuilder struct{}
 
 type opConfig struct {
 	Type      string `yaml:"type"`
 	SecretRef string `yaml:"secret_ref"`
-	TokenEnv  string `yaml:"token_env,omitempty"`
 }
 
 func (opBuilder) Build(raw yaml.Node, logger *slog.Logger) (Handle, error) {
@@ -51,14 +48,10 @@ func (opBuilder) Build(raw yaml.Node, logger *slog.Logger) (Handle, error) {
 	if !looksLikeUUID(ref.Item) {
 		return nil, fmt.Errorf("1password store secret_ref %q: item segment must be a UUID (use the SDK \"Copy Item UUID\" action)", cfg.SecretRef)
 	}
-	if cfg.TokenEnv == "" {
-		cfg.TokenEnv = defaultOPTokenEnv
-	}
 	return &opHandle{
-		ref:      ref,
-		secret:   cfg.SecretRef,
-		tokenEnv: cfg.TokenEnv,
-		logger:   logger,
+		ref:    ref,
+		secret: cfg.SecretRef,
+		logger: logger,
 	}, nil
 }
 
@@ -72,10 +65,9 @@ type opSDKItemsAPI interface {
 // opHandle persists the credential blob as the value of a single field on
 // a 1Password item.
 type opHandle struct {
-	ref      secrets.OPRef
-	secret   string // original secret_ref string for log/Name output
-	tokenEnv string
-	logger   *slog.Logger
+	ref    secrets.OPRef
+	secret string // original secret_ref string for log/Name output
+	logger *slog.Logger
 
 	mu    sync.Mutex
 	items opSDKItemsAPI
@@ -142,9 +134,9 @@ func (h *opHandle) getItems(ctx context.Context) (opSDKItemsAPI, error) {
 	if h.items != nil {
 		return h.items, nil
 	}
-	token := os.Getenv(h.tokenEnv)
+	token := os.Getenv(opTokenEnv)
 	if token == "" {
-		return nil, fmt.Errorf("1password store %q: env var %q is not set or empty", h.secret, h.tokenEnv)
+		return nil, fmt.Errorf("1password store %q: env var %q is not set or empty", h.secret, opTokenEnv)
 	}
 	client, err := onepassword.NewClient(ctx,
 		onepassword.WithServiceAccountToken(token),

--- a/internal/broker/store/op_connect.go
+++ b/internal/broker/store/op_connect.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	defaultOPConnectHostEnv  = "OP_CONNECT_HOST"
-	defaultOPConnectTokenEnv = "OP_CONNECT_TOKEN"
+	opConnectHostEnv  = "OP_CONNECT_HOST"
+	opConnectTokenEnv = "OP_CONNECT_TOKEN"
 )
 
 type opConnectBuilder struct{}
@@ -26,8 +26,6 @@ type opConnectBuilder struct{}
 type opConnectConfig struct {
 	Type      string `yaml:"type"`
 	SecretRef string `yaml:"secret_ref"`
-	HostEnv   string `yaml:"host_env,omitempty"`
-	TokenEnv  string `yaml:"token_env,omitempty"`
 }
 
 func (opConnectBuilder) Build(raw yaml.Node, logger *slog.Logger) (Handle, error) {
@@ -42,18 +40,10 @@ func (opConnectBuilder) Build(raw yaml.Node, logger *slog.Logger) (Handle, error
 	if err != nil {
 		return nil, fmt.Errorf("1password_connect store: %w", err)
 	}
-	if cfg.HostEnv == "" {
-		cfg.HostEnv = defaultOPConnectHostEnv
-	}
-	if cfg.TokenEnv == "" {
-		cfg.TokenEnv = defaultOPConnectTokenEnv
-	}
 	return &opConnectHandle{
-		ref:      ref,
-		secret:   cfg.SecretRef,
-		hostEnv:  cfg.HostEnv,
-		tokenEnv: cfg.TokenEnv,
-		logger:   logger,
+		ref:    ref,
+		secret: cfg.SecretRef,
+		logger: logger,
 	}, nil
 }
 
@@ -69,11 +59,9 @@ type opConnectClient interface {
 // opConnectHandle persists the credential blob via a 1Password Connect
 // server.
 type opConnectHandle struct {
-	ref      secrets.OPRef
-	secret   string
-	hostEnv  string
-	tokenEnv string
-	logger   *slog.Logger
+	ref    secrets.OPRef
+	secret string
+	logger *slog.Logger
 
 	mu     sync.Mutex
 	client opConnectClient
@@ -149,13 +137,13 @@ func (h *opConnectHandle) getClient() (opConnectClient, error) {
 	if h.client != nil {
 		return h.client, nil
 	}
-	host := os.Getenv(h.hostEnv)
+	host := os.Getenv(opConnectHostEnv)
 	if host == "" {
-		return nil, fmt.Errorf("1password_connect store %q: env var %q is not set or empty", h.secret, h.hostEnv)
+		return nil, fmt.Errorf("1password_connect store %q: env var %q is not set or empty", h.secret, opConnectHostEnv)
 	}
-	token := os.Getenv(h.tokenEnv)
+	token := os.Getenv(opConnectTokenEnv)
 	if token == "" {
-		return nil, fmt.Errorf("1password_connect store %q: env var %q is not set or empty", h.secret, h.tokenEnv)
+		return nil, fmt.Errorf("1password_connect store %q: env var %q is not set or empty", h.secret, opConnectTokenEnv)
 	}
 	h.client = connect.NewClientWithUserAgent(host, token, "iron-token-broker/"+version.Version)
 	return h.client, nil

--- a/internal/transform/secrets/op_connect_resolver.go
+++ b/internal/transform/secrets/op_connect_resolver.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	defaultOPConnectHostEnv  = "OP_CONNECT_HOST"
-	defaultOPConnectTokenEnv = "OP_CONNECT_TOKEN"
+	opConnectHostEnv  = "OP_CONNECT_HOST"
+	opConnectTokenEnv = "OP_CONNECT_TOKEN"
 )
 
 // opConnectClient is the subset of the Connect SDK client used by
@@ -29,23 +29,20 @@ type opConnectClient interface {
 
 // opConnectBuilder reads secrets from a 1Password Connect server.
 type opConnectBuilder struct {
-	clientFor func(ctx context.Context, hostEnv, tokenEnv string) (opConnectClient, error)
+	clientFor func(ctx context.Context) (opConnectClient, error)
 	logger    *slog.Logger
 }
 
 type opConnectConfig struct {
 	Type       string `yaml:"type"`
 	SecretRef  string `yaml:"secret_ref"`
-	HostEnv    string `yaml:"host_env,omitempty"`
-	TokenEnv   string `yaml:"token_env,omitempty"`
 	TTL        string `yaml:"ttl,omitempty"`
 	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
 func newOPConnectBuilder(logger *slog.Logger) *opConnectBuilder {
 	cache := &opConnectClientCache{
-		clients: make(map[string]opConnectClient),
-		getenv:  os.Getenv,
+		getenv: os.Getenv,
 		newClient: func(host, token string) opConnectClient {
 			return opConnectSDKClient{c: connect.NewClientWithUserAgent(host, token, "iron-proxy/"+version.Version)}
 		},
@@ -65,19 +62,13 @@ func (r *opConnectBuilder) Build(raw yaml.Node) (secretSource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("1password_connect: %w", err)
 	}
-	if cfg.HostEnv == "" {
-		cfg.HostEnv = defaultOPConnectHostEnv
-	}
-	if cfg.TokenEnv == "" {
-		cfg.TokenEnv = defaultOPConnectTokenEnv
-	}
 	return buildLazySource(cfg.SecretRef, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg, ref)
 	})
 }
 
 func (r *opConnectBuilder) fetchSecret(ctx context.Context, cfg opConnectConfig, ref OPRef) (string, error) {
-	client, err := r.clientFor(ctx, cfg.HostEnv, cfg.TokenEnv)
+	client, err := r.clientFor(ctx)
 	if err != nil {
 		return "", fmt.Errorf("creating 1password_connect client: %w", err)
 	}
@@ -163,33 +154,31 @@ func SelectConnectField(item *onepassword.Item, ref OPRef) (string, error) {
 	return "", fmt.Errorf("field %q not found on item", ref.Field)
 }
 
-// opConnectClientCache caches one Connect client per (hostEnv, tokenEnv)
-// pair. Reusing a client pools the underlying HTTP transport.
+// opConnectClientCache lazily constructs a single Connect client. Reusing
+// it pools the underlying HTTP transport.
 type opConnectClientCache struct {
 	mu        sync.Mutex
-	clients   map[string]opConnectClient
+	client    opConnectClient
 	getenv    func(string) string
 	newClient func(host, token string) opConnectClient
 }
 
-func (c *opConnectClientCache) get(_ context.Context, hostEnv, tokenEnv string) (opConnectClient, error) {
+func (c *opConnectClientCache) get(_ context.Context) (opConnectClient, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	key := hostEnv + "|" + tokenEnv
-	if client, ok := c.clients[key]; ok {
-		return client, nil
+	if c.client != nil {
+		return c.client, nil
 	}
-	host := c.getenv(hostEnv)
+	host := c.getenv(opConnectHostEnv)
 	if host == "" {
-		return nil, fmt.Errorf("env var %q is not set or empty", hostEnv)
+		return nil, fmt.Errorf("env var %q is not set or empty", opConnectHostEnv)
 	}
-	token := c.getenv(tokenEnv)
+	token := c.getenv(opConnectTokenEnv)
 	if token == "" {
-		return nil, fmt.Errorf("env var %q is not set or empty", tokenEnv)
+		return nil, fmt.Errorf("env var %q is not set or empty", opConnectTokenEnv)
 	}
-	client := c.newClient(host, token)
-	c.clients[key] = client
-	return client, nil
+	c.client = c.newClient(host, token)
+	return c.client, nil
 }
 
 // opConnectSDKClient adapts a connect.Client to the opConnectClient interface.

--- a/internal/transform/secrets/op_connect_resolver_test.go
+++ b/internal/transform/secrets/op_connect_resolver_test.go
@@ -34,7 +34,7 @@ func staticOPConnectClient(vault *onepassword.Vault, item *onepassword.Item) *mo
 
 func newTestOPConnectBuilder(client opConnectClient) *opConnectBuilder {
 	return &opConnectBuilder{
-		clientFor: func(_ context.Context, _, _ string) (opConnectClient, error) {
+		clientFor: func(_ context.Context) (opConnectClient, error) {
 			return client, nil
 		},
 		logger: slog.Default(),
@@ -61,16 +61,8 @@ func sampleVault() *onepassword.Vault {
 	return &onepassword.Vault{ID: "vault-uuid", Name: "Engineering"}
 }
 
-func TestOPConnectBuilder_HappyPath_DefaultEnvs(t *testing.T) {
-	var gotHostEnv, gotTokenEnv string
-	r := &opConnectBuilder{
-		clientFor: func(_ context.Context, hostEnv, tokenEnv string) (opConnectClient, error) {
-			gotHostEnv = hostEnv
-			gotTokenEnv = tokenEnv
-			return staticOPConnectClient(sampleVault(), sampleItem()), nil
-		},
-		logger: slog.Default(),
-	}
+func TestOPConnectBuilder_HappyPath(t *testing.T) {
+	r := newTestOPConnectBuilder(staticOPConnectClient(sampleVault(), sampleItem()))
 
 	node := yamlNode(t, map[string]string{
 		"type":       "1password_connect",
@@ -83,34 +75,6 @@ func TestOPConnectBuilder_HappyPath_DefaultEnvs(t *testing.T) {
 	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-secret", val)
-	require.Equal(t, "OP_CONNECT_HOST", gotHostEnv)
-	require.Equal(t, "OP_CONNECT_TOKEN", gotTokenEnv)
-}
-
-func TestOPConnectBuilder_HappyPath_CustomEnvs(t *testing.T) {
-	var gotHostEnv, gotTokenEnv string
-	r := &opConnectBuilder{
-		clientFor: func(_ context.Context, hostEnv, tokenEnv string) (opConnectClient, error) {
-			gotHostEnv = hostEnv
-			gotTokenEnv = tokenEnv
-			return staticOPConnectClient(sampleVault(), sampleItem()), nil
-		},
-		logger: slog.Default(),
-	}
-
-	node := yamlNode(t, map[string]string{
-		"type":       "1password_connect",
-		"secret_ref": "op://Engineering/OpenAI/credential",
-		"host_env":   "MY_CONNECT_HOST",
-		"token_env":  "MY_CONNECT_TOKEN",
-	})
-	result, err := r.Build(node)
-	require.NoError(t, err)
-
-	_, err = result.Get(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "MY_CONNECT_HOST", gotHostEnv)
-	require.Equal(t, "MY_CONNECT_TOKEN", gotTokenEnv)
 }
 
 func TestOPConnectBuilder_PassesParsedRefToClient(t *testing.T) {
@@ -398,12 +362,11 @@ func TestSelectConnectField(t *testing.T) {
 func TestOPConnectClientCache_ReadsHostAndTokenFromEnv(t *testing.T) {
 	var gotHost, gotToken string
 	cache := &opConnectClientCache{
-		clients: make(map[string]opConnectClient),
 		getenv: func(key string) string {
 			switch key {
-			case "MY_HOST":
+			case opConnectHostEnv:
 				return "https://connect.internal"
-			case "MY_TOKEN":
+			case opConnectTokenEnv:
 				return "tok"
 			}
 			return ""
@@ -414,7 +377,7 @@ func TestOPConnectClientCache_ReadsHostAndTokenFromEnv(t *testing.T) {
 		},
 	}
 
-	_, err := cache.get(context.Background(), "MY_HOST", "MY_TOKEN")
+	_, err := cache.get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "https://connect.internal", gotHost)
 	require.Equal(t, "tok", gotToken)
@@ -422,58 +385,47 @@ func TestOPConnectClientCache_ReadsHostAndTokenFromEnv(t *testing.T) {
 
 func TestOPConnectClientCache_ErrorOnMissingHost(t *testing.T) {
 	cache := &opConnectClientCache{
-		clients: make(map[string]opConnectClient),
 		getenv: func(key string) string {
-			if key == "TOK" {
+			if key == opConnectTokenEnv {
 				return "tok"
 			}
 			return ""
 		},
 		newClient: func(string, string) opConnectClient { return nil },
 	}
-	_, err := cache.get(context.Background(), "MISSING_HOST", "TOK")
+	_, err := cache.get(context.Background())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "\"MISSING_HOST\" is not set or empty")
+	require.Contains(t, err.Error(), "\"OP_CONNECT_HOST\" is not set or empty")
 }
 
 func TestOPConnectClientCache_ErrorOnMissingToken(t *testing.T) {
 	cache := &opConnectClientCache{
-		clients: make(map[string]opConnectClient),
 		getenv: func(key string) string {
-			if key == "HOST" {
+			if key == opConnectHostEnv {
 				return "https://connect.internal"
 			}
 			return ""
 		},
 		newClient: func(string, string) opConnectClient { return nil },
 	}
-	_, err := cache.get(context.Background(), "HOST", "MISSING_TOKEN")
+	_, err := cache.get(context.Background())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "\"MISSING_TOKEN\" is not set or empty")
+	require.Contains(t, err.Error(), "\"OP_CONNECT_TOKEN\" is not set or empty")
 }
 
-func TestOPConnectClientCache_ReusesPerEnvPair(t *testing.T) {
+func TestOPConnectClientCache_ReusesClient(t *testing.T) {
 	calls := 0
 	cache := &opConnectClientCache{
-		clients: make(map[string]opConnectClient),
-		getenv:  func(string) string { return "x" },
+		getenv: func(string) string { return "x" },
 		newClient: func(string, string) opConnectClient {
 			calls++
 			return staticOPConnectClient(sampleVault(), sampleItem())
 		},
 	}
 
-	_, err := cache.get(context.Background(), "H1", "T1")
+	_, err := cache.get(context.Background())
 	require.NoError(t, err)
-	_, err = cache.get(context.Background(), "H1", "T1")
+	_, err = cache.get(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 1, calls, "same host/token env pair should reuse the client")
-
-	_, err = cache.get(context.Background(), "H1", "T2")
-	require.NoError(t, err)
-	require.Equal(t, 2, calls, "different token env should create a new client")
-
-	_, err = cache.get(context.Background(), "H2", "T1")
-	require.NoError(t, err)
-	require.Equal(t, 3, calls, "different host env should create a new client")
+	require.Equal(t, 1, calls, "repeated calls should reuse the cached client")
 }

--- a/internal/transform/secrets/op_resolver.go
+++ b/internal/transform/secrets/op_resolver.go
@@ -14,9 +14,9 @@ import (
 	"github.com/ironsh/iron-proxy/internal/version"
 )
 
-// defaultOPTokenEnv is the conventional environment variable for 1Password
+// opTokenEnv is the conventional environment variable for 1Password
 // service account tokens, matching the SDK's own examples.
-const defaultOPTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
+const opTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN"
 
 // opClient is the subset of the 1Password SDK used by opBuilder, narrowed for testability.
 type opClient interface {
@@ -25,22 +25,20 @@ type opClient interface {
 
 // opBuilder reads secrets from 1Password using a service account token.
 type opBuilder struct {
-	clientFor func(ctx context.Context, tokenEnv string) (opClient, error)
+	clientFor func(ctx context.Context) (opClient, error)
 	logger    *slog.Logger
 }
 
 type opConfig struct {
 	Type       string `yaml:"type"`
 	SecretRef  string `yaml:"secret_ref"`
-	TokenEnv   string `yaml:"token_env,omitempty"`
 	TTL        string `yaml:"ttl,omitempty"`
 	FailureTTL string `yaml:"failure_ttl,omitempty"`
 }
 
 func newOPBuilder(logger *slog.Logger) *opBuilder {
 	cache := &opClientCache{
-		clients: make(map[string]opClient),
-		getenv:  os.Getenv,
+		getenv: os.Getenv,
 		newClient: func(ctx context.Context, token string) (opClient, error) {
 			c, err := onepassword.NewClient(ctx,
 				onepassword.WithServiceAccountToken(token),
@@ -66,16 +64,13 @@ func (r *opBuilder) Build(raw yaml.Node) (secretSource, error) {
 	if !strings.HasPrefix(cfg.SecretRef, "op://") {
 		return nil, fmt.Errorf("1password secret_ref %q must start with \"op://\"", cfg.SecretRef)
 	}
-	if cfg.TokenEnv == "" {
-		cfg.TokenEnv = defaultOPTokenEnv
-	}
 	return buildLazySource(cfg.SecretRef, cfg.TTL, cfg.FailureTTL, r.logger, func(ctx context.Context) (string, error) {
 		return r.fetchSecret(ctx, cfg)
 	})
 }
 
 func (r *opBuilder) fetchSecret(ctx context.Context, cfg opConfig) (string, error) {
-	client, err := r.clientFor(ctx, cfg.TokenEnv)
+	client, err := r.clientFor(ctx)
 	if err != nil {
 		return "", fmt.Errorf("creating 1password client: %w", err)
 	}
@@ -89,32 +84,32 @@ func (r *opBuilder) fetchSecret(ctx context.Context, cfg opConfig) (string, erro
 	return val, nil
 }
 
-// opClientCache caches one SDK client per token-env-name. The 1P SDK loads a
+// opClientCache lazily constructs a single SDK client. The 1P SDK loads a
 // Wasm module on NewClient, so reusing the client across multiple secret
 // entries is significantly cheaper than creating one per entry.
 type opClientCache struct {
 	mu        sync.Mutex
-	clients   map[string]opClient
+	client    opClient
 	getenv    func(string) string
 	newClient func(ctx context.Context, token string) (opClient, error)
 }
 
-func (c *opClientCache) get(ctx context.Context, tokenEnv string) (opClient, error) {
+func (c *opClientCache) get(ctx context.Context) (opClient, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if client, ok := c.clients[tokenEnv]; ok {
-		return client, nil
+	if c.client != nil {
+		return c.client, nil
 	}
-	token := c.getenv(tokenEnv)
+	token := c.getenv(opTokenEnv)
 	if token == "" {
-		return nil, fmt.Errorf("env var %q is not set or empty", tokenEnv)
+		return nil, fmt.Errorf("env var %q is not set or empty", opTokenEnv)
 	}
 	client, err := c.newClient(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	c.clients[tokenEnv] = client
-	return client, nil
+	c.client = client
+	return c.client, nil
 }
 
 // opSDKClient adapts the 1Password SDK *Client to the opClient interface.

--- a/internal/transform/secrets/op_resolver_test.go
+++ b/internal/transform/secrets/op_resolver_test.go
@@ -27,22 +27,15 @@ func staticOPClient(value string, err error) *mockOPClient {
 
 func newTestOPBuilder(client opClient) *opBuilder {
 	return &opBuilder{
-		clientFor: func(_ context.Context, _ string) (opClient, error) {
+		clientFor: func(_ context.Context) (opClient, error) {
 			return client, nil
 		},
 		logger: slog.Default(),
 	}
 }
 
-func TestOPBuilder_HappyPath_DefaultTokenEnv(t *testing.T) {
-	var gotEnv string
-	r := &opBuilder{
-		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
-			gotEnv = tokenEnv
-			return staticOPClient("real-secret", nil), nil
-		},
-		logger: slog.Default(),
-	}
+func TestOPBuilder_HappyPath(t *testing.T) {
+	r := newTestOPBuilder(staticOPClient("real-secret", nil))
 
 	node := yamlNode(t, map[string]string{
 		"type":       "1password",
@@ -55,31 +48,6 @@ func TestOPBuilder_HappyPath_DefaultTokenEnv(t *testing.T) {
 	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-secret", val)
-	require.Equal(t, "OP_SERVICE_ACCOUNT_TOKEN", gotEnv)
-}
-
-func TestOPBuilder_HappyPath_CustomTokenEnv(t *testing.T) {
-	var gotEnv string
-	r := &opBuilder{
-		clientFor: func(_ context.Context, tokenEnv string) (opClient, error) {
-			gotEnv = tokenEnv
-			return staticOPClient("custom-token-secret", nil), nil
-		},
-		logger: slog.Default(),
-	}
-
-	node := yamlNode(t, map[string]string{
-		"type":       "1password",
-		"secret_ref": "op://Engineering/OpenAI/credential",
-		"token_env":  "CUSTOM_OP_TOKEN",
-	})
-	result, err := r.Build(node)
-	require.NoError(t, err)
-
-	val, err := result.Get(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "custom-token-secret", val)
-	require.Equal(t, "CUSTOM_OP_TOKEN", gotEnv)
 }
 
 func TestOPBuilder_TTLReturnsCachedValue(t *testing.T) {
@@ -182,9 +150,8 @@ func TestOPBuilder_Errors(t *testing.T) {
 func TestOPClientCache_ReadsTokenFromEnv(t *testing.T) {
 	var gotToken string
 	cache := &opClientCache{
-		clients: make(map[string]opClient),
 		getenv: func(key string) string {
-			if key == "MY_OP_TOKEN" {
+			if key == opTokenEnv {
 				return "ops_secret_value"
 			}
 			return ""
@@ -195,55 +162,48 @@ func TestOPClientCache_ReadsTokenFromEnv(t *testing.T) {
 		},
 	}
 
-	_, err := cache.get(context.Background(), "MY_OP_TOKEN")
+	_, err := cache.get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "ops_secret_value", gotToken)
 }
 
 func TestOPClientCache_ErrorOnMissingEnvVar(t *testing.T) {
 	cache := &opClientCache{
-		clients:   make(map[string]opClient),
 		getenv:    func(string) string { return "" },
 		newClient: func(_ context.Context, _ string) (opClient, error) { return nil, nil },
 	}
 
-	_, err := cache.get(context.Background(), "MISSING_OP_TOKEN")
+	_, err := cache.get(context.Background())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "not set or empty")
+	require.Contains(t, err.Error(), "\"OP_SERVICE_ACCOUNT_TOKEN\" is not set or empty")
 }
 
-func TestOPClientCache_ReusesClientPerTokenEnv(t *testing.T) {
+func TestOPClientCache_ReusesClient(t *testing.T) {
 	calls := 0
 	cache := &opClientCache{
-		clients: make(map[string]opClient),
-		getenv:  func(string) string { return "tok" },
+		getenv: func(string) string { return "tok" },
 		newClient: func(_ context.Context, _ string) (opClient, error) {
 			calls++
 			return staticOPClient("v", nil), nil
 		},
 	}
 
-	_, err := cache.get(context.Background(), "ENV1")
+	_, err := cache.get(context.Background())
 	require.NoError(t, err)
-	_, err = cache.get(context.Background(), "ENV1")
+	_, err = cache.get(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, 1, calls, "second get on the same token_env should reuse the cached client")
-
-	_, err = cache.get(context.Background(), "ENV2")
-	require.NoError(t, err)
-	require.Equal(t, 2, calls, "different token_env should create a new client")
+	require.Equal(t, 1, calls, "repeated calls should reuse the cached client")
 }
 
 func TestOPClientCache_PropagatesNewClientError(t *testing.T) {
 	cache := &opClientCache{
-		clients: make(map[string]opClient),
-		getenv:  func(string) string { return "tok" },
+		getenv: func(string) string { return "tok" },
 		newClient: func(_ context.Context, _ string) (opClient, error) {
 			return nil, fmt.Errorf("sdk init failed")
 		},
 	}
 
-	_, err := cache.get(context.Background(), "ENV")
+	_, err := cache.get(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "sdk init failed")
 }

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -218,12 +218,10 @@ transforms:
         # Replace mode with 1Password Connect (self-hosted Connect server).
         # secret_ref uses the same op:// syntax as the 1password source. The
         # Connect server URL is read from OP_CONNECT_HOST and the API token
-        # from OP_CONNECT_TOKEN by default; override with host_env / token_env.
+        # from OP_CONNECT_TOKEN.
         # - source:
         #     type: 1password_connect
         #     secret_ref: "op://Engineering/OpenAI/credential"
-        #     host_env: OP_CONNECT_HOST    # optional; this is the default
-        #     token_env: OP_CONNECT_TOKEN  # optional; this is the default
         #     ttl: "15m"                   # optional, re-fetch interval; 0 = no refresh
         #   replace:
         #     proxy_value: "proxy-token-1pc"

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -202,12 +202,11 @@ transforms:
         #     - host: "api.example.com"
 
         # Replace mode with 1Password (service account token auth). The token
-        # is read from the OP_SERVICE_ACCOUNT_TOKEN env var by default; override
-        # with token_env. secret_ref uses 1Password's secret reference syntax.
+        # is read from the OP_SERVICE_ACCOUNT_TOKEN env var. secret_ref uses
+        # 1Password's secret reference syntax.
         # - source:
         #     type: 1password
         #     secret_ref: "op://Engineering/OpenAI/credential"
-        #     token_env: OP_SERVICE_ACCOUNT_TOKEN  # optional; this is the default
         #     ttl: "15m"                            # optional, re-fetch interval; 0 = no refresh
         #   replace:
         #     proxy_value: "proxy-token-1p"


### PR DESCRIPTION
Removes the `host_env` and `token_env` config knobs from the `1password` and `1password_connect` sources (and matching broker stores). These overrides were never used in practice; the SDK conventions (`OP_SERVICE_ACCOUNT_TOKEN`, `OP_CONNECT_HOST`, `OP_CONNECT_TOKEN`) are now hardcoded. Per-env-name client caches collapse to a single lazily-built client.