### PR TITLE
ci: release iron-token-broker on prefixed iron-token-broker/v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "iron-token-broker/v*"
   pull_request:
     branches: [main]
 
@@ -34,22 +35,41 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        if: (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/iron-token-broker/v')) && !contains(github.ref, '-')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (iron-proxy)
+        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
+          distribution: goreleaser-pro
           version: latest
           args: >-
             release
+            --config .goreleaser.yml
             ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' || '' }}
             --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Run GoReleaser (iron-token-broker)
+        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/iron-token-broker/v')
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: >-
+            release
+            --config .goreleaser.iron-token-broker.yml
+            ${{ !startsWith(github.ref, 'refs/tags/iron-token-broker/v') && '--snapshot' || '' }}
+            --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
         if: always()

--- a/.goreleaser.iron-token-broker.yml
+++ b/.goreleaser.iron-token-broker.yml
@@ -1,0 +1,46 @@
+version: 2
+
+monorepo:
+  tag_prefix: iron-token-broker/
+  dir: .
+
+dist: dist/iron-token-broker
+
+builds:
+  - id: iron-token-broker
+    main: ./cmd/iron-token-broker
+    binary: iron-token-broker
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
+
+archives:
+  - id: iron-token-broker
+    ids:
+      - iron-token-broker
+    formats: ["tar.gz"]
+    name_template: "iron-token-broker_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+dockers_v2:
+  - id: iron-token-broker
+    ids:
+      - iron-token-broker
+    images:
+      - "ironsh/iron-token-broker"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    dockerfile: Dockerfile.broker.release
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,23 +1,11 @@
 version: 2
 
+dist: dist/iron-proxy
+
 builds:
   - id: iron-proxy
     main: ./cmd/iron-proxy
     binary: iron-proxy
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    ldflags:
-      - -s -w -X github.com/ironsh/iron-proxy/internal/version.Version={{.Version}}
-
-  - id: iron-token-broker
-    main: ./cmd/iron-token-broker
-    binary: iron-token-broker
     env:
       - CGO_ENABLED=0
     goos:
@@ -36,12 +24,6 @@ archives:
     formats: ["tar.gz"]
     name_template: "iron-proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
-  - id: iron-token-broker
-    ids:
-      - iron-token-broker
-    formats: ["tar.gz"]
-    name_template: "iron-token-broker_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-
 dockers_v2:
   - id: iron-proxy
     ids:
@@ -52,16 +34,6 @@ dockers_v2:
       - "{{ .Version }}"
       - "latest"
     dockerfile: Dockerfile.release
-
-  - id: iron-token-broker
-    ids:
-      - iron-token-broker
-    images:
-      - "ironsh/iron-token-broker"
-    tags:
-      - "{{ .Version }}"
-      - "latest"
-    dockerfile: Dockerfile.broker.release
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Splits the goreleaser config so iron-token-broker uses Goreleaser Pro's `monorepo.tag_prefix` and releases on its own `iron-token-broker/v*` tags, independent of iron-proxy's `v*` cadence. The release workflow now triggers on both tag patterns and runs each goreleaser config conditionally; PRs still snapshot both. Requires a `GORELEASER_KEY` repo secret for the Pro distribution.