### PR TITLE
ci: split release workflow per binary and allow gumroad egress

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  iron-proxy:
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,14 +36,13 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
-        if: (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/iron-token-broker/v')) && !contains(github.ref, '-')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Run GoReleaser (iron-proxy)
-        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser-pro
@@ -56,8 +56,40 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
+      - uses: ironsh/iron-proxy-action/summary@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
+        if: always()
+
+  iron-token-broker:
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/iron-token-broker/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ironsh/iron-proxy-action@fa1fd82ec32396d044deba7040a6db576bec927a # v0.1.4
+        with:
+          egress-rules: egress-rules.yaml
+          disable-docker: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Docker Hub
+        if: startsWith(github.ref, 'refs/tags/iron-token-broker/v') && !contains(github.ref, '-')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
       - name: Run GoReleaser (iron-token-broker)
-        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/iron-token-broker/v')
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser-pro

--- a/egress-rules.yaml
+++ b/egress-rules.yaml
@@ -30,6 +30,7 @@ domains:
   # GoReleaser
   - "goreleaser.com"
   - "*.goreleaser.com"
+  - "api.gumroad.com" # GoReleaser Pro license validation
 
   # AWS (for integration tests)
   - "secretsmanager.us-west-1.amazonaws.com"


### PR DESCRIPTION
Splits the release workflow into separate `iron-proxy` and `iron-token-broker` jobs, each gated by its own tag prefix. Also adds `api.gumroad.com` to the egress allowlist so GoReleaser Pro can validate its license.