### PR TITLE
fix(ci): always log in to Docker Hub on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Docker Hub
-        if: startsWith(github.ref, 'refs/tags/iron-token-broker/v') && !contains(github.ref, '-')
+        if: startsWith(github.ref, 'refs/tags/iron-token-broker/v')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.goreleaser.iron-token-broker.yml
+++ b/.goreleaser.iron-token-broker.yml
@@ -36,7 +36,7 @@ dockers_v2:
       - "ironsh/iron-token-broker"
     tags:
       - "{{ .Version }}"
-      - "latest"
+      - '{{ if not .Prerelease }}latest{{ end }}'
     dockerfile: Dockerfile.broker.release
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ dockers_v2:
       - "ironsh/iron-proxy"
     tags:
       - "{{ .Version }}"
-      - "latest"
+      - '{{ if not .Prerelease }}latest{{ end }}'
     dockerfile: Dockerfile.release
 
 checksum:


### PR DESCRIPTION
The prerelease guard `!contains(github.ref, '-')` always evaluated false for iron-token-broker tags because the ref prefix itself contains a dash, so the Docker Hub login step was silently skipped on every broker release. Dropped the guard on both jobs so prereleases also push, and gated the `latest` Docker tag on `.Prerelease` in both goreleaser configs so RC builds don't clobber it.