### PR TITLE
fix(release): auto-detect prereleases and scope broker changelog

### DIFF
--- a/.goreleaser.iron-token-broker.yml
+++ b/.goreleaser.iron-token-broker.yml
@@ -42,5 +42,17 @@ dockers_v2:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  prerelease: auto
+
 changelog:
   sort: asc
+  filters:
+    include:
+      - "(?i)broker"
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^style:"
+      - "^Merge"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,5 +38,8 @@ dockers_v2:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  prerelease: auto
+
 changelog:
   sort: asc


### PR DESCRIPTION
Sets `release.prerelease: auto` on both goreleaser configs so semver prerelease suffixes (`-rc.N`, `-alpha`, `-beta`) mark the GitHub release as prerelease and keep it off the "Latest" badge. The `iron-token-broker/v0.0.1-rc.1` release had to be flipped to prerelease by hand because of this.

Also scopes the iron-token-broker changelog via a commit-message include filter so the first release (and future releases that span unrelated iron-proxy commits between two broker tags) only lists broker-related commits.