### PR TITLE
fix(release): ignore broker tags when releasing iron-proxy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,10 @@ version: 2
 
 dist: dist/iron-proxy
 
+git:
+  ignore_tags:
+    - "^iron-token-broker/"
+
 builds:
   - id: iron-proxy
     main: ./cmd/iron-proxy


### PR DESCRIPTION
GoReleaser was picking `iron-token-broker/v*` as the previous tag when releasing iron-proxy, scoping the changelog to broker commits. The broker config sidesteps this via `monorepo.tag_prefix`, but the proxy config had no equivalent filter. Adds `git.ignore_tags` so iron-proxy releases skip broker-prefixed tags.