### PR TITLE
feat(broker): support token_endpoint_headers on credentials

### DIFF
--- a/README.iron-token-broker.md
+++ b/README.iron-token-broker.md
@@ -168,6 +168,22 @@ sources from iron-proxy's `internal/transform/secrets` package, including
 `env` (which the store side cannot use because environment variables are
 not writable).
 
+Vendors that require an extra header on the token endpoint (e.g.
+`x-api-key` alongside the standard form-body client auth) can declare it
+under `token_endpoint_headers`. The shape matches the oauth_token
+transform's option of the same name: each value is a discrete secret
+source, header names go on the wire verbatim.
+
+```yaml
+credentials:
+  - id: example
+    token_endpoint: https://idp.example.com/oauth/token
+    client_id: {type: env, var: EXAMPLE_CLIENT_ID}
+    token_endpoint_headers:
+      x-api-key: {type: env, var: EXAMPLE_API_KEY}
+    store: {type: file, path: /var/lib/iron-token-broker/example.json}
+```
+
 ## Deployment patterns
 
 - **One broker per credential id, always.** The store is a dumb

--- a/internal/broker/config/config.go
+++ b/internal/broker/config/config.go
@@ -84,6 +84,12 @@ type Credential struct {
 	ClientSecret yaml.Node `yaml:"client_secret,omitempty"`
 	Store        yaml.Node `yaml:"store"`
 
+	// TokenEndpointHeaders is a map of header name to secret source. Each
+	// resolved value is sent as a request header on the token POST itself.
+	// Mirrors the oauth_token transform's token_endpoint_headers — some
+	// vendors require an api-key header alongside client_id/client_secret.
+	TokenEndpointHeaders map[string]yaml.Node `yaml:"token_endpoint_headers,omitempty"`
+
 	// Per-credential overrides for the broker-level defaults.
 	EarlyRefreshSlack    Duration `yaml:"early_refresh_slack,omitempty"`
 	EarlyRefreshFraction float64  `yaml:"early_refresh_fraction,omitempty"`
@@ -218,6 +224,11 @@ func Validate(cfg *Config) error {
 		if c.RefreshTimeout < 0 {
 			return fmt.Errorf("credentials[%q].refresh_timeout must be non-negative", c.ID)
 		}
+		for name := range c.TokenEndpointHeaders {
+			if name == "" {
+				return fmt.Errorf("credentials[%q].token_endpoint_headers: header name must not be empty", c.ID)
+			}
+		}
 	}
 	return nil
 }
@@ -233,6 +244,12 @@ type BuiltCredential struct {
 	ClientID      secrets.Source
 	ClientSecret  secrets.Source // nil for public clients
 	Store         store.Handle
+
+	// TokenEndpointHeaders holds resolved secret sources for headers sent
+	// on the refresh POST itself, keyed by header name. Header names are
+	// kept verbatim so vendors that demand a specific casing get it on
+	// the wire.
+	TokenEndpointHeaders map[string]secrets.Source
 
 	EarlyRefreshSlack    time.Duration
 	EarlyRefreshFraction float64
@@ -264,6 +281,17 @@ func BuildCredentials(cfg *Config, logger *slog.Logger) ([]BuiltCredential, erro
 		if err != nil {
 			return nil, fmt.Errorf("credentials[%q].store: %w", c.ID, err)
 		}
+		var endpointHeaders map[string]secrets.Source
+		if len(c.TokenEndpointHeaders) > 0 {
+			endpointHeaders = make(map[string]secrets.Source, len(c.TokenEndpointHeaders))
+			for name, node := range c.TokenEndpointHeaders {
+				src, err := secrets.BuildSource(node, logger)
+				if err != nil {
+					return nil, fmt.Errorf("credentials[%q].token_endpoint_headers[%q]: %w", c.ID, name, err)
+				}
+				endpointHeaders[name] = src
+			}
+		}
 		out = append(out, BuiltCredential{
 			ID:                   c.ID,
 			TokenEndpoint:        c.TokenEndpoint,
@@ -271,6 +299,7 @@ func BuildCredentials(cfg *Config, logger *slog.Logger) ([]BuiltCredential, erro
 			ClientID:             clientID,
 			ClientSecret:         clientSecret,
 			Store:                handle,
+			TokenEndpointHeaders: endpointHeaders,
 			EarlyRefreshSlack:    nonZero(time.Duration(c.EarlyRefreshSlack), time.Duration(cfg.Defaults.EarlyRefreshSlack)),
 			EarlyRefreshFraction: nonZeroFloat(c.EarlyRefreshFraction, cfg.Defaults.EarlyRefreshFraction),
 			MaxRefreshInterval:   nonZero(time.Duration(c.MaxRefreshInterval), time.Duration(cfg.Defaults.MaxRefreshInterval)),

--- a/internal/broker/config/config_test.go
+++ b/internal/broker/config/config_test.go
@@ -122,6 +122,48 @@ credentials:
 	}
 }
 
+func TestBuildCredentialsResolvesTokenEndpointHeaders(t *testing.T) {
+	t.Setenv("EXAMPLE_CLIENT_ID", "client-A")
+	t.Setenv("EXAMPLE_API_KEY", "venue-key")
+	cfg, err := loadYAML(t, `
+credentials:
+  - id: example
+    token_endpoint: https://idp.example/oauth/token
+    client_id:
+      type: env
+      var: EXAMPLE_CLIENT_ID
+    token_endpoint_headers:
+      x-api-key:
+        type: env
+        var: EXAMPLE_API_KEY
+    store:
+      type: file
+      path: `+filepath.Join(t.TempDir(), "creds.json")+`
+`)
+	require.NoError(t, err)
+	built, err := BuildCredentials(cfg, slog.Default())
+	require.NoError(t, err)
+	require.Len(t, built, 1)
+	require.Len(t, built[0].TokenEndpointHeaders, 1)
+	val, err := built[0].TokenEndpointHeaders["x-api-key"].Get(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "venue-key", val)
+}
+
+func TestLoadRejectsEmptyTokenEndpointHeaderName(t *testing.T) {
+	_, err := loadYAML(t, `
+credentials:
+  - id: example
+    token_endpoint: https://idp.example
+    client_id: {type: env, var: X}
+    store: {type: file, path: /tmp/x.json}
+    token_endpoint_headers:
+      "": {type: env, var: APIKEY}
+`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token_endpoint_headers")
+}
+
 func TestParseLogLevel(t *testing.T) {
 	for _, level := range []string{"debug", "info", "warn", "error"} {
 		_, err := ParseLogLevel(level)

--- a/internal/broker/credential.go
+++ b/internal/broker/credential.go
@@ -219,6 +219,17 @@ func (c *credentialState) refreshOnce(ctx context.Context) error {
 			return fmt.Errorf("resolving client_secret from %q: %w", c.cfg.ClientSecret.Name(), err)
 		}
 	}
+	var headers map[string]string
+	if len(c.cfg.TokenEndpointHeaders) > 0 {
+		headers = make(map[string]string, len(c.cfg.TokenEndpointHeaders))
+		for name, src := range c.cfg.TokenEndpointHeaders {
+			v, err := src.Get(ctx)
+			if err != nil {
+				return fmt.Errorf("resolving token_endpoint_headers[%q] from %q: %w", name, src.Name(), err)
+			}
+			headers[name] = v
+		}
+	}
 
 	start := c.now()
 	out, err := c.refresh.Refresh(ctx, refreshRequest{
@@ -227,6 +238,7 @@ func (c *credentialState) refreshOnce(ctx context.Context) error {
 		ClientSecret:  clientSecret,
 		RefreshToken:  prevBlob.RefreshToken,
 		Scopes:        c.cfg.Scopes,
+		Headers:       headers,
 	})
 	elapsed := c.now().Sub(start)
 	if err != nil {

--- a/internal/broker/credential_test.go
+++ b/internal/broker/credential_test.go
@@ -130,6 +130,42 @@ func TestCredentialFirstRefreshRotates(t *testing.T) {
 	require.Equal(t, "rt-1", persisted.RefreshToken)
 }
 
+func TestCredentialResolvesTokenEndpointHeaders(t *testing.T) {
+	bootstrap := store.CredentialBlob{
+		RefreshToken: "rt-0",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+		LastRefresh:  time.Now().Add(-time.Hour),
+	}
+	handle, _ := newFileHandle(t, bootstrap)
+
+	var seenHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"at-1","refresh_token":"rt-1","expires_in":3600}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	built := config.BuiltCredential{
+		ID:            "test",
+		TokenEndpoint: srv.URL,
+		ClientID:      newConstantSource("client_id", "client-A"),
+		Store:         handle,
+		TokenEndpointHeaders: map[string]secrets.Source{
+			"x-api-key": newConstantSource("apikey", "venue-key"),
+		},
+		EarlyRefreshSlack:    1 * time.Minute,
+		EarlyRefreshFraction: 0.2,
+		MaxRefreshInterval:   24 * time.Hour,
+		RefreshTimeout:       5 * time.Second,
+	}
+	c := newCredentialState(built, slog.Default(), newMetrics(), &http.Client{Timeout: 5 * time.Second})
+	require.NoError(t, c.load(t.Context()))
+	require.NoError(t, c.refreshOnce(t.Context()))
+
+	require.Equal(t, "venue-key", seenHeaders.Get("X-Api-Key"))
+}
+
 func TestCredentialInvalidGrantMarksDead(t *testing.T) {
 	bootstrap := store.CredentialBlob{RefreshToken: "rt-0"}
 	handle, _ := newFileHandle(t, bootstrap)

--- a/internal/broker/refresh.go
+++ b/internal/broker/refresh.go
@@ -31,6 +31,10 @@ type refreshRequest struct {
 	ClientSecret  string // empty for public clients
 	RefreshToken  string
 	Scopes        []string // optional
+	// Headers are extra request headers to set on the token POST itself.
+	// Used for vendors that require an api-key header alongside the form
+	// body. Header names go on the wire verbatim.
+	Headers map[string]string
 }
 
 // refreshClient performs the raw RFC 6749 4.5 refresh_token grant POST and
@@ -79,6 +83,15 @@ func (rc *refreshClient) Refresh(ctx context.Context, req refreshRequest) (refre
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	httpReq.Header.Set("Accept", "application/json")
+	// Vendor-specific headers (e.g. x-api-key) bypass Header.Set so the
+	// operator-supplied casing reaches the wire verbatim. Go's net/http
+	// writes Header map keys as-is, but Set canonicalizes via
+	// textproto.CanonicalMIMEHeaderKey, which would rewrite "x-api-key"
+	// to "X-Api-Key". A handful of IdP gateways validate the lowercase
+	// form and reject the canonical one.
+	for k, v := range req.Headers {
+		httpReq.Header[k] = []string{v}
+	}
 
 	resp, err := rc.http.Do(httpReq)
 	if err != nil {

--- a/internal/broker/refresh_test.go
+++ b/internal/broker/refresh_test.go
@@ -1,10 +1,13 @@
 package broker
 
 import (
+	"bufio"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -49,6 +52,91 @@ func TestRefreshSuccessRotatesToken(t *testing.T) {
 	require.Contains(t, seenForm, "client_id=client-A")
 	require.Contains(t, seenForm, "client_secret=secret-A")
 	require.Contains(t, seenForm, "scope=a+b")
+}
+
+func TestRefreshSendsTokenEndpointHeaders(t *testing.T) {
+	var seenHeaders http.Header
+	srv := newRefreshTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seenHeaders = r.Header.Clone()
+		_, _ = io.WriteString(w, `{"access_token":"at","expires_in":60}`)
+	})
+
+	rc := newRefreshClient(nil)
+	_, err := rc.Refresh(t.Context(), refreshRequest{
+		TokenEndpoint: srv.URL,
+		ClientID:      "c",
+		RefreshToken:  "rt",
+		Headers: map[string]string{
+			"x-api-key": "venue-api-key",
+			"x-tenant":  "acme",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "venue-api-key", seenHeaders.Get("X-Api-Key"))
+	require.Equal(t, "acme", seenHeaders.Get("X-Tenant"))
+	// Defaults still present.
+	require.Equal(t, "application/x-www-form-urlencoded", seenHeaders.Get("Content-Type"))
+	require.Equal(t, "application/json", seenHeaders.Get("Accept"))
+}
+
+// TestRefreshPreservesHeaderCasing reads the raw HTTP request bytes off
+// the wire to verify that operator-supplied header names land in their
+// original casing — a handful of IdP gateways validate the lowercase
+// form and reject Go's canonical "X-Api-Key".
+func TestRefreshPreservesHeaderCasing(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	requestLine := make(chan []string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		br := bufio.NewReader(conn)
+		var lines []string
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if line == "" {
+				break
+			}
+			lines = append(lines, line)
+		}
+		requestLine <- lines
+		// Drain the body and reply 200 so the client doesn't error first.
+		body := `{"access_token":"at","expires_in":60}`
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Length: "+
+			strconv.Itoa(len(body))+"\r\n\r\n"+body)
+	}()
+
+	rc := newRefreshClient(&http.Client{Timeout: 2 * time.Second})
+	_, err = rc.Refresh(t.Context(), refreshRequest{
+		TokenEndpoint: "http://" + ln.Addr().String(),
+		ClientID:      "c",
+		RefreshToken:  "rt",
+		Headers: map[string]string{
+			"x-api-key":   "venue-key",
+			"X-Tenant-ID": "acme",
+		},
+	})
+	require.NoError(t, err)
+
+	select {
+	case lines := <-requestLine:
+		joined := strings.Join(lines, "\n")
+		require.Contains(t, joined, "x-api-key: venue-key",
+			"operator-supplied lowercase header must reach the wire verbatim, got:\n%s", joined)
+		require.Contains(t, joined, "X-Tenant-ID: acme",
+			"operator-supplied mixed-case header must reach the wire verbatim, got:\n%s", joined)
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive the request")
+	}
 }
 
 func TestRefreshOmitsEmptyClientSecret(t *testing.T) {

--- a/internal/transform/oauth/grant.go
+++ b/internal/transform/oauth/grant.go
@@ -147,8 +147,13 @@ func (t *headerInjectingTransport) RoundTrip(req *http.Request) (*http.Response,
 	// Clone before mutating: the oauth2 lib may retry, and we must not leak
 	// header mutations back to the caller's request object.
 	r := req.Clone(req.Context())
+	// Direct map assignment bypasses textproto.CanonicalMIMEHeaderKey so the
+	// operator-supplied casing reaches the wire verbatim. Go's net/http
+	// writes Header map keys as-is, but Set would rewrite "x-api-key" to
+	// "X-Api-Key" — a handful of IdP gateways validate the lowercase form
+	// and reject the canonical one.
 	for k, v := range t.headers {
-		r.Header.Set(k, v)
+		r.Header[k] = []string{v}
 	}
 	return t.base.RoundTrip(r)
 }

--- a/internal/transform/oauth/oauth_test.go
+++ b/internal/transform/oauth/oauth_test.go
@@ -792,9 +792,11 @@ tokens:
 	_, err := o.TransformRequest(context.Background(), newContext(), req)
 	require.NoError(t, err)
 
-	// Header casing preserved verbatim. Go's http.Header canonicalizes on Get,
-	// but the wire bytes use the original "x-api-key" since we Set on a cloned
-	// request inside our RoundTripper, then the server canonicalizes on read.
+	// httptest can't observe wire-level casing (the server parses through
+	// textproto, which canonicalizes); the wire-level preservation guarantee
+	// is exercised by the broker's TestRefreshPreservesHeaderCasing, which
+	// uses a raw TCP listener. Here we just confirm the value reached the
+	// token endpoint at all.
 	require.Equal(t, "venue-api-key", srv.LastHeaders().Get("X-Api-Key"))
 	// The inbound request itself must not have received the header.
 	require.Empty(t, req.Header.Get("X-Api-Key"))

--- a/iron-token-broker.example.yaml
+++ b/iron-token-broker.example.yaml
@@ -66,3 +66,17 @@ credentials:
       type: aws_sm
       secret_id: iron-broker/okta/credential_blob
       region: us-east-1
+
+  # A vendor that requires an api-key header on the token endpoint in
+  # addition to the standard form-body client_id/client_secret. Mirrors
+  # the oauth_token transform's token_endpoint_headers: each value is a
+  # discrete secret source, header names go on the wire verbatim.
+  - id: example-vendor
+    token_endpoint: https://api.example-vendor.com/oauth/token
+    client_id:     {type: env, var: EXAMPLE_VENDOR_CLIENT_ID}
+    client_secret: {type: env, var: EXAMPLE_VENDOR_CLIENT_SECRET}
+    token_endpoint_headers:
+      x-api-key: {type: env, var: EXAMPLE_VENDOR_API_KEY}
+    store:
+      type: file
+      path: /var/lib/iron-token-broker/example-vendor.json


### PR DESCRIPTION
Mirrors the oauth_token transform's `token_endpoint_headers` map on the broker so credentials that need a vendor-specific header (e.g. `x-api-key`) alongside the standard form-body client auth can declare it. Each entry is a discrete secret source resolved per refresh, so a rotated value picks up without restart.

Also fixes a latent bug in both the broker's new refresh path and the oauth_token transport: `http.Header.Set` was canonicalizing operator-supplied header names ("x-api-key" → "X-Api-Key") even though the existing comment claimed casing was preserved. Both now use direct map assignment so the original casing reaches the wire. The broker carries the wire-level test (raw `net.Listen`) since httptest's parser canonicalizes on read.