### PR TITLE
refactor(integration_test): consolidate shared helpers

### DIFF
--- a/integration_test/aws_sm_test.go
+++ b/integration_test/aws_sm_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,50 +10,27 @@ import (
 // TestAWSSecretsManager boots the proxy with real AWS Secrets Manager secrets
 // and verifies that proxy tokens in request headers are swapped for real values.
 func TestAWSSecretsManager(t *testing.T) {
-	tmpDir := t.TempDir()
-	binary := proxyBinary(t)
+	cases := []struct {
+		name, header, sent, want string
+	}{
+		{"raw_secret", "X-Raw-Secret", "proxy-raw-secret", "example-value"},
+		{"kv_secret", "X-KV-Secret", "proxy-kv-secret", "example-value"},
+	}
 
-	// Upstream: echoes back the secret headers so we can verify the swap.
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Got-Raw-Secret", r.Header.Get("X-Raw-Secret"))
-		w.Header().Set("X-Got-KV-Secret", r.Header.Get("X-KV-Secret"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
+	headers := make([]string, len(cases))
+	for i, tc := range cases {
+		headers[i] = tc.header
+	}
+	upstreamHost := echoHeadersUpstream(t, headers...)
 
-	cfgPath := renderConfig(t, tmpDir, "aws_sm.yaml", nil)
-	proxy := startProxy(t, binary, cfgPath, nil)
-	upstreamHost := upstream.Listener.Addr().String()
+	cfgPath := renderConfig(t, t.TempDir(), "aws_sm.yaml", nil)
+	proxy := startProxy(t, proxyBinary(t), cfgPath, nil)
 
-	t.Run("raw_secret", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-Raw-Secret", "proxy-raw-secret")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "example-value", resp.Header.Get("X-Got-Raw-Secret"))
-	})
-
-	t.Run("kv_secret", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-KV-Secret", "proxy-kv-secret")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "example-value", resp.Header.Get("X-Got-KV-Secret"))
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, hdr := proxyGet(t, proxy.HTTPAddr, upstreamHost, map[string]string{tc.header: tc.sent})
+			require.Equal(t, http.StatusOK, status)
+			require.Equal(t, tc.want, hdr.Get(echoedHeaderName(tc.header)))
+		})
+	}
 }

--- a/integration_test/aws_ssm_test.go
+++ b/integration_test/aws_ssm_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,50 +10,27 @@ import (
 // TestAWSSystemsManagerParameterStore boots the proxy with real AWS SSM
 // Parameter Store parameters and verifies proxy token replacement.
 func TestAWSSystemsManagerParameterStore(t *testing.T) {
-	tmpDir := t.TempDir()
-	binary := proxyBinary(t)
+	cases := []struct {
+		name, header, sent, want string
+	}{
+		{"raw_parameter", "X-Raw-Param", "proxy-raw-param", "example_raw_value"},
+		{"json_parameter", "X-JSON-Param", "proxy-json-param", "example_value"},
+	}
 
-	// Upstream: echoes back the parameter headers so we can verify the swap.
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Got-Raw-Param", r.Header.Get("X-Raw-Param"))
-		w.Header().Set("X-Got-JSON-Param", r.Header.Get("X-JSON-Param"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
+	headers := make([]string, len(cases))
+	for i, tc := range cases {
+		headers[i] = tc.header
+	}
+	upstreamHost := echoHeadersUpstream(t, headers...)
 
-	cfgPath := renderConfig(t, tmpDir, "aws_ssm.yaml", nil)
-	proxy := startProxy(t, binary, cfgPath, nil)
-	upstreamHost := upstream.Listener.Addr().String()
+	cfgPath := renderConfig(t, t.TempDir(), "aws_ssm.yaml", nil)
+	proxy := startProxy(t, proxyBinary(t), cfgPath, nil)
 
-	t.Run("raw_parameter", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-Raw-Param", "proxy-raw-param")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "example_raw_value", resp.Header.Get("X-Got-Raw-Param"))
-	})
-
-	t.Run("json_parameter", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-JSON-Param", "proxy-json-param")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "example_value", resp.Header.Get("X-Got-JSON-Param"))
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, hdr := proxyGet(t, proxy.HTTPAddr, upstreamHost, map[string]string{tc.header: tc.sent})
+			require.Equal(t, http.StatusOK, status)
+			require.Equal(t, tc.want, hdr.Get(echoedHeaderName(tc.header)))
+		})
+	}
 }

--- a/integration_test/gcp_auth_bigquery_cli_test.go
+++ b/integration_test/gcp_auth_bigquery_cli_test.go
@@ -34,10 +34,7 @@ import (
 // test_dataset.test_table with a test_field column readable by the configured
 // service account.
 func TestGCPAuthBigQueryGcloudCLI(t *testing.T) {
-	keyfilePath := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
-	if keyfilePath == "" {
-		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE not set")
-	}
+	keyfilePath := requireEnv(t, "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
 	gcloudBin, err := exec.LookPath("gcloud")
 	if err != nil {
 		t.Skip("gcloud CLI not found on PATH")

--- a/integration_test/gcp_auth_bigquery_test.go
+++ b/integration_test/gcp_auth_bigquery_test.go
@@ -31,10 +31,7 @@ import (
 // Requires a BigQuery table at test_dataset.test_table with a test_field
 // column readable by the configured service account.
 func TestGCPAuthBigQuery(t *testing.T) {
-	keyfilePath := os.Getenv("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
-	if keyfilePath == "" {
-		t.Skip("GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE not set")
-	}
+	keyfilePath := requireEnv(t, "GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
 	keyJSON, err := os.ReadFile(keyfilePath)
 	require.NoError(t, err, "reading GCP_BIGQUERY_SERVICE_ACCOUNT_KEY_FILE")
 

--- a/integration_test/helpers_test.go
+++ b/integration_test/helpers_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +22,60 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// echoHeadersUpstream starts an httptest.Server that copies each named request
+// header into a response header of the same name with "Got-" inserted after
+// the leading "X-" (so "X-Foo-Secret" is echoed back as "X-Got-Foo-Secret").
+// Returns the upstream's host:port. The server is closed on test cleanup.
+func echoHeadersUpstream(t *testing.T, headers ...string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, h := range headers {
+			w.Header().Set(echoedHeaderName(h), r.Header.Get(h))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
+}
+
+// echoedHeaderName returns the response header name used by echoHeadersUpstream
+// for a given request header: "X-Foo" -> "X-Got-Foo".
+func echoedHeaderName(h string) string {
+	if rest, ok := strings.CutPrefix(h, "X-"); ok {
+		return "X-Got-" + rest
+	}
+	return "X-Got-" + h
+}
+
+// proxyGet sends a GET through proxyAddr with Host=upstreamHost and the given
+// request headers, drains the body, and returns the status code and response
+// headers. Fails the test on transport errors.
+func proxyGet(t *testing.T, proxyAddr, upstreamHost string, reqHeaders map[string]string) (int, http.Header) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "http://"+proxyAddr+"/", nil)
+	require.NoError(t, err)
+	req.Host = upstreamHost
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, resp.Header
+}
+
+// requireEnv returns the value of envVar, calling t.Skip if it is empty.
+func requireEnv(t *testing.T, envVar string) string {
+	t.Helper()
+	v := os.Getenv(envVar)
+	if v == "" {
+		t.Skipf("%s not set; skipping", envVar)
+	}
+	return v
+}
 
 // generateServiceAccountKeyPEM returns a freshly-minted RSA private key in
 // PEM (PKCS#8) form, suitable for embedding in a service-account JSON keyfile.

--- a/integration_test/judge_test.go
+++ b/integration_test/judge_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -94,10 +93,7 @@ type judgeFixture struct {
 // envVarName is unset so local runs without the secret pass cleanly.
 func setupJudgeFixture(t *testing.T, configTemplate, envVarName string) *judgeFixture {
 	t.Helper()
-	apiKey := os.Getenv(envVarName)
-	if apiKey == "" {
-		t.Skipf("%s not set; skipping real-LLM judge integration test", envVarName)
-	}
+	apiKey := requireEnv(t, envVarName)
 
 	hits := make(chan upstreamHit, 8)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/integration_test/management_reload_test.go
+++ b/integration_test/management_reload_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -34,12 +34,11 @@ func TestManagementReload(t *testing.T) {
 	t.Setenv("IRON_RELOAD_ITEST_API_KEY", apiKey)
 
 	// Upstream: echoes back the secret header so we can verify the swap.
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Got-Reload-Secret", r.Header.Get("X-Reload-Secret"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-	upstreamPort := upstream.Listener.Addr().(*net.TCPAddr).Port
+	upstreamHost := echoHeadersUpstream(t, "X-Reload-Secret")
+	_, port, err := net.SplitHostPort(upstreamHost)
+	require.NoError(t, err)
+	upstreamPort, err := strconv.Atoi(port)
+	require.NoError(t, err)
 
 	// In-process DNS server that resolves host-a.test and host-b.test to
 	// 127.0.0.1. The proxy's upstream_resolver is pointed at this so the
@@ -57,14 +56,16 @@ func TestManagementReload(t *testing.T) {
 	hostA := fmt.Sprintf("host-a.test:%d", upstreamPort)
 	hostB := fmt.Sprintf("host-b.test:%d", upstreamPort)
 
+	reloadHeaders := map[string]string{"X-Reload-Secret": "proxy-reload-token"}
+
 	t.Run("config_a_active", func(t *testing.T) {
 		// host-a.test is allowed and its secret is swapped.
-		got, status := doSecretRequest(t, proxy.HTTPAddr, hostA)
+		status, hdr := proxyGet(t, proxy.HTTPAddr, hostA, reloadHeaders)
 		require.Equal(t, http.StatusOK, status)
-		require.Equal(t, secretValueA, got)
+		require.Equal(t, secretValueA, hdr.Get("X-Got-Reload-Secret"))
 
 		// host-b.test is rejected by config A's allowlist.
-		_, status = doSecretRequest(t, proxy.HTTPAddr, hostB)
+		status, _ = proxyGet(t, proxy.HTTPAddr, hostB, reloadHeaders)
 		require.Equal(t, http.StatusForbidden, status)
 	})
 
@@ -86,34 +87,16 @@ func TestManagementReload(t *testing.T) {
 
 	t.Run("config_b_active", func(t *testing.T) {
 		// host-b.test is now allowed and its secret is swapped.
-		got, status := doSecretRequest(t, proxy.HTTPAddr, hostB)
+		status, hdr := proxyGet(t, proxy.HTTPAddr, hostB, reloadHeaders)
+		got := hdr.Get("X-Got-Reload-Secret")
 		require.Equal(t, http.StatusOK, status)
 		require.Equal(t, secretValueB, got)
 		require.NotEqual(t, secretValueA, got)
 
 		// host-a.test is now rejected by config B's allowlist.
-		_, status = doSecretRequest(t, proxy.HTTPAddr, hostA)
+		status, _ = proxyGet(t, proxy.HTTPAddr, hostA, reloadHeaders)
 		require.Equal(t, http.StatusForbidden, status)
 	})
-}
-
-// doSecretRequest sends a request through the proxy with the proxy-token in
-// the X-Reload-Secret header and returns the value the upstream observed
-// (echoed back via X-Got-Reload-Secret) along with the response status.
-// When the request is rejected by the proxy, the value will be empty.
-func doSecretRequest(t *testing.T, proxyAddr, hostHeader string) (string, int) {
-	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/", proxyAddr), nil)
-	require.NoError(t, err)
-	req.Host = hostHeader
-	req.Header.Set("X-Reload-Secret", "proxy-reload-token")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	_, err = io.Copy(io.Discard, resp.Body)
-	require.NoError(t, err)
-	return resp.Header.Get("X-Got-Reload-Secret"), resp.StatusCode
 }
 
 // startTestDNSResolver starts a tiny UDP DNS server on a random port that

--- a/integration_test/onepassword_connect_test.go
+++ b/integration_test/onepassword_connect_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,32 +11,14 @@ import (
 // server and verifies that proxy tokens in request headers are swapped for the
 // resolved value. Reuses the same vault and item as TestOnePassword.
 func TestOnePasswordConnect(t *testing.T) {
-	tmpDir := t.TempDir()
-	binary := proxyBinary(t)
+	upstreamHost := echoHeadersUpstream(t, "X-OP-Connect-Secret")
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Got-OP-Connect-Secret", r.Header.Get("X-OP-Connect-Secret"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	cfgPath := renderConfig(t, tmpDir, "onepassword_connect.yaml", nil)
-	proxy := startProxy(t, binary, cfgPath, nil)
-	upstreamHost := upstream.Listener.Addr().String()
+	cfgPath := renderConfig(t, t.TempDir(), "onepassword_connect.yaml", nil)
+	proxy := startProxy(t, proxyBinary(t), cfgPath, nil)
 
 	t.Run("op connect secret", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-OP-Connect-Secret", "proxy-op-connect-secret")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "1password-example-password", resp.Header.Get("X-Got-OP-Connect-Secret"))
+		status, hdr := proxyGet(t, proxy.HTTPAddr, upstreamHost, map[string]string{"X-OP-Connect-Secret": "proxy-op-connect-secret"})
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, "1password-example-password", hdr.Get("X-Got-OP-Connect-Secret"))
 	})
 }

--- a/integration_test/onepassword_test.go
+++ b/integration_test/onepassword_test.go
@@ -1,10 +1,7 @@
 package integration_test
 
 import (
-	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,33 +10,14 @@ import (
 // TestOnePassword boots the proxy with a real 1Password secret and verifies
 // that proxy tokens in request headers are swapped for the resolved value.
 func TestOnePassword(t *testing.T) {
-	tmpDir := t.TempDir()
-	binary := proxyBinary(t)
+	upstreamHost := echoHeadersUpstream(t, "X-OP-Secret")
 
-	// Upstream: echoes back the secret header so we can verify the swap.
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Got-OP-Secret", r.Header.Get("X-OP-Secret"))
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	cfgPath := renderConfig(t, tmpDir, "onepassword.yaml", nil)
-	proxy := startProxy(t, binary, cfgPath, nil)
-	upstreamHost := upstream.Listener.Addr().String()
+	cfgPath := renderConfig(t, t.TempDir(), "onepassword.yaml", nil)
+	proxy := startProxy(t, proxyBinary(t), cfgPath, nil)
 
 	t.Run("op_secret", func(t *testing.T) {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/", proxy.HTTPAddr), nil)
-		require.NoError(t, err)
-		req.Host = upstreamHost
-		req.Header.Set("X-OP-Secret", "proxy-op-secret")
-
-		resp, err := http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		require.NoError(t, err)
-
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "1password-example-password", resp.Header.Get("X-Got-OP-Secret"))
+		status, hdr := proxyGet(t, proxy.HTTPAddr, upstreamHost, map[string]string{"X-OP-Secret": "proxy-op-secret"})
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, "1password-example-password", hdr.Get("X-Got-OP-Secret"))
 	})
 }


### PR DESCRIPTION
Extracts `echoHeadersUpstream`, `proxyGet`, and `requireEnv` into `integration_test/helpers_test.go` and updates the AWS Secrets Manager, AWS SSM, GCP BigQuery, 1Password (Connect + CLI), judge, and management-reload tests to use them. Removes duplicated upstream/server setup and HTTP request boilerplate across the integration suite while preserving existing assertions.