### PR TITLE
fix(proxy): preserve percent-encoded reserved chars in upstream path

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -376,12 +377,17 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 
 	// Build upstream request. Use r.URL (which transforms may have modified)
-	// rather than r.RequestURI (which is immutable).
-	path := r.URL.Path
-	if r.URL.RawQuery != "" {
-		path = path + "?" + r.URL.RawQuery
-	}
-	upstreamURL := fmt.Sprintf("%s://%s%s", scheme, host, path)
+	// rather than r.RequestURI (which is immutable). Preserve RawPath so
+	// percent-encoded reserved characters like %2F survive to the upstream —
+	// some APIs (e.g. GCS object names) treat decoded vs encoded slashes as
+	// distinct path segments.
+	upstreamURL := (&url.URL{
+		Scheme:   scheme,
+		Host:     host,
+		Path:     r.URL.Path,
+		RawPath:  r.URL.RawPath,
+		RawQuery: r.URL.RawQuery,
+	}).String()
 
 	reqBody := transform.RequireBufferedBody(r.Body)
 	// Check Len() before StreamingReader(), which clears the original reader.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -777,6 +777,39 @@ func TestHTTPProxy_RejectsDotSegmentPaths(t *testing.T) {
 	require.False(t, upstreamHit, "upstream must not be reached for dot-segment paths")
 }
 
+// TestHTTPProxy_PreservesEscapedSlashes verifies that %2F in the request
+// path is forwarded to the upstream as %2F rather than being decoded to /.
+// Some APIs (e.g. GCS object names under /o/<object>) treat encoded vs
+// decoded slashes as distinct path segments. See issue #155.
+func TestHTTPProxy_PreservesEscapedSlashes(t *testing.T) {
+	var gotRequestURI string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequestURI = r.RequestURI
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	_, httpAddr, _, _ := startProxy(t)
+
+	// Send via raw TCP to keep the Go client from normalizing %2F.
+	conn, err := net.DialTimeout("tcp", httpAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const rawPath = "/download/storage/v1/b/bkt/o/dir%2Fsub%2Ffile.gz?alt=media"
+	rawReq := fmt.Sprintf("GET %s HTTP/1.1\r\nHost: %s\r\n\r\n",
+		rawPath, upstream.Listener.Addr().String())
+	_, err = conn.Write([]byte(rawReq))
+	require.NoError(t, err)
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 4096)
+	_, err = conn.Read(buf)
+	require.NoError(t, err)
+
+	require.Equal(t, rawPath, gotRequestURI)
+}
+
 func TestContainsDotSegments(t *testing.T) {
 	cases := []struct {
 		path string


### PR DESCRIPTION
The HTTP handler built the upstream URL from `r.URL.Path` (already decoded), so `%2F` and other percent-encoded reserved characters were collapsed before the upstream request was constructed. This broke APIs like GCS that route on encoded slashes within a single path segment (e.g. `/o/<object>` where the object name contains slashes). The fix constructs the upstream URL via `url.URL` with both `Path` and `RawPath` set so `EscapedPath` preserves the original encoding end-to-end.

Audited existing transforms: oauth/gcpauth/awsauth/hmacsign only read `URL.Path`; token_broker_resolver builds its own URL with `RawPath` set; secrets `swapPath` clears `RawPath` after substitution, which is fine for placeholder tokens but would re-encode a coexisting `%2F` in the same path (narrow edge case, predates this fix).

Fixes #155.