### PR TITLE
fix(awsauth): let CONNECT through the tunnel policy check

### DIFF
--- a/internal/transform/awsauth/awsauth.go
+++ b/internal/transform/awsauth/awsauth.go
@@ -221,6 +221,16 @@ func buildAllowSet(items []string) map[string]struct{} {
 func (a *AWSAuth) Name() string { return "aws_auth" }
 
 func (a *AWSAuth) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	// The proxy replays request transforms against a synthetic CONNECT request
+	// to make tunnel-level policy decisions before MITM (see proxy.tunnelTransformCheck).
+	// A CONNECT carries no SigV4 signature — the signed request only becomes
+	// visible after the tunnel is established and TLS is terminated. Rejecting
+	// it here would kill the tunnel before the real request is ever seen, so let
+	// CONNECT pass; signing happens on the post-MITM request that follows.
+	if req.Method == http.MethodConnect {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
 	if !hostmatch.MatchAnyRule(a.rules, req) {
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}

--- a/internal/transform/awsauth/awsauth_test.go
+++ b/internal/transform/awsauth/awsauth_test.go
@@ -392,6 +392,21 @@ rules:
 		require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
 	})
 
+	t.Run("lets a CONNECT through even for a matched host (signs the post-MITM request)", func(t *testing.T) {
+		a := buildTransformWith(t, minimalYAML, mapBuilder(srcs))
+		// The proxy replays transforms against a synthetic CONNECT to make
+		// tunnel-level policy decisions before MITM. A CONNECT carries no SigV4
+		// signature, so aws_auth must not reject it — the signed request only
+		// appears after the tunnel is established and TLS is terminated.
+		req, err := http.NewRequest(http.MethodConnect, "https://bedrock-runtime.us-east-1.amazonaws.com:443", nil)
+		require.NoError(t, err)
+
+		res, err := a.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+		require.Empty(t, req.Header.Get("Authorization"))
+	})
+
 	t.Run("allowed_services gates which services this entry will sign for", func(t *testing.T) {
 		a := buildTransformWith(t, `
 access_key_id:     {type: env, var: AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
The proxy replays request transforms against a synthetic CONNECT request to make tunnel-level policy decisions before MITM (proxy.tunnelTransformCheck). The aws_auth transform matched on host only and rejected any matched request lacking a SigV4 signature -- including that synthetic CONNECT, which can never carry one (the signed request only appears after the tunnel is established and TLS is terminated). That short-circuited the tunnel with 400/missing_sigv4 before the real, boto3-signed request was ever seen, so SigV4 re-signing never happened for HTTPS clients tunneling through a CONNECT proxy (e.g. boto3).

Return ActionContinue for CONNECT so the tunnel establishes; signing then happens on the post-MITM request that follows. allowlist/secrets already tolerate the synthetic CONNECT.