### PR TITLE
feat(postgres): allow multi-statement queries that pass the role policy

### DIFF
--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -265,13 +265,23 @@ func TestPostgresPolicy(t *testing.T) {
 		require.Contains(t, pgErr.Message, "managed by the proxy")
 	})
 
-	t.Run("multi statement is rejected", func(t *testing.T) {
+	t.Run("clean multi statement is allowed", func(t *testing.T) {
 		conn := dial(t, pgClientPassword)
 		err := exec(t, conn, "SELECT 1; SELECT 2")
+		require.NoError(t, err)
+		// Role policy still holds after a batch executes.
+		require.Equal(t, pgRole, currentRole(t, conn))
+	})
+
+	t.Run("multi statement with role change is rejected", func(t *testing.T) {
+		conn := dial(t, pgClientPassword)
+		err := exec(t, conn, "SELECT 1; SET ROLE other_role")
 		require.Error(t, err)
 		var pgErr *pgconn.PgError
 		require.True(t, errors.As(err, &pgErr))
-		require.Contains(t, pgErr.Message, "multi-statement")
+		require.Contains(t, pgErr.Message, "managed by the proxy")
+		// The batch was rejected before forwarding, so nothing took effect.
+		require.Equal(t, pgRole, currentRole(t, conn))
 	})
 
 	t.Run("set_config function call bypass is rejected", func(t *testing.T) {

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -17,9 +17,10 @@
 // While the relay is running the proxy is mostly transparent: it rejects only
 // client-issued role-changing statements (`SET ROLE`, `RESET ROLE`,
 // `SET SESSION AUTHORIZATION`, `RESET SESSION AUTHORIZATION`), the function-
-// call equivalents (`set_config('role', ...)`), DO blocks, and multi-statement
-// Simple Queries. Extended Query, COPY, and prepared statements pass through
-// unchanged.
+// call equivalents (`set_config('role', ...)`), and DO blocks. Multi-statement
+// Simple Queries are allowed as long as every statement passes the role policy;
+// a batch is rejected if any statement mutates the role or is a DO block.
+// Extended Query, COPY, and prepared statements pass through unchanged.
 //
 // Multiple servers are supported: the top-level postgres: key is a list, so
 // one proxy process can front several databases (each with its own listen

--- a/internal/postgres/policy.go
+++ b/internal/postgres/policy.go
@@ -10,9 +10,6 @@ const (
 	// SET ROLE / RESET ROLE / SET SESSION AUTHORIZATION / RESET SESSION AUTHORIZATION.
 	// The proxy sets the role at session start and forbids overrides.
 	RejectClientRoleChange RejectReason = iota + 1
-	// RejectMultiStatement — the client sent a multi-statement Simple Query.
-	// Rejected to keep policy decidable.
-	RejectMultiStatement
 	// RejectDoBlock — the client sent a DO $$ ... $$ anonymous code block.
 	// The plpgsql body is opaque to our SQL-level AST walker; rejecting
 	// avoids the risk of an embedded role change.
@@ -22,6 +19,10 @@ const (
 // ClassifyClientStatement inspects sql and returns whether the relay should
 // reject it before forwarding upstream. (reason == 0) means "allow".
 //
+// Multi-statement Simple Queries are allowed when every statement passes the
+// role policy; Classify rejects the batch if any statement mutates the role or
+// is a DO block.
+//
 // Used for both Simple Query bodies and the SQL string carried by Extended
 // Query Parse messages.
 func ClassifyClientStatement(sql string) (allowed bool, reason RejectReason) {
@@ -29,8 +30,6 @@ func ClassifyClientStatement(sql string) (allowed bool, reason RejectReason) {
 	switch op.Kind {
 	case OpSetRole, OpSetSessionAuthorization, OpResetRole, OpResetSessionAuthorization:
 		return false, RejectClientRoleChange
-	case OpMulti:
-		return false, RejectMultiStatement
 	case OpDoBlock:
 		// DO blocks contain opaque plpgsql we can't introspect from the SQL
 		// AST. Rather than risk an embedded role change slipping through,

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -27,8 +27,12 @@ func TestClassifyClientStatement(t *testing.T) {
 		{name: "set session authorization rejected", sql: "SET SESSION AUTHORIZATION admin", reason: RejectClientRoleChange},
 		{name: "reset session authorization rejected", sql: "RESET SESSION AUTHORIZATION", reason: RejectClientRoleChange},
 
-		{name: "multi statement rejected", sql: "SELECT 1; SELECT 2", reason: RejectMultiStatement},
-		{name: "multi statement with set role rejected as multi", sql: "SET ROLE x; SELECT 1", reason: RejectMultiStatement},
+		// Multi-statement batches are allowed when every statement passes the
+		// role policy, and rejected per-statement otherwise.
+		{name: "clean multi statement allowed", sql: "SELECT 1; SELECT 2", allowed: true},
+		{name: "multi statement with set role rejected", sql: "SET ROLE x; SELECT 1", reason: RejectClientRoleChange},
+		{name: "multi statement with trailing set role rejected", sql: "SELECT 1; SET ROLE x", reason: RejectClientRoleChange},
+		{name: "multi statement with do block rejected", sql: "SELECT 1; DO $$ BEGIN END $$", reason: RejectDoBlock},
 
 		// SET of other GUCs is fine — only role-changing statements are rejected.
 		{name: "set search_path allowed", sql: "SET search_path = public", allowed: true},

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -174,7 +174,7 @@ func completeClientHandshake(backend *pgproto3.Backend, hj *pgconn.HijackedConn)
 // after the role has been set on the upstream session.
 //
 // Two goroutines do socket I/O: c2s reads client messages and rejects
-// role-changing or multi-statement queries before forwarding everything else;
+// role-changing statements (and DO blocks) before forwarding everything else;
 // s2c is a pure passthrough.
 //
 // Writes to the client serialize through clientWriteMu since both goroutines
@@ -234,8 +234,7 @@ func (r *relay) run() {
 }
 
 // clientToServer reads frontend messages from the client and forwards them
-// upstream, rejecting only role-changing statements and multi-statement
-// Simple Queries.
+// upstream, rejecting only role-changing statements and DO blocks.
 func (r *relay) clientToServer() {
 	for {
 		msg, err := r.backend.Receive()
@@ -332,12 +331,6 @@ func (r *relay) writeClient(msgs ...pgproto3.BackendMessage) {
 // rejectError builds the ErrorResponse synthesized for a policy denial.
 func rejectError(reason RejectReason) *pgproto3.ErrorResponse {
 	switch reason {
-	case RejectMultiStatement:
-		return &pgproto3.ErrorResponse{
-			Severity: "ERROR",
-			Code:     "42601",
-			Message:  "blocked by iron-proxy policy: multi-statement queries not permitted",
-		}
 	case RejectDoBlock:
 		return &pgproto3.ErrorResponse{
 			Severity: "ERROR",

--- a/internal/postgres/sql.go
+++ b/internal/postgres/sql.go
@@ -41,9 +41,6 @@ const (
 	OpResetRole
 	// OpResetSessionAuthorization is the same for session_authorization.
 	OpResetSessionAuthorization
-	// OpMulti indicates the input contains more than one top-level statement.
-	// Rejected to keep the policy decidable.
-	OpMulti
 	// OpEmpty indicates a whitespace/comment-only input or no statements.
 	OpEmpty
 	// OpDoBlock is a DO $$ ... $$ block. The plpgsql body is opaque to our
@@ -109,31 +106,44 @@ func classifyUncached(sql string) Op {
 	if len(stmts) == 0 {
 		return Op{Kind: OpEmpty}
 	}
-	if len(stmts) > 1 {
-		return Op{Kind: OpMulti}
-	}
 
-	root := stmts[0].GetStmt()
-	if root == nil {
-		return Op{Kind: OpEmpty}
+	// Multi-statement Simple Queries are permitted as long as every statement
+	// passes the role policy. We classify each statement and reject the whole
+	// batch on the first one that mutates the role or is an (opaque) DO block.
+	// The relay forwards the batch unchanged when all statements are allowed;
+	// the upstream runs it as one implicit transaction.
+	for _, s := range stmts {
+		root := s.GetStmt()
+		if root == nil {
+			continue
+		}
+		if kind := classifyStmt(root); kind != OpOther {
+			return Op{Kind: kind}
+		}
 	}
+	return Op{Kind: OpOther}
+}
 
+// classifyStmt classifies a single statement's root node, returning the OpKind
+// of any role-mutating or otherwise-rejectable construct it finds, or OpOther
+// when the statement is allowed.
+func classifyStmt(root *pg_query.Node) OpKind {
 	// Top-level shape gives us a fast path for the common DDL/DML cases.
 	switch root.Node.(type) {
 	case *pg_query.Node_TransactionStmt:
 		// BEGIN / COMMIT / ROLLBACK / SAVEPOINT etc. — no role mutation.
-		return Op{Kind: OpOther}
+		return OpOther
 	case *pg_query.Node_DoStmt:
-		return Op{Kind: OpDoBlock}
+		return OpDoBlock
 	}
 
 	// Generic scan: any role-affecting node anywhere in the tree triggers a
 	// rejection. Covers SELECT set_config(...), PREPARE ... AS SET ROLE,
 	// CTEs, subqueries, INSERT...SELECT, function arguments, etc.
 	if kind := scanForRoleChange(root); kind != 0 {
-		return Op{Kind: kind}
+		return kind
 	}
-	return Op{Kind: OpOther}
+	return OpOther
 }
 
 // scanForRoleChange walks the AST rooted at node and returns the OpKind of

--- a/internal/postgres/sql_test.go
+++ b/internal/postgres/sql_test.go
@@ -46,9 +46,14 @@ func TestClassify(t *testing.T) {
 		{name: "start transaction", sql: "START TRANSACTION", want: OpOther},
 		{name: "savepoint", sql: "SAVEPOINT a", want: OpOther},
 
-		// Multi-statement
-		{name: "multi set then select", sql: "SET ROLE tenant; SELECT 1", want: OpMulti},
-		{name: "multi select then select", sql: "SELECT 1; SELECT 2", want: OpMulti},
+		// Multi-statement — classified per statement; the batch takes the
+		// verdict of its first rejectable statement, else OpOther.
+		{name: "multi set then select rejects on set role", sql: "SET ROLE tenant; SELECT 1", want: OpSetRole},
+		{name: "multi select then select allowed", sql: "SELECT 1; SELECT 2", want: OpOther},
+		{name: "multi benign then set role", sql: "SELECT 1; SET ROLE tenant", want: OpSetRole},
+		{name: "multi benign then do block", sql: "SELECT 1; DO $$ BEGIN END $$", want: OpDoBlock},
+		{name: "multi benign then set_config role", sql: "SELECT 1; SELECT set_config('role', 'admin', false)", want: OpSetRole},
+		{name: "multi non-role sets allowed", sql: "SET search_path = public; SELECT 1", want: OpOther},
 		// Trailing semicolon alone is *not* multi (pg_query collapses it).
 		{name: "trailing semicolon not multi", sql: "SET ROLE tenant;", want: OpSetRole},
 


### PR DESCRIPTION
Replaces the statement-count rejection in the Postgres proxy with per-statement classification. A multi-statement Simple Query is now forwarded as long as every statement passes the role policy; the batch is rejected if any statement mutates the role (`SET ROLE` / `set_config('role', ...)`) or is a DO block. The wire relay is unchanged since the `Query` passthrough already forwards the whole message and multiple result sets already stream back, so the upstream runs the batch as one implicit transaction. Removes the now-unused `OpMulti` / `RejectMultiStatement`.