### PR TITLE
feat(postgres): derive listeners from control-plane sync section

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -11,8 +11,10 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
 	"github.com/ironsh/iron-proxy/internal/config"
@@ -105,13 +107,27 @@ func main() {
 	// errc collects fatal errors from all background goroutines: servers
 	// and (in managed mode) the config poller.
 	errc := make(chan error, 5)
+
+	// Postgres listeners come from the local YAML postgres: block (self-managed
+	// proxies, inline DSNs) and, in managed mode, from env-derived listeners
+	// synced by the control plane. The manager is created up front so the
+	// config poller can hot-reload it; local policies are the base set that
+	// synced listeners are layered onto.
+	localPgPolicies, err := postgres.LoadFromNode(cfg.Postgres, logger)
+	if err != nil {
+		logger.Error("loading postgres config", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	pgManager := postgres.NewManager(logger)
+	pgPolicies := localPgPolicies
+
 	var holder *transform.PipelineHolder
 	var mcpHolder *mcp.PolicyHolder
 	var otelCfg iotel.ExportConfig
 
 	if managed {
 		var ingestToken string
-		holder, mcpHolder, ingestToken = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, logger)
+		holder, mcpHolder, ingestToken, pgPolicies = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgPolicies, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -189,13 +205,6 @@ func main() {
 			slog.Any("cidrs", cfg.Proxy.UpstreamDenyCIDRs.Values),
 		)
 	}
-
-	pgPolicies, err := postgres.LoadFromNode(cfg.Postgres, logger)
-	if err != nil {
-		logger.Error("loading postgres config", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	pgManager := postgres.NewManager(logger)
 
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
@@ -301,7 +310,7 @@ func main() {
 //
 // Initial MCP policy preference: control-plane-supplied mcp block first, then
 // fall back to cfg.MCP from the YAML if the sync did not include one.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgPolicies []*postgres.Policy, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, []*postgres.Policy) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -320,12 +329,13 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	configHash := ""
 	ingestToken := ""
-	var initialRules, initialSecrets, initialMCP json.RawMessage
+	var initialRules, initialSecrets, initialMCP, initialPostgres json.RawMessage
 	if syncResp != nil {
 		configHash = syncResp.ConfigHash
 		initialRules = syncResp.Rules
 		initialSecrets = syncResp.Secrets
 		initialMCP = syncResp.MCP
+		initialPostgres = syncResp.Postgres
 		ingestToken = syncResp.IngestToken
 		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 || len(syncResp.MCP) > 0 {
 			logger.Info("received initial config from control plane",
@@ -357,6 +367,14 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		os.Exit(1)
 	}
 
+	// Compute the initial postgres listener set: local YAML policies plus any
+	// synced listeners whose env vars are present. If the initial sync carried
+	// no postgres block (or an invalid one), fall back to the local policies.
+	pgPolicies := localPgPolicies
+	if policies, ok := postgresPoliciesFromSync(localPgPolicies, os.Getenv, logger, initialPostgres); ok {
+		pgPolicies = policies
+	}
+
 	// Start config poller.
 	poller := controlplane.NewPoller(client, configHash, func(u controlplane.SyncUpdate) error {
 		if u.Rules != nil || u.Secrets != nil {
@@ -365,6 +383,9 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		if u.MCP != nil {
 			applyMCPSync(mcpHolder, logger, u.MCP)
 		}
+		if u.Postgres != nil {
+			applyPostgresSync(ctx, pgManager, localPgPolicies, os.Getenv, logger, u.Postgres)
+		}
 		return nil
 	}, logger)
 
@@ -372,7 +393,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, mcpHolder, ingestToken
+	return holder, mcpHolder, ingestToken, pgPolicies
 }
 
 // buildInitialMCPHolder picks the initial MCP policy source: a control-plane
@@ -460,6 +481,90 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 	} else {
 		logger.Info("mcp policy reloaded")
 	}
+}
+
+// pgEnv returns the environment variable name carrying the given listener knob
+// for a control-plane-synced postgres upstream. foreignID is normalized to
+// env-safe form: uppercased, with '-', '.', and '~' mapped to '_' (the full set
+// of non-alphanumeric characters a foreign_id may contain). For foreignID
+// "pg-analytics" and suffix "LISTEN" the result is
+// "IRON_PROXY_PG_PG_ANALYTICS_LISTEN".
+func pgEnv(foreignID, suffix string) string {
+	norm := strings.Map(func(r rune) rune {
+		switch r {
+		case '-', '.', '~':
+			return '_'
+		default:
+			return unicode.ToUpper(r)
+		}
+	}, foreignID)
+	return "IRON_PROXY_PG_" + norm + "_" + suffix
+}
+
+// postgresPoliciesFromSync builds the full postgres policy set for managed mode:
+// the local YAML policies plus every control-plane-synced listener whose
+// LISTEN, CLIENT_USER, and CLIENT_PASSWORD env vars are all present. Local YAML
+// policies win on a foreign_id/name conflict, and the conflicting synced entry
+// is dropped with a log line. A synced entry missing any required env var is
+// skipped (also logged) — that is how a proxy granted a secret it isn't meant
+// to serve locally simply ignores it. Returns ok=false only when the sync
+// payload itself is invalid, signaling the caller to keep the current
+// listeners.
+func postgresPoliciesFromSync(local []*postgres.Policy, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) ([]*postgres.Policy, bool) {
+	entries, err := config.PostgresFromSync(raw, logger)
+	if err != nil {
+		logger.Error("rejecting invalid postgres config from sync, keeping current listeners", slog.String("error", err.Error()))
+		return nil, false
+	}
+
+	localNames := make(map[string]bool, len(local))
+	for _, p := range local {
+		localNames[p.Name()] = true
+	}
+
+	policies := make([]*postgres.Policy, 0, len(local)+len(entries))
+	policies = append(policies, local...)
+	for _, e := range entries {
+		if localNames[e.ForeignID] {
+			logger.Warn("postgres listener defined in both local config and control plane; keeping local",
+				slog.String("foreign_id", e.ForeignID))
+			continue
+		}
+		listen := getenv(pgEnv(e.ForeignID, "LISTEN"))
+		clientUser := getenv(pgEnv(e.ForeignID, "CLIENT_USER"))
+		clientPassword := getenv(pgEnv(e.ForeignID, "CLIENT_PASSWORD"))
+		if listen == "" || clientUser == "" || clientPassword == "" {
+			logger.Info("skipping synced postgres listener: required env vars not set",
+				slog.String("foreign_id", e.ForeignID),
+				slog.Bool("has_listen", listen != ""),
+				slog.Bool("has_client_user", clientUser != ""),
+				slog.Bool("has_client_password", clientPassword != ""),
+			)
+			continue
+		}
+		p, err := postgres.NewManagedPolicy(e.ForeignID, listen, e.DSN, clientUser, clientPassword, e.Role)
+		if err != nil {
+			logger.Error("skipping synced postgres listener: invalid policy",
+				slog.String("foreign_id", e.ForeignID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		policies = append(policies, p)
+	}
+	return policies, true
+}
+
+// applyPostgresSync rebuilds the postgres listener set from a sync payload and
+// hot-reloads the manager. An invalid payload is logged and the running
+// listeners are preserved.
+func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local []*postgres.Policy, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) {
+	policies, ok := postgresPoliciesFromSync(local, getenv, logger, raw)
+	if !ok {
+		return
+	}
+	mgr.Reload(ctx, policies)
+	logger.Info("postgres listeners reloaded from sync", slog.Int("count", len(policies)))
 }
 
 // newReloadFunc returns a management.ReloadFunc that re-reads the YAML config

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -9,11 +10,149 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 
 	_ "github.com/ironsh/iron-proxy/internal/transform/allowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
+
+// staticSource is a no-op secrets.Source for building local test policies.
+type staticSource struct{ name, value string }
+
+func (s staticSource) Name() string                        { return s.name }
+func (s staticSource) Get(context.Context) (string, error) { return s.value, nil }
+
+func mapEnv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPgEnv(t *testing.T) {
+	cases := []struct {
+		foreignID, suffix, want string
+	}{
+		{"pg-analytics", "LISTEN", "IRON_PROXY_PG_PG_ANALYTICS_LISTEN"},
+		{"PG.Main", "CLIENT_USER", "IRON_PROXY_PG_PG_MAIN_CLIENT_USER"},
+		{"warehouse~1", "CLIENT_PASSWORD", "IRON_PROXY_PG_WAREHOUSE_1_CLIENT_PASSWORD"},
+		{"already_snake", "LISTEN", "IRON_PROXY_PG_ALREADY_SNAKE_LISTEN"},
+		{"db123", "LISTEN", "IRON_PROXY_PG_DB123_LISTEN"},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, pgEnv(c.foreignID, c.suffix), "pgEnv(%q,%q)", c.foreignID, c.suffix)
+	}
+}
+
+func TestPostgresPoliciesFromSync_EnvPresent(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "s3cret",
+	})
+
+	policies, ok := postgresPoliciesFromSync(nil, getenv, discardLogger(), raw)
+	require.True(t, ok)
+	require.Len(t, policies, 1)
+	require.Equal(t, "pg-analytics", policies[0].Name())
+	require.Equal(t, "127.0.0.1:0", policies[0].Listen())
+	require.Equal(t, "readonly", policies[0].Role())
+	require.True(t, policies[0].VerifyClient("app", "s3cret"))
+}
+
+func TestPostgresPoliciesFromSync_NoRole(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PGMAIN_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_PGMAIN_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PGMAIN_CLIENT_PASSWORD": "pw",
+	})
+
+	policies, ok := postgresPoliciesFromSync(nil, getenv, discardLogger(), raw)
+	require.True(t, ok)
+	require.Len(t, policies, 1)
+	require.Empty(t, policies[0].Role(), "absent role must be a no-op")
+}
+
+func TestPostgresPoliciesFromSync_MissingEnvSkipped(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	// LISTEN is set but client credentials are missing: the entry is skipped,
+	// not an error.
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN": "127.0.0.1:0",
+	})
+
+	policies, ok := postgresPoliciesFromSync(nil, getenv, logger, raw)
+	require.True(t, ok)
+	require.Empty(t, policies)
+	require.Contains(t, logBuf.String(), "skipping synced postgres listener")
+}
+
+func TestPostgresPoliciesFromSync_LocalWinsOnConflict(t *testing.T) {
+	local, err := postgres.NewManagedPolicy("pg-analytics", "127.0.0.1:0",
+		staticSource{name: "local", value: "host=local"}, "localuser", "localpw", "")
+	require.NoError(t, err)
+
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"},"role":"readonly"}]`)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
+	})
+
+	policies, ok := postgresPoliciesFromSync([]*postgres.Policy{local}, getenv, logger, raw)
+	require.True(t, ok)
+	require.Len(t, policies, 1, "synced entry colliding with local must be dropped")
+	require.Same(t, local, policies[0])
+	require.Empty(t, policies[0].Role(), "the local policy (no role) must win")
+	require.Contains(t, logBuf.String(), "defined in both local config and control plane")
+}
+
+func TestPostgresPoliciesFromSync_InvalidPayload(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	policies, ok := postgresPoliciesFromSync(nil, mapEnv(nil), logger, json.RawMessage(`{not an array`))
+	require.False(t, ok, "invalid payload must signal keep-current")
+	require.Nil(t, policies)
+	require.Contains(t, logBuf.String(), "rejecting invalid postgres config")
+}
+
+func TestPostgresPoliciesFromSync_NullPayloadKeepsLocal(t *testing.T) {
+	local, err := postgres.NewManagedPolicy("pgmain", "127.0.0.1:0",
+		staticSource{name: "local", value: "host=local"}, "u", "p", "")
+	require.NoError(t, err)
+
+	policies, ok := postgresPoliciesFromSync([]*postgres.Policy{local}, mapEnv(nil), discardLogger(), json.RawMessage("null"))
+	require.True(t, ok)
+	require.Equal(t, []*postgres.Policy{local}, policies)
+}
+
+func TestApplyPostgresSync_ReloadsListeners(t *testing.T) {
+	mgr := postgres.NewManager(discardLogger())
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
+	})
+
+	applyPostgresSync(context.Background(), mgr, nil, getenv, discardLogger(), raw)
+	require.Equal(t, []string{"pg-analytics"}, mgr.Names())
+}
+
+var _ secrets.Source = staticSource{}
 
 func TestApplyPipelineSync_ValidConfig_Swaps(t *testing.T) {
 	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -3,8 +3,11 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
 // TransformsFromSync builds a []Transform from the control plane's sync
@@ -57,6 +60,68 @@ func MCPFromSync(raw json.RawMessage) (node yaml.Node, present bool, err error) 
 		return yaml.Node{}, false, fmt.Errorf("parsing mcp: %w", err)
 	}
 	return node, true, nil
+}
+
+// PostgresSyncEntry is one control-plane-synced postgres upstream. The DSN and
+// optional role come from the control plane; the listener and client knobs are
+// supplied separately via environment variables keyed off ForeignID (see the
+// managed-mode env convention in cmd/iron-proxy).
+type PostgresSyncEntry struct {
+	ForeignID string
+	DSN       secrets.Source
+	Role      string
+}
+
+// PostgresFromSync parses the top-level postgres: array from the control
+// plane's sync payload into PostgresSyncEntry values, building each entry's DSN
+// source through the same secrets.BuildSource path the YAML config uses. A nil
+// or JSON-null payload returns (nil, nil); individual null array elements are
+// skipped. Source construction is lazy, so an entry whose DSN points at an
+// unset env var still parses without error here.
+func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncEntry, error) {
+	if !isNonNullJSON(raw) {
+		return nil, nil
+	}
+
+	var rawEntries []json.RawMessage
+	if err := json.Unmarshal(raw, &rawEntries); err != nil {
+		return nil, fmt.Errorf("parsing postgres: %w", err)
+	}
+
+	entries := make([]PostgresSyncEntry, 0, len(rawEntries))
+	for i, re := range rawEntries {
+		if !isNonNullJSON(re) {
+			continue
+		}
+		var e struct {
+			ForeignID string          `json:"foreign_id"`
+			DSN       json.RawMessage `json:"dsn"`
+			Role      string          `json:"role"`
+		}
+		if err := json.Unmarshal(re, &e); err != nil {
+			return nil, fmt.Errorf("parsing postgres[%d]: %w", i, err)
+		}
+		if e.ForeignID == "" {
+			return nil, fmt.Errorf("postgres[%d]: foreign_id is required", i)
+		}
+		if !isNonNullJSON(e.DSN) {
+			return nil, fmt.Errorf("postgres[%q]: dsn is required", e.ForeignID)
+		}
+		node, err := yamlNodeFromRawJSON(e.DSN)
+		if err != nil {
+			return nil, fmt.Errorf("postgres[%q]: parsing dsn: %w", e.ForeignID, err)
+		}
+		src, err := secrets.BuildSource(node, logger)
+		if err != nil {
+			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
+		}
+		entries = append(entries, PostgresSyncEntry{
+			ForeignID: e.ForeignID,
+			DSN:       src,
+			Role:      e.Role,
+		})
+	}
+	return entries, nil
 }
 
 // yamlNodeFromRawJSON parses raw JSON bytes as a yaml.Node. JSON is valid YAML,

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -1,11 +1,85 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func syncTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPostgresFromSync_NilAndNull(t *testing.T) {
+	entries, err := PostgresFromSync(nil, syncTestLogger())
+	require.NoError(t, err)
+	require.Empty(t, entries)
+
+	entries, err = PostgresFromSync(json.RawMessage("null"), syncTestLogger())
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestPostgresFromSync_ParsesEntries(t *testing.T) {
+	t.Setenv("PG_ANALYTICS_DSN", "host=analytics")
+	t.Setenv("PG_MAIN_DSN", "host=main")
+
+	raw := json.RawMessage(`[
+		{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
+		{"id":"pgs_2","foreign_id":"pg-main","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
+	]`)
+
+	entries, err := PostgresFromSync(raw, syncTestLogger())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	require.Equal(t, "pg-analytics", entries[0].ForeignID)
+	require.Equal(t, "readonly", entries[0].Role)
+	require.NotNil(t, entries[0].DSN)
+	got, err := entries[0].DSN.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "host=analytics", got)
+
+	require.Equal(t, "pg-main", entries[1].ForeignID)
+	require.Empty(t, entries[1].Role)
+}
+
+func TestPostgresFromSync_SkipsNullElements(t *testing.T) {
+	t.Setenv("PG_DSN", "host=x")
+	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"}},null]`)
+
+	entries, err := PostgresFromSync(raw, syncTestLogger())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "pg-x", entries[0].ForeignID)
+}
+
+func TestPostgresFromSync_MissingForeignID(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "foreign_id is required")
+}
+
+func TestPostgresFromSync_MissingDSN(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x"}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "dsn is required")
+}
+
+func TestPostgresFromSync_UnknownSourceType(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"bogus"}}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "building dsn source")
+}
+
+func TestPostgresFromSync_InvalidJSON(t *testing.T) {
+	_, err := PostgresFromSync(json.RawMessage(`{not an array`), syncTestLogger())
+	require.ErrorContains(t, err, "parsing postgres")
+}
 
 func TestTransformsFromSync_RulesPresent(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -16,6 +16,7 @@ type SyncResponse struct {
 	Rules       json.RawMessage `json:"rules"`
 	Secrets     json.RawMessage `json:"secrets"`
 	MCP         json.RawMessage `json:"mcp"`
+	Postgres    json.RawMessage `json:"postgres"`
 	IngestToken string          `json:"ingest_token"`
 }
 

--- a/internal/controlplane/poller.go
+++ b/internal/controlplane/poller.go
@@ -16,9 +16,10 @@ const PollInterval = 5 * time.Second
 // callback. Fields are nil or JSON null when the control plane did not include
 // them in this sync.
 type SyncUpdate struct {
-	Rules   json.RawMessage
-	Secrets json.RawMessage
-	MCP     json.RawMessage
+	Rules    json.RawMessage
+	Secrets  json.RawMessage
+	MCP      json.RawMessage
+	Postgres json.RawMessage
 }
 
 // Poller periodically calls Sync and applies config updates.
@@ -80,19 +81,22 @@ func (p *Poller) sync(ctx context.Context) error {
 	hasRules := isNonNullJSON(resp.Rules)
 	hasSecrets := isNonNullJSON(resp.Secrets)
 	hasMCP := isNonNullJSON(resp.MCP)
+	hasPostgres := isNonNullJSON(resp.Postgres)
 
-	if hasRules || hasSecrets || hasMCP {
+	if hasRules || hasSecrets || hasMCP || hasPostgres {
 		p.logger.Info("config update received from control plane",
 			slog.String("config_hash", resp.ConfigHash),
 			slog.Bool("has_rules", hasRules),
 			slog.Bool("has_secrets", hasSecrets),
 			slog.Bool("has_mcp", hasMCP),
+			slog.Bool("has_postgres", hasPostgres),
 		)
 		if p.onUpdate != nil {
 			if err := p.onUpdate(SyncUpdate{
-				Rules:   resp.Rules,
-				Secrets: resp.Secrets,
-				MCP:     resp.MCP,
+				Rules:    resp.Rules,
+				Secrets:  resp.Secrets,
+				MCP:      resp.MCP,
+				Postgres: resp.Postgres,
 			}); err != nil {
 				p.logger.Error("applying config update", slog.String("error", err.Error()))
 			}

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -211,6 +211,39 @@ func compileOne(c ServerConfig, idx int, logger *slog.Logger, buildSource Source
 	}, nil
 }
 
+// NewManagedPolicy builds a Policy for a control-plane-synced listener. The
+// upstream DSN source and optional role come from the control plane; the listen
+// address and client credentials come from the proxy's environment. Unlike the
+// YAML path, clientPassword is the literal password value, not the name of an
+// env var — managed mode has no second level of indirection. All fields except
+// role are required.
+func NewManagedPolicy(name, listen string, dsn secrets.Source, clientUser, clientPassword, role string) (*Policy, error) {
+	if name == "" {
+		return nil, fmt.Errorf("postgres: managed policy name is required")
+	}
+	ctx := fmt.Sprintf("postgres[%q]", name)
+	if listen == "" {
+		return nil, fmt.Errorf("%s: listen is required", ctx)
+	}
+	if dsn == nil {
+		return nil, fmt.Errorf("%s: dsn source is required", ctx)
+	}
+	if clientUser == "" {
+		return nil, fmt.Errorf("%s: client user is required", ctx)
+	}
+	if clientPassword == "" {
+		return nil, fmt.Errorf("%s: client password is required", ctx)
+	}
+	return &Policy{
+		name:           name,
+		listen:         listen,
+		role:           role,
+		upstreamDSN:    dsn,
+		clientUser:     clientUser,
+		clientPassword: clientPassword,
+	}, nil
+}
+
 // QuoteIdent returns s formatted as a Postgres double-quoted identifier,
 // suitable for safe interpolation into SQL like `SET ROLE "<ident>"`.
 // Embedded `"` characters are doubled per Postgres lexical rules.

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -63,6 +63,35 @@ func TestClassifyClientStatement(t *testing.T) {
 	}
 }
 
+func TestNewManagedPolicy(t *testing.T) {
+	dsn := staticDSN{name: "dsn", value: "host=db"}
+
+	p, err := NewManagedPolicy("pg-analytics", "127.0.0.1:6432", dsn, "app", "pw", "readonly")
+	require.NoError(t, err)
+	require.Equal(t, "pg-analytics", p.Name())
+	require.Equal(t, "127.0.0.1:6432", p.Listen())
+	require.Equal(t, "readonly", p.Role())
+	require.True(t, p.VerifyClient("app", "pw"))
+	require.False(t, p.VerifyClient("app", "wrong"))
+
+	// Absent role is allowed (no SET ROLE issued).
+	p, err = NewManagedPolicy("pg-main", "127.0.0.1:6433", dsn, "app", "pw", "")
+	require.NoError(t, err)
+	require.Empty(t, p.Role())
+
+	// Required fields.
+	_, err = NewManagedPolicy("", "127.0.0.1:0", dsn, "app", "pw", "")
+	require.ErrorContains(t, err, "name is required")
+	_, err = NewManagedPolicy("n", "", dsn, "app", "pw", "")
+	require.ErrorContains(t, err, "listen is required")
+	_, err = NewManagedPolicy("n", "127.0.0.1:0", nil, "app", "pw", "")
+	require.ErrorContains(t, err, "dsn source is required")
+	_, err = NewManagedPolicy("n", "127.0.0.1:0", dsn, "", "pw", "")
+	require.ErrorContains(t, err, "client user is required")
+	_, err = NewManagedPolicy("n", "127.0.0.1:0", dsn, "app", "", "")
+	require.ErrorContains(t, err, "client password is required")
+}
+
 func TestQuoteIdent(t *testing.T) {
 	cases := []struct {
 		in, out string


### PR DESCRIPTION
Consumes a new top-level `postgres` array in the control plane sync response. Each entry carries a DSN (a `secrets.Source` block) and optional role, keyed by `foreign_id`. The proxy turns each granted entry into a running listener by reading the listen address and client credentials from standardized env vars derived from the `foreign_id` (`IRON_PROXY_PG_<FOREIGN_ID>_{LISTEN,CLIENT_USER,CLIENT_PASSWORD}`).

Entries whose required env vars are unset are skipped with a log line, so a proxy granted a secret it isn't meant to serve locally just ignores it. The existing local-YAML `postgres:` block keeps working for self-managed proxies and wins on a `foreign_id` conflict. Listeners hot-reload through the existing manager `Reload` path; an invalid sync payload is logged and the running listeners are preserved.