### PR TITLE
feat(controlplane): apply synced transforms in managed pipeline

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -329,15 +329,16 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	configHash := ""
 	ingestToken := ""
-	var initialRules, initialSecrets, initialMCP, initialPostgres json.RawMessage
+	var initialRules, initialSecrets, initialTransformsRaw, initialMCP, initialPostgres json.RawMessage
 	if syncResp != nil {
 		configHash = syncResp.ConfigHash
 		initialRules = syncResp.Rules
 		initialSecrets = syncResp.Secrets
+		initialTransformsRaw = syncResp.Transforms
 		initialMCP = syncResp.MCP
 		initialPostgres = syncResp.Postgres
 		ingestToken = syncResp.IngestToken
-		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 || len(syncResp.MCP) > 0 {
+		if len(syncResp.Rules) > 0 || len(syncResp.Secrets) > 0 || len(syncResp.Transforms) > 0 || len(syncResp.MCP) > 0 {
 			logger.Info("received initial config from control plane",
 				slog.String("config_hash", syncResp.ConfigHash),
 			)
@@ -345,7 +346,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 	}
 
 	// Build initial pipeline from sync response.
-	initialTransforms, err := config.TransformsFromSync(initialRules, initialSecrets)
+	initialTransforms, err := config.TransformsFromSync(initialRules, initialSecrets, initialTransformsRaw)
 	if err != nil {
 		logger.Error("parsing initial config", slog.String("error", err.Error()))
 		os.Exit(1)
@@ -377,8 +378,8 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 
 	// Start config poller.
 	poller := controlplane.NewPoller(client, configHash, func(u controlplane.SyncUpdate) error {
-		if u.Rules != nil || u.Secrets != nil {
-			applyPipelineSync(holder, bodyLimits, logger, u.Rules, u.Secrets)
+		if u.Rules != nil || u.Secrets != nil || u.Transforms != nil {
+			applyPipelineSync(holder, bodyLimits, logger, u.Rules, u.Secrets, u.Transforms)
 		}
 		if u.MCP != nil {
 			applyMCPSync(mcpHolder, logger, u.MCP)
@@ -439,8 +440,8 @@ func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger 
 // swaps it in. If parsing or pipeline construction fails, the existing pipeline
 // is preserved and an error is logged: an invalid push from the control plane
 // must not take down the proxy.
-func applyPipelineSync(holder *transform.PipelineHolder, bodyLimits transform.BodyLimits, logger *slog.Logger, rules, secrets json.RawMessage) {
-	newTransforms, err := config.TransformsFromSync(rules, secrets)
+func applyPipelineSync(holder *transform.PipelineHolder, bodyLimits transform.BodyLimits, logger *slog.Logger, rules, secrets, transforms json.RawMessage) {
+	newTransforms, err := config.TransformsFromSync(rules, secrets, transforms)
 	if err != nil {
 		logger.Error("rejecting invalid pipeline config from sync, keeping current pipeline", slog.String("error", err.Error()))
 		return

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -162,7 +162,7 @@ func TestApplyPipelineSync_ValidConfig_Swaps(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
 	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)
-	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil, nil)
 
 	require.NotSame(t, original, holder.Load(), "pipeline should have been swapped")
 	require.Equal(t, "allowlist", holder.Load().Names())
@@ -176,7 +176,7 @@ func TestApplyPipelineSync_InvalidJSON_KeepsExistingPipeline(t *testing.T) {
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	applyPipelineSync(holder, transform.BodyLimits{}, logger, json.RawMessage(`{not json`), nil)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, json.RawMessage(`{not json`), nil, nil)
 
 	require.Same(t, original, holder.Load(), "pipeline must not be swapped on invalid config")
 	require.Contains(t, logBuf.String(), "rejecting invalid pipeline config")
@@ -192,7 +192,7 @@ func TestApplyPipelineSync_InvalidRule_KeepsExistingPipeline(t *testing.T) {
 
 	// host and cidr are mutually exclusive — rule construction fails.
 	rules := json.RawMessage(`[{"host":"example.com","cidr":"10.0.0.0/8"}]`)
-	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil, nil)
 
 	require.Same(t, original, holder.Load(), "pipeline must not be swapped when transform construction fails")
 	require.Contains(t, logBuf.String(), "rejecting invalid pipeline config")
@@ -208,7 +208,7 @@ func TestApplyPipelineSync_PreservesAuditFunc(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	rules := json.RawMessage(`[{"host":"example.com"}]`)
-	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil)
+	applyPipelineSync(holder, transform.BodyLimits{}, logger, rules, nil, nil)
 
 	holder.Load().EmitAudit(nil)
 	require.True(t, called, "audit func should be carried over to the new pipeline")

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -11,12 +11,20 @@ import (
 )
 
 // TransformsFromSync builds a []Transform from the control plane's sync
-// payload. Each payload field is a JSON array that gets wrapped to match the
-// corresponding transform's config shape: rules → {"rules": [...]} for the
-// allowlist transform, secrets → {"secrets": [...]} for the secrets transform.
-// Pipeline order is allowlist first, then secrets. Fields that are nil or JSON
-// null are skipped.
-func TransformsFromSync(rules, secrets json.RawMessage) ([]Transform, error) {
+// payload. The rules and secrets fields are JSON arrays that get wrapped to
+// match the corresponding transform's config shape: rules → {"rules": [...]}
+// for the allowlist transform, secrets → {"secrets": [...]} for the secrets
+// transform. The transforms field is the control plane's already-shaped
+// transform array — each element a {name, config} object bundling the
+// gcp_auth, hmac_sign, and oauth_token transforms granted to the proxy's
+// principal.
+//
+// Pipeline order is allowlist, then secrets, then the control-plane transforms
+// in delivered order. Secrets runs before the transforms so a body-mutating
+// secret swap lands before hmac_sign signs the body, matching the canonical
+// ordering in iron-proxy.example.yaml. Fields that are nil or JSON null are
+// skipped.
+func TransformsFromSync(rules, secrets, transformsRaw json.RawMessage) ([]Transform, error) {
 	var transforms []Transform
 
 	if isNonNullJSON(rules) {
@@ -41,7 +49,56 @@ func TransformsFromSync(rules, secrets json.RawMessage) ([]Transform, error) {
 		})
 	}
 
+	extra, err := transformsFromArray(transformsRaw)
+	if err != nil {
+		return nil, err
+	}
+	transforms = append(transforms, extra...)
+
 	return transforms, nil
+}
+
+// transformsFromArray parses the control plane's top-level transforms array
+// into Transform values. Each element is a {name, config} object whose shape
+// matches the YAML transforms list, so config is carried through verbatim as a
+// yaml.Node for the named transform's factory to decode. A nil or JSON-null
+// payload yields no transforms; null array elements are skipped.
+func transformsFromArray(raw json.RawMessage) ([]Transform, error) {
+	if !isNonNullJSON(raw) {
+		return nil, nil
+	}
+
+	var rawEntries []json.RawMessage
+	if err := json.Unmarshal(raw, &rawEntries); err != nil {
+		return nil, fmt.Errorf("parsing transforms: %w", err)
+	}
+
+	out := make([]Transform, 0, len(rawEntries))
+	for i, re := range rawEntries {
+		if !isNonNullJSON(re) {
+			continue
+		}
+		var e struct {
+			Name   string          `json:"name"`
+			Config json.RawMessage `json:"config"`
+		}
+		if err := json.Unmarshal(re, &e); err != nil {
+			return nil, fmt.Errorf("parsing transforms[%d]: %w", i, err)
+		}
+		if e.Name == "" {
+			return nil, fmt.Errorf("transforms[%d]: name is required", i)
+		}
+		var node yaml.Node
+		if isNonNullJSON(e.Config) {
+			n, err := yamlNodeFromRawJSON(e.Config)
+			if err != nil {
+				return nil, fmt.Errorf("transforms[%d] (%s): parsing config: %w", i, e.Name, err)
+			}
+			node = n
+		}
+		out = append(out, Transform{Name: e.Name, Config: node})
+	}
+	return out, nil
 }
 
 // MCPFromSync converts a JSON document for the top-level mcp: block into a

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -84,38 +84,38 @@ func TestPostgresFromSync_InvalidJSON(t *testing.T) {
 func TestTransformsFromSync_RulesPresent(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"example.com","methods":["GET"],"paths":["/api/*"]}]`)
 
-	transforms, err := TransformsFromSync(rules, nil)
+	transforms, err := TransformsFromSync(rules, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 	require.Equal(t, "allowlist", transforms[0].Name)
 }
 
 func TestTransformsFromSync_Nil(t *testing.T) {
-	transforms, err := TransformsFromSync(nil, nil)
+	transforms, err := TransformsFromSync(nil, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, transforms)
 }
 
 func TestTransformsFromSync_NullJSON(t *testing.T) {
-	transforms, err := TransformsFromSync(json.RawMessage("null"), json.RawMessage("null"))
+	transforms, err := TransformsFromSync(json.RawMessage("null"), json.RawMessage("null"), json.RawMessage("null"))
 	require.NoError(t, err)
 	require.Empty(t, transforms)
 }
 
 func TestTransformsFromSync_InvalidRules(t *testing.T) {
-	_, err := TransformsFromSync(json.RawMessage(`{bad json`), nil)
+	_, err := TransformsFromSync(json.RawMessage(`{bad json`), nil, nil)
 	require.ErrorContains(t, err, "parsing rules")
 }
 
 func TestTransformsFromSync_InvalidSecrets(t *testing.T) {
-	_, err := TransformsFromSync(nil, json.RawMessage(`{bad json`))
+	_, err := TransformsFromSync(nil, json.RawMessage(`{bad json`), nil)
 	require.ErrorContains(t, err, "parsing secrets")
 }
 
 func TestTransformsFromSync_RoundTrip(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"*.example.com","methods":["GET","POST"],"paths":["/api/*"]},{"host":"api.test.io","methods":["*"],"paths":["*"]}]`)
 
-	transforms, err := TransformsFromSync(rules, nil)
+	transforms, err := TransformsFromSync(rules, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 
@@ -137,7 +137,7 @@ func TestTransformsFromSync_RoundTrip(t *testing.T) {
 func TestTransformsFromSync_EmptyRules(t *testing.T) {
 	rules := json.RawMessage(`[]`)
 
-	transforms, err := TransformsFromSync(rules, nil)
+	transforms, err := TransformsFromSync(rules, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 
@@ -153,7 +153,7 @@ func TestTransformsFromSync_EmptyRules(t *testing.T) {
 func TestTransformsFromSync_SecretsPresent(t *testing.T) {
 	secrets := json.RawMessage(`[{"source":{"type":"env","var":"OPENAI_API_KEY"},"inject":{"header":"Authorization","formatter":"Bearer {{ .Value }}"},"rules":[{"host":"api.openai.com"}]}]`)
 
-	transforms, err := TransformsFromSync(nil, secrets)
+	transforms, err := TransformsFromSync(nil, secrets, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 	require.Equal(t, "secrets", transforms[0].Name)
@@ -186,7 +186,7 @@ func TestTransformsFromSync_RulesAndSecretsOrder(t *testing.T) {
 	rules := json.RawMessage(`[{"host":"example.com"}]`)
 	secrets := json.RawMessage(`[{"source":{"type":"env","var":"X"},"inject":{"header":"Authorization"},"rules":[{"host":"example.com"}]}]`)
 
-	transforms, err := TransformsFromSync(rules, secrets)
+	transforms, err := TransformsFromSync(rules, secrets, nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 2)
 	require.Equal(t, "allowlist", transforms[0].Name)
@@ -194,10 +194,110 @@ func TestTransformsFromSync_RulesAndSecretsOrder(t *testing.T) {
 }
 
 func TestTransformsFromSync_EmptySecrets(t *testing.T) {
-	transforms, err := TransformsFromSync(nil, json.RawMessage(`[]`))
+	transforms, err := TransformsFromSync(nil, json.RawMessage(`[]`), nil)
 	require.NoError(t, err)
 	require.Len(t, transforms, 1)
 	require.Equal(t, "secrets", transforms[0].Name)
+}
+
+func TestTransformsFromSync_OAuthTokenTransform(t *testing.T) {
+	// The control plane bundles every granted OAuth token secret into a single
+	// oauth_token transform delivered in the transforms array.
+	transformsRaw := json.RawMessage(`[
+		{
+			"name": "oauth_token",
+			"config": {
+				"tokens": [
+					{
+						"grant": "refresh_token",
+						"token_endpoint": "https://slack.com/api/oauth.v2.access",
+						"client_id": {"type": "env", "var": "SLACK_CLIENT_ID"},
+						"refresh_token": {"type": "control_plane", "value": "xoxe-1-..."},
+						"scopes": ["chat:write"],
+						"header": "Authorization",
+						"value_prefix": "Bearer",
+						"rules": [{"host": "slack.com", "methods": ["POST"], "paths": ["/api/*"]}]
+					}
+				]
+			}
+		}
+	]`)
+
+	transforms, err := TransformsFromSync(nil, nil, transformsRaw)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "oauth_token", transforms[0].Name)
+
+	var decoded struct {
+		Tokens []struct {
+			Grant         string `yaml:"grant"`
+			TokenEndpoint string `yaml:"token_endpoint"`
+			ClientID      struct {
+				Type string `yaml:"type"`
+				Var  string `yaml:"var"`
+			} `yaml:"client_id"`
+			Scopes []string `yaml:"scopes"`
+			Rules  []struct {
+				Host string `yaml:"host"`
+			} `yaml:"rules"`
+		} `yaml:"tokens"`
+	}
+	require.NoError(t, transforms[0].Config.Decode(&decoded))
+	require.Len(t, decoded.Tokens, 1)
+	require.Equal(t, "refresh_token", decoded.Tokens[0].Grant)
+	require.Equal(t, "https://slack.com/api/oauth.v2.access", decoded.Tokens[0].TokenEndpoint)
+	require.Equal(t, "env", decoded.Tokens[0].ClientID.Type)
+	require.Equal(t, "SLACK_CLIENT_ID", decoded.Tokens[0].ClientID.Var)
+	require.Equal(t, []string{"chat:write"}, decoded.Tokens[0].Scopes)
+	require.Equal(t, "slack.com", decoded.Tokens[0].Rules[0].Host)
+}
+
+func TestTransformsFromSync_TransformsAfterSecrets(t *testing.T) {
+	// allowlist, then secrets, then the control-plane transforms in delivered
+	// order — so a body-mutating secret swap runs before hmac_sign signs.
+	rules := json.RawMessage(`[{"host":"example.com"}]`)
+	secrets := json.RawMessage(`[{"source":{"type":"env","var":"X"},"inject":{"header":"Authorization"},"rules":[{"host":"example.com"}]}]`)
+	transformsRaw := json.RawMessage(`[
+		{"name":"hmac_sign","config":{"credentials":{"secret":{"type":"env","var":"K"}}}},
+		{"name":"oauth_token","config":{"tokens":[]}}
+	]`)
+
+	transforms, err := TransformsFromSync(rules, secrets, transformsRaw)
+	require.NoError(t, err)
+	require.Len(t, transforms, 4)
+	require.Equal(t, "allowlist", transforms[0].Name)
+	require.Equal(t, "secrets", transforms[1].Name)
+	require.Equal(t, "hmac_sign", transforms[2].Name)
+	require.Equal(t, "oauth_token", transforms[3].Name)
+}
+
+func TestTransformsFromSync_TransformsNilAndNull(t *testing.T) {
+	transforms, err := TransformsFromSync(nil, nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, transforms)
+
+	transforms, err = TransformsFromSync(nil, nil, json.RawMessage("null"))
+	require.NoError(t, err)
+	require.Empty(t, transforms)
+}
+
+func TestTransformsFromSync_TransformsSkipsNullElements(t *testing.T) {
+	transformsRaw := json.RawMessage(`[null,{"name":"oauth_token","config":{"tokens":[]}},null]`)
+	transforms, err := TransformsFromSync(nil, nil, transformsRaw)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "oauth_token", transforms[0].Name)
+}
+
+func TestTransformsFromSync_TransformsMissingName(t *testing.T) {
+	transformsRaw := json.RawMessage(`[{"config":{"tokens":[]}}]`)
+	_, err := TransformsFromSync(nil, nil, transformsRaw)
+	require.ErrorContains(t, err, "name is required")
+}
+
+func TestTransformsFromSync_TransformsInvalidJSON(t *testing.T) {
+	_, err := TransformsFromSync(nil, nil, json.RawMessage(`{not an array`))
+	require.ErrorContains(t, err, "parsing transforms")
 }
 
 func TestMCPFromSync_Nil(t *testing.T) {

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -12,9 +12,14 @@ import (
 
 // SyncResponse is the parsed response from the sync endpoint.
 type SyncResponse struct {
-	ConfigHash  string          `json:"config_hash"`
-	Rules       json.RawMessage `json:"rules"`
-	Secrets     json.RawMessage `json:"secrets"`
+	ConfigHash string          `json:"config_hash"`
+	Rules      json.RawMessage `json:"rules"`
+	Secrets    json.RawMessage `json:"secrets"`
+	// Transforms is the control plane's pre-shaped transform array, bundling
+	// the gcp_auth, hmac_sign, and oauth_token transforms granted to the
+	// proxy's principal. Unlike rules/secrets it is already in {name, config}
+	// form.
+	Transforms  json.RawMessage `json:"transforms"`
 	MCP         json.RawMessage `json:"mcp"`
 	Postgres    json.RawMessage `json:"postgres"`
 	IngestToken string          `json:"ingest_token"`

--- a/internal/controlplane/poller.go
+++ b/internal/controlplane/poller.go
@@ -16,10 +16,11 @@ const PollInterval = 5 * time.Second
 // callback. Fields are nil or JSON null when the control plane did not include
 // them in this sync.
 type SyncUpdate struct {
-	Rules    json.RawMessage
-	Secrets  json.RawMessage
-	MCP      json.RawMessage
-	Postgres json.RawMessage
+	Rules      json.RawMessage
+	Secrets    json.RawMessage
+	Transforms json.RawMessage
+	MCP        json.RawMessage
+	Postgres   json.RawMessage
 }
 
 // Poller periodically calls Sync and applies config updates.
@@ -80,23 +81,26 @@ func (p *Poller) sync(ctx context.Context) error {
 
 	hasRules := isNonNullJSON(resp.Rules)
 	hasSecrets := isNonNullJSON(resp.Secrets)
+	hasTransforms := isNonNullJSON(resp.Transforms)
 	hasMCP := isNonNullJSON(resp.MCP)
 	hasPostgres := isNonNullJSON(resp.Postgres)
 
-	if hasRules || hasSecrets || hasMCP || hasPostgres {
+	if hasRules || hasSecrets || hasTransforms || hasMCP || hasPostgres {
 		p.logger.Info("config update received from control plane",
 			slog.String("config_hash", resp.ConfigHash),
 			slog.Bool("has_rules", hasRules),
 			slog.Bool("has_secrets", hasSecrets),
+			slog.Bool("has_transforms", hasTransforms),
 			slog.Bool("has_mcp", hasMCP),
 			slog.Bool("has_postgres", hasPostgres),
 		)
 		if p.onUpdate != nil {
 			if err := p.onUpdate(SyncUpdate{
-				Rules:    resp.Rules,
-				Secrets:  resp.Secrets,
-				MCP:      resp.MCP,
-				Postgres: resp.Postgres,
+				Rules:      resp.Rules,
+				Secrets:    resp.Secrets,
+				Transforms: resp.Transforms,
+				MCP:        resp.MCP,
+				Postgres:   resp.Postgres,
 			}); err != nil {
 				p.logger.Error("applying config update", slog.String("error", err.Error()))
 			}

--- a/internal/controlplane/poller_test.go
+++ b/internal/controlplane/poller_test.go
@@ -76,6 +76,38 @@ func TestPollerInitialSyncDeliversMCP(t *testing.T) {
 	require.False(t, isNonNullJSON(got.Secrets))
 }
 
+func TestPollerInitialSyncDeliversTransforms(t *testing.T) {
+	transformsRaw := `[{"name":"oauth_token","config":{"tokens":[]}}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(SyncResponse{
+			ConfigHash: "sha256:transforms",
+			Transforms: json.RawMessage(transformsRaw),
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "irpt_test", testLogger())
+
+	var got SyncUpdate
+	var called atomic.Int32
+	poller := NewPoller(client, "", func(u SyncUpdate) error {
+		called.Add(1)
+		got = u
+		return nil
+	}, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := poller.Run(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, called.Load(), int32(1))
+	require.JSONEq(t, transformsRaw, string(got.Transforms))
+	require.False(t, isNonNullJSON(got.Rules))
+	require.False(t, isNonNullJSON(got.Secrets))
+}
+
 func TestPollerNoUpdateOnNullRulesSecrets(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The control plane delivers `gcp_auth`, `hmac_sign`, and `oauth_token` transforms bundled in a top-level `transforms` array on `/proxy/sync`, but the proxy's `SyncResponse` had no such field, so `TransformsFromSync` only ever emitted `allowlist` and `secrets`. All three transform types — `oauth_token` included — were silently dropped in managed mode at both startup and every reload.

This plumbs the `transforms` array through `SyncResponse`, `SyncUpdate`, and `TransformsFromSync`, appending it after `allowlist`+`secrets` so a body-mutating secret swap lands before `hmac_sign` signs the body (matching the canonical ordering in `iron-proxy.example.yaml`). The transform types are already blank-imported, so `buildPipeline` constructs them by name with no further changes.