### PR TITLE
feat(postgres): single listener fronting database-routed upstreams

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -482,22 +482,27 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 	}
 }
 
-// pgListenEnv is the environment variable carrying the bind address for the
-// postgres listener in managed mode, used when the local YAML config does not
-// supply a listen address of its own.
-const pgListenEnv = "IRON_PROXY_PG_LISTEN"
+// Environment variables that configure the managed postgres listener when the
+// proxy has no local YAML postgres block to source these from. They configure
+// the single listener, not individual upstreams.
+const (
+	pgListenEnv         = "IRON_PROXY_PG_LISTEN"
+	pgClientUserEnv     = "IRON_PROXY_PG_CLIENT_USER"
+	pgClientPasswordEnv = "IRON_PROXY_PG_CLIENT_PASSWORD"
+)
 
-// postgresListenerFromSync builds the single postgres listener for managed mode:
-// the local YAML upstreams (if any) plus control-plane-synced upstreams layered
-// on from the sync payload. The bind address is the local listener's address
-// when the YAML config supplies one, otherwise IRON_PROXY_PG_LISTEN. Each synced
-// entry becomes an upstream keyed by its database, carrying the database, DSN,
-// client credentials, and role the control plane delivered — managed mode needs
-// no per-upstream proxy configuration. A synced upstream whose database collides
-// with a local upstream or another synced upstream is dropped (logged). When no
-// bind address is available or no upstreams resolve, no listener is returned.
-// Returns ok=false only when the sync payload itself is invalid, signaling the
-// caller to keep the current listener.
+// postgresListenerFromSync builds the single postgres listener for managed mode.
+// Each synced entry becomes an upstream keyed by its database, carrying the
+// database, DSN, and role the control plane delivered.
+//
+// When a local YAML postgres block is present, the synced upstreams are layered
+// onto it, reusing its bind address and client credential; a synced upstream
+// whose database collides with a local one is dropped (logged). Otherwise the
+// listener is built from the environment: IRON_PROXY_PG_LISTEN plus the shared
+// IRON_PROXY_PG_CLIENT_USER / IRON_PROXY_PG_CLIENT_PASSWORD. When no bind address
+// or client credential is available, or no upstreams resolve, no listener is
+// returned. Returns ok=false only when the sync payload itself is invalid,
+// signaling the caller to keep the current listener.
 func postgresListenerFromSync(local *postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) (*postgres.Listener, bool) {
 	entries, err := config.PostgresFromSync(raw, logger)
 	if err != nil {
@@ -505,42 +510,10 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 		return nil, false
 	}
 
-	// Start from the local upstreams; synced upstreams are layered on, and local
-	// wins on a database collision.
-	seenDatabases := make(map[string]bool)
-	upstreams := make([]*postgres.Upstream, 0, len(entries))
-	listen := ""
-	if local != nil {
-		listen = local.Listen()
-		for _, u := range local.Upstreams() {
-			seenDatabases[u.Database()] = true
-			upstreams = append(upstreams, u)
-		}
-	}
-	if listen == "" {
-		listen = getenv(pgListenEnv)
-	}
-
-	// listen is empty only when there is no local listener (a compiled local
-	// listener always carries a bind address) and IRON_PROXY_PG_LISTEN is unset.
-	// Without an address there is nothing to bind, so drop the synced upstreams.
-	if listen == "" {
-		if len(entries) > 0 {
-			logger.Info("skipping control-plane postgres upstreams: no listen address (set IRON_PROXY_PG_LISTEN)",
-				slog.Int("upstream_count", len(entries)))
-		}
-		return nil, true
-	}
-
+	synced := make([]*postgres.Upstream, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if seenDatabases[e.Database] {
-			logger.Warn("skipping synced postgres upstream: duplicate database",
-				slog.String("foreign_id", e.ForeignID),
-				slog.String("database", e.Database),
-			)
-			continue
-		}
-		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.ClientUser, e.ClientPassword, e.Role)
+		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.Role)
 		if err != nil {
 			logger.Error("skipping synced postgres upstream: invalid upstream",
 				slog.String("foreign_id", e.ForeignID),
@@ -548,15 +521,46 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 			)
 			continue
 		}
-		seenDatabases[e.Database] = true
-		upstreams = append(upstreams, u)
+		if seen[u.Database()] {
+			logger.Warn("skipping synced postgres upstream: duplicate database",
+				slog.String("foreign_id", e.ForeignID),
+				slog.String("database", u.Database()),
+			)
+			continue
+		}
+		seen[u.Database()] = true
+		synced = append(synced, u)
 	}
 
-	if len(upstreams) == 0 {
+	// With a local listener, layer the synced upstreams on top, reusing its
+	// address and client credential. Local wins on a database collision.
+	if local != nil {
+		merged, dropped := local.WithUpstreams(synced)
+		for _, db := range dropped {
+			logger.Warn("skipping synced postgres upstream: duplicate database",
+				slog.String("database", db))
+		}
+		return merged, true
+	}
+
+	// No local listener: source the listener knobs from the environment.
+	if len(synced) == 0 {
+		return nil, true
+	}
+	listen := getenv(pgListenEnv)
+	clientUser := getenv(pgClientUserEnv)
+	clientPassword := getenv(pgClientPasswordEnv)
+	if listen == "" || clientUser == "" || clientPassword == "" {
+		logger.Info("skipping control-plane postgres upstreams: listener env not fully set",
+			slog.Bool("has_listen", listen != ""),
+			slog.Bool("has_client_user", clientUser != ""),
+			slog.Bool("has_client_password", clientPassword != ""),
+			slog.Int("upstream_count", len(synced)),
+		)
 		return nil, true
 	}
 
-	listener, err := postgres.NewListener(listen, upstreams)
+	listener, err := postgres.NewListener(listen, clientUser, clientPassword, synced)
 	if err != nil {
 		logger.Error("skipping postgres listener: invalid listener", slog.String("error", err.Error()))
 		return nil, true

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -11,10 +11,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
-	"unicode"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
 	"github.com/ironsh/iron-proxy/internal/config"
@@ -489,36 +487,17 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 // supply a listen address of its own.
 const pgListenEnv = "IRON_PROXY_PG_LISTEN"
 
-// pgEnv returns the environment variable name carrying the given per-route
-// client credential for a control-plane-synced postgres upstream. foreignID is
-// normalized to env-safe form: uppercased, with '-', '.', and '~' mapped to '_'
-// (the full set of non-alphanumeric characters a foreign_id may contain). For
-// foreignID "pg-analytics" and suffix "CLIENT_USER" the result is
-// "IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER".
-func pgEnv(foreignID, suffix string) string {
-	norm := strings.Map(func(r rune) rune {
-		switch r {
-		case '-', '.', '~':
-			return '_'
-		default:
-			return unicode.ToUpper(r)
-		}
-	}, foreignID)
-	return "IRON_PROXY_PG_" + norm + "_" + suffix
-}
-
 // postgresListenerFromSync builds the single postgres listener for managed mode:
 // the local YAML upstreams (if any) plus control-plane-synced upstreams layered
 // on from the sync payload. The bind address is the local listener's address
 // when the YAML config supplies one, otherwise IRON_PROXY_PG_LISTEN. Each synced
-// entry becomes an upstream keyed by its database, with per-upstream client
-// credentials read from IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD;
-// an entry missing either credential is skipped (logged) — that is how a proxy
-// granted a secret it isn't meant to serve locally simply ignores it. A synced
-// upstream whose database collides with a local upstream or another synced
-// upstream is dropped (logged). When no bind address is available or no upstreams
-// resolve, no listener is returned. Returns ok=false only when the sync payload
-// itself is invalid, signaling the caller to keep the current listener.
+// entry becomes an upstream keyed by its database, carrying the database, DSN,
+// client credentials, and role the control plane delivered — managed mode needs
+// no per-upstream proxy configuration. A synced upstream whose database collides
+// with a local upstream or another synced upstream is dropped (logged). When no
+// bind address is available or no upstreams resolve, no listener is returned.
+// Returns ok=false only when the sync payload itself is invalid, signaling the
+// caller to keep the current listener.
 func postgresListenerFromSync(local *postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) (*postgres.Listener, bool) {
 	entries, err := config.PostgresFromSync(raw, logger)
 	if err != nil {
@@ -554,16 +533,6 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 	}
 
 	for _, e := range entries {
-		clientUser := getenv(pgEnv(e.ForeignID, "CLIENT_USER"))
-		clientPassword := getenv(pgEnv(e.ForeignID, "CLIENT_PASSWORD"))
-		if clientUser == "" || clientPassword == "" {
-			logger.Info("skipping synced postgres upstream: client credentials not set",
-				slog.String("foreign_id", e.ForeignID),
-				slog.Bool("has_client_user", clientUser != ""),
-				slog.Bool("has_client_password", clientPassword != ""),
-			)
-			continue
-		}
 		if seenDatabases[e.Database] {
 			logger.Warn("skipping synced postgres upstream: duplicate database",
 				slog.String("foreign_id", e.ForeignID),
@@ -571,7 +540,7 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 			)
 			continue
 		}
-		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, clientUser, clientPassword, e.Role)
+		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.ClientUser, e.ClientPassword, e.Role)
 		if err != nil {
 			logger.Error("skipping synced postgres upstream: invalid upstream",
 				slog.String("foreign_id", e.ForeignID),

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -508,17 +508,17 @@ func pgEnv(foreignID, suffix string) string {
 }
 
 // postgresListenerFromSync builds the single postgres listener for managed mode:
-// the local YAML routes (if any) plus control-plane-synced routes layered on
-// from the sync payload. The bind address is the local listener's address when
-// the YAML config supplies one, otherwise IRON_PROXY_PG_LISTEN. Each synced
-// entry becomes a route keyed by its database, with per-route client credentials
-// read from IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD; an entry
-// missing either credential is skipped (logged) — that is how a proxy granted a
-// secret it isn't meant to serve locally simply ignores it. A synced route whose
-// database collides with a local route or another synced route is dropped
-// (logged). When no bind address is available or no routes resolve, no listener
-// is returned. Returns ok=false only when the sync payload itself is invalid,
-// signaling the caller to keep the current listener.
+// the local YAML upstreams (if any) plus control-plane-synced upstreams layered
+// on from the sync payload. The bind address is the local listener's address
+// when the YAML config supplies one, otherwise IRON_PROXY_PG_LISTEN. Each synced
+// entry becomes an upstream keyed by its database, with per-upstream client
+// credentials read from IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD;
+// an entry missing either credential is skipped (logged) — that is how a proxy
+// granted a secret it isn't meant to serve locally simply ignores it. A synced
+// upstream whose database collides with a local upstream or another synced
+// upstream is dropped (logged). When no bind address is available or no upstreams
+// resolve, no listener is returned. Returns ok=false only when the sync payload
+// itself is invalid, signaling the caller to keep the current listener.
 func postgresListenerFromSync(local *postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) (*postgres.Listener, bool) {
 	entries, err := config.PostgresFromSync(raw, logger)
 	if err != nil {
@@ -526,16 +526,16 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 		return nil, false
 	}
 
-	// Start from the local routes; synced routes are layered on, and local wins
-	// on a database collision.
+	// Start from the local upstreams; synced upstreams are layered on, and local
+	// wins on a database collision.
 	seenDatabases := make(map[string]bool)
-	routes := make([]*postgres.Route, 0, len(entries))
+	upstreams := make([]*postgres.Upstream, 0, len(entries))
 	listen := ""
 	if local != nil {
 		listen = local.Listen()
-		for _, r := range local.Routes() {
-			seenDatabases[r.Database()] = true
-			routes = append(routes, r)
+		for _, u := range local.Upstreams() {
+			seenDatabases[u.Database()] = true
+			upstreams = append(upstreams, u)
 		}
 	}
 	if listen == "" {
@@ -544,11 +544,11 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 
 	// listen is empty only when there is no local listener (a compiled local
 	// listener always carries a bind address) and IRON_PROXY_PG_LISTEN is unset.
-	// Without an address there is nothing to bind, so drop the synced routes.
+	// Without an address there is nothing to bind, so drop the synced upstreams.
 	if listen == "" {
 		if len(entries) > 0 {
-			logger.Info("skipping control-plane postgres routes: no listen address (set IRON_PROXY_PG_LISTEN)",
-				slog.Int("route_count", len(entries)))
+			logger.Info("skipping control-plane postgres upstreams: no listen address (set IRON_PROXY_PG_LISTEN)",
+				slog.Int("upstream_count", len(entries)))
 		}
 		return nil, true
 	}
@@ -557,7 +557,7 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 		clientUser := getenv(pgEnv(e.ForeignID, "CLIENT_USER"))
 		clientPassword := getenv(pgEnv(e.ForeignID, "CLIENT_PASSWORD"))
 		if clientUser == "" || clientPassword == "" {
-			logger.Info("skipping synced postgres route: client credentials not set",
+			logger.Info("skipping synced postgres upstream: client credentials not set",
 				slog.String("foreign_id", e.ForeignID),
 				slog.Bool("has_client_user", clientUser != ""),
 				slog.Bool("has_client_password", clientPassword != ""),
@@ -565,29 +565,29 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 			continue
 		}
 		if seenDatabases[e.Database] {
-			logger.Warn("skipping synced postgres route: duplicate database",
+			logger.Warn("skipping synced postgres upstream: duplicate database",
 				slog.String("foreign_id", e.ForeignID),
 				slog.String("database", e.Database),
 			)
 			continue
 		}
-		r, err := postgres.NewManagedRoute(e.Database, e.DSN, clientUser, clientPassword, e.Role)
+		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, clientUser, clientPassword, e.Role)
 		if err != nil {
-			logger.Error("skipping synced postgres route: invalid route",
+			logger.Error("skipping synced postgres upstream: invalid upstream",
 				slog.String("foreign_id", e.ForeignID),
 				slog.String("error", err.Error()),
 			)
 			continue
 		}
 		seenDatabases[e.Database] = true
-		routes = append(routes, r)
+		upstreams = append(upstreams, u)
 	}
 
-	if len(routes) == 0 {
+	if len(upstreams) == 0 {
 		return nil, true
 	}
 
-	listener, err := postgres.NewListener(listen, routes)
+	listener, err := postgres.NewListener(listen, upstreams)
 	if err != nil {
 		logger.Error("skipping postgres listener: invalid listener", slog.String("error", err.Error()))
 		return nil, true

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -108,18 +108,17 @@ func main() {
 	// and (in managed mode) the config poller.
 	errc := make(chan error, 5)
 
-	// Postgres listeners come from the local YAML postgres: block (self-managed
-	// proxies, inline DSNs) and, in managed mode, from a control-plane-synced
-	// listener whose routes are derived from the sync payload. The manager is
-	// created up front so the config poller can hot-reload it; local listeners
-	// are the base set the synced listener is layered onto.
-	localPgListeners, err := postgres.LoadFromNode(cfg.Postgres, logger)
+	// The postgres listener comes from the local YAML postgres: block
+	// (self-managed proxies, inline DSNs) and, in managed mode, has additional
+	// routes layered on from the control-plane sync payload. The manager is
+	// created up front so the config poller can hot-reload it.
+	localPgListener, err := postgres.LoadFromNode(cfg.Postgres, logger)
 	if err != nil {
 		logger.Error("loading postgres config", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	pgManager := postgres.NewManager(logger)
-	pgListeners := localPgListeners
+	pgListener := localPgListener
 
 	var holder *transform.PipelineHolder
 	var mcpHolder *mcp.PolicyHolder
@@ -127,7 +126,7 @@ func main() {
 
 	if managed {
 		var ingestToken string
-		holder, mcpHolder, ingestToken, pgListeners = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListeners, logger)
+		holder, mcpHolder, ingestToken, pgListener = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListener, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -243,7 +242,7 @@ func main() {
 	if mgmtServer != nil {
 		go func() { errc <- fmt.Errorf("management: %w", mgmtServer.ListenAndServe()) }()
 	}
-	pgManager.Start(pgListeners, errc)
+	pgManager.Start(pgListener, errc)
 
 	startAttrs := []any{
 		slog.String("dns_listen", cfg.DNS.Listen),
@@ -310,7 +309,7 @@ func main() {
 //
 // Initial MCP policy preference: control-plane-supplied mcp block first, then
 // fall back to cfg.MCP from the YAML if the sync did not include one.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListeners []*postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, []*postgres.Listener) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListener *postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, *postgres.Listener) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -368,13 +367,13 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		os.Exit(1)
 	}
 
-	// Compute the initial postgres listener set: local YAML listeners plus the
-	// control-plane-synced listener when its env vars are present. If the initial
-	// sync carried no postgres block (or an invalid one), fall back to the local
-	// listeners.
-	pgListeners := localPgListeners
-	if listeners, ok := postgresListenersFromSync(localPgListeners, os.Getenv, logger, initialPostgres); ok {
-		pgListeners = listeners
+	// Compute the initial postgres listener: the local YAML listener with any
+	// control-plane-synced routes layered on when its env vars are present. If
+	// the initial sync carried no postgres block (or an invalid one), fall back
+	// to the local listener.
+	pgListener := localPgListener
+	if listener, ok := postgresListenerFromSync(localPgListener, os.Getenv, logger, initialPostgres); ok {
+		pgListener = listener
 	}
 
 	// Start config poller.
@@ -386,7 +385,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 			applyMCPSync(mcpHolder, logger, u.MCP)
 		}
 		if u.Postgres != nil {
-			applyPostgresSync(ctx, pgManager, localPgListeners, os.Getenv, logger, u.Postgres)
+			applyPostgresSync(ctx, pgManager, localPgListener, os.Getenv, logger, u.Postgres)
 		}
 		return nil
 	}, logger)
@@ -395,7 +394,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, mcpHolder, ingestToken, pgListeners
+	return holder, mcpHolder, ingestToken, pgListener
 }
 
 // buildInitialMCPHolder picks the initial MCP policy source: a control-plane
@@ -485,13 +484,9 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 	}
 }
 
-// managedPgListenerName is the name given to the single listener that fronts
-// all control-plane-synced postgres routes.
-const managedPgListenerName = "control-plane"
-
 // pgListenEnv is the environment variable carrying the bind address for the
-// control-plane-synced postgres listener. A single listener now fronts every
-// synced upstream, so the bind address is shared rather than per-foreign-id.
+// postgres listener in managed mode, used when the local YAML config does not
+// supply a listen address of its own.
 const pgListenEnv = "IRON_PROXY_PG_LISTEN"
 
 // pgEnv returns the environment variable name carrying the given per-route
@@ -512,38 +507,52 @@ func pgEnv(foreignID, suffix string) string {
 	return "IRON_PROXY_PG_" + norm + "_" + suffix
 }
 
-// postgresListenersFromSync builds the full postgres listener set for managed
-// mode: the local YAML listeners plus a single control-plane listener whose
-// routes are derived from the sync payload. The managed listener binds the
-// address in IRON_PROXY_PG_LISTEN; each synced entry becomes a route keyed by
-// its database, with per-route client credentials read from
-// IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD. An entry missing
-// either credential is skipped (logged) — that is how a proxy granted a secret
-// it isn't meant to serve locally simply ignores it. When IRON_PROXY_PG_LISTEN
-// is unset or no entry resolves to a usable route, no managed listener is added.
-// Returns ok=false only when the sync payload itself is invalid, signaling the
-// caller to keep the current listeners.
-func postgresListenersFromSync(local []*postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) ([]*postgres.Listener, bool) {
+// postgresListenerFromSync builds the single postgres listener for managed mode:
+// the local YAML routes (if any) plus control-plane-synced routes layered on
+// from the sync payload. The bind address is the local listener's address when
+// the YAML config supplies one, otherwise IRON_PROXY_PG_LISTEN. Each synced
+// entry becomes a route keyed by its database, with per-route client credentials
+// read from IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD; an entry
+// missing either credential is skipped (logged) — that is how a proxy granted a
+// secret it isn't meant to serve locally simply ignores it. A synced route whose
+// database collides with a local route or another synced route is dropped
+// (logged). When no bind address is available or no routes resolve, no listener
+// is returned. Returns ok=false only when the sync payload itself is invalid,
+// signaling the caller to keep the current listener.
+func postgresListenerFromSync(local *postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) (*postgres.Listener, bool) {
 	entries, err := config.PostgresFromSync(raw, logger)
 	if err != nil {
-		logger.Error("rejecting invalid postgres config from sync, keeping current listeners", slog.String("error", err.Error()))
+		logger.Error("rejecting invalid postgres config from sync, keeping current listener", slog.String("error", err.Error()))
 		return nil, false
 	}
 
-	listeners := make([]*postgres.Listener, 0, len(local)+1)
-	listeners = append(listeners, local...)
-
-	listen := getenv(pgListenEnv)
-	if listen == "" {
-		if len(entries) > 0 {
-			logger.Info("skipping control-plane postgres routes: IRON_PROXY_PG_LISTEN not set",
-				slog.Int("route_count", len(entries)))
+	// Start from the local routes; synced routes are layered on, and local wins
+	// on a database collision.
+	seenDatabases := make(map[string]bool)
+	routes := make([]*postgres.Route, 0, len(entries))
+	listen := ""
+	if local != nil {
+		listen = local.Listen()
+		for _, r := range local.Routes() {
+			seenDatabases[r.Database()] = true
+			routes = append(routes, r)
 		}
-		return listeners, true
+	}
+	if listen == "" {
+		listen = getenv(pgListenEnv)
 	}
 
-	seenDatabases := make(map[string]bool, len(entries))
-	routes := make([]*postgres.Route, 0, len(entries))
+	// listen is empty only when there is no local listener (a compiled local
+	// listener always carries a bind address) and IRON_PROXY_PG_LISTEN is unset.
+	// Without an address there is nothing to bind, so drop the synced routes.
+	if listen == "" {
+		if len(entries) > 0 {
+			logger.Info("skipping control-plane postgres routes: no listen address (set IRON_PROXY_PG_LISTEN)",
+				slog.Int("route_count", len(entries)))
+		}
+		return nil, true
+	}
+
 	for _, e := range entries {
 		clientUser := getenv(pgEnv(e.ForeignID, "CLIENT_USER"))
 		clientPassword := getenv(pgEnv(e.ForeignID, "CLIENT_PASSWORD"))
@@ -575,29 +584,27 @@ func postgresListenersFromSync(local []*postgres.Listener, getenv func(string) s
 	}
 
 	if len(routes) == 0 {
-		return listeners, true
+		return nil, true
 	}
 
-	managed, err := postgres.NewListener(managedPgListenerName, listen, routes)
+	listener, err := postgres.NewListener(listen, routes)
 	if err != nil {
-		logger.Error("skipping control-plane postgres listener: invalid listener",
-			slog.String("error", err.Error()))
-		return listeners, true
+		logger.Error("skipping postgres listener: invalid listener", slog.String("error", err.Error()))
+		return nil, true
 	}
-	listeners = append(listeners, managed)
-	return listeners, true
+	return listener, true
 }
 
-// applyPostgresSync rebuilds the postgres listener set from a sync payload and
+// applyPostgresSync rebuilds the postgres listener from a sync payload and
 // hot-reloads the manager. An invalid payload is logged and the running
-// listeners are preserved.
-func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local []*postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) {
-	listeners, ok := postgresListenersFromSync(local, getenv, logger, raw)
+// listener is preserved.
+func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local *postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) {
+	listener, ok := postgresListenerFromSync(local, getenv, logger, raw)
 	if !ok {
 		return
 	}
-	mgr.Reload(ctx, listeners)
-	logger.Info("postgres listeners reloaded from sync", slog.Int("count", len(listeners)))
+	mgr.Reload(ctx, listener)
+	logger.Info("postgres listener reloaded from sync", slog.Bool("running", listener != nil))
 }
 
 // newReloadFunc returns a management.ReloadFunc that re-reads the YAML config
@@ -623,17 +630,17 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolde
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
-		newPgListeners, err := postgres.LoadFromNode(newCfg.Postgres, logger)
+		newPgListener, err := postgres.LoadFromNode(newCfg.Postgres, logger)
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
 		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 		holder.Store(newPipeline)
 		mcpHolder.Store(newPolicy)
-		pgManager.Reload(ctx, newPgListeners)
+		pgManager.Reload(ctx, newPgListener)
 		logger.Info("pipeline reloaded via management API",
 			slog.String("transforms", newPipeline.Names()),
-			slog.Int("postgres_listeners", len(newPgListeners)),
+			slog.Bool("postgres_listener", newPgListener != nil),
 		)
 		return nil
 	}

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -109,17 +109,17 @@ func main() {
 	errc := make(chan error, 5)
 
 	// Postgres listeners come from the local YAML postgres: block (self-managed
-	// proxies, inline DSNs) and, in managed mode, from env-derived listeners
-	// synced by the control plane. The manager is created up front so the
-	// config poller can hot-reload it; local policies are the base set that
-	// synced listeners are layered onto.
-	localPgPolicies, err := postgres.LoadFromNode(cfg.Postgres, logger)
+	// proxies, inline DSNs) and, in managed mode, from a control-plane-synced
+	// listener whose routes are derived from the sync payload. The manager is
+	// created up front so the config poller can hot-reload it; local listeners
+	// are the base set the synced listener is layered onto.
+	localPgListeners, err := postgres.LoadFromNode(cfg.Postgres, logger)
 	if err != nil {
 		logger.Error("loading postgres config", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	pgManager := postgres.NewManager(logger)
-	pgPolicies := localPgPolicies
+	pgListeners := localPgListeners
 
 	var holder *transform.PipelineHolder
 	var mcpHolder *mcp.PolicyHolder
@@ -127,7 +127,7 @@ func main() {
 
 	if managed {
 		var ingestToken string
-		holder, mcpHolder, ingestToken, pgPolicies = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgPolicies, logger)
+		holder, mcpHolder, ingestToken, pgListeners = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListeners, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -243,7 +243,7 @@ func main() {
 	if mgmtServer != nil {
 		go func() { errc <- fmt.Errorf("management: %w", mgmtServer.ListenAndServe()) }()
 	}
-	pgManager.Start(pgPolicies, errc)
+	pgManager.Start(pgListeners, errc)
 
 	startAttrs := []any{
 		slog.String("dns_listen", cfg.DNS.Listen),
@@ -310,7 +310,7 @@ func main() {
 //
 // Initial MCP policy preference: control-plane-supplied mcp block first, then
 // fall back to cfg.MCP from the YAML if the sync did not include one.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgPolicies []*postgres.Policy, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, []*postgres.Policy) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListeners []*postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, []*postgres.Listener) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -368,12 +368,13 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		os.Exit(1)
 	}
 
-	// Compute the initial postgres listener set: local YAML policies plus any
-	// synced listeners whose env vars are present. If the initial sync carried
-	// no postgres block (or an invalid one), fall back to the local policies.
-	pgPolicies := localPgPolicies
-	if policies, ok := postgresPoliciesFromSync(localPgPolicies, os.Getenv, logger, initialPostgres); ok {
-		pgPolicies = policies
+	// Compute the initial postgres listener set: local YAML listeners plus the
+	// control-plane-synced listener when its env vars are present. If the initial
+	// sync carried no postgres block (or an invalid one), fall back to the local
+	// listeners.
+	pgListeners := localPgListeners
+	if listeners, ok := postgresListenersFromSync(localPgListeners, os.Getenv, logger, initialPostgres); ok {
+		pgListeners = listeners
 	}
 
 	// Start config poller.
@@ -385,7 +386,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 			applyMCPSync(mcpHolder, logger, u.MCP)
 		}
 		if u.Postgres != nil {
-			applyPostgresSync(ctx, pgManager, localPgPolicies, os.Getenv, logger, u.Postgres)
+			applyPostgresSync(ctx, pgManager, localPgListeners, os.Getenv, logger, u.Postgres)
 		}
 		return nil
 	}, logger)
@@ -394,7 +395,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, mcpHolder, ingestToken, pgPolicies
+	return holder, mcpHolder, ingestToken, pgListeners
 }
 
 // buildInitialMCPHolder picks the initial MCP policy source: a control-plane
@@ -484,12 +485,21 @@ func applyMCPSync(holder *mcp.PolicyHolder, logger *slog.Logger, raw json.RawMes
 	}
 }
 
-// pgEnv returns the environment variable name carrying the given listener knob
-// for a control-plane-synced postgres upstream. foreignID is normalized to
-// env-safe form: uppercased, with '-', '.', and '~' mapped to '_' (the full set
-// of non-alphanumeric characters a foreign_id may contain). For foreignID
-// "pg-analytics" and suffix "LISTEN" the result is
-// "IRON_PROXY_PG_PG_ANALYTICS_LISTEN".
+// managedPgListenerName is the name given to the single listener that fronts
+// all control-plane-synced postgres routes.
+const managedPgListenerName = "control-plane"
+
+// pgListenEnv is the environment variable carrying the bind address for the
+// control-plane-synced postgres listener. A single listener now fronts every
+// synced upstream, so the bind address is shared rather than per-foreign-id.
+const pgListenEnv = "IRON_PROXY_PG_LISTEN"
+
+// pgEnv returns the environment variable name carrying the given per-route
+// client credential for a control-plane-synced postgres upstream. foreignID is
+// normalized to env-safe form: uppercased, with '-', '.', and '~' mapped to '_'
+// (the full set of non-alphanumeric characters a foreign_id may contain). For
+// foreignID "pg-analytics" and suffix "CLIENT_USER" the result is
+// "IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER".
 func pgEnv(foreignID, suffix string) string {
 	norm := strings.Map(func(r rune) rune {
 		switch r {
@@ -502,70 +512,92 @@ func pgEnv(foreignID, suffix string) string {
 	return "IRON_PROXY_PG_" + norm + "_" + suffix
 }
 
-// postgresPoliciesFromSync builds the full postgres policy set for managed mode:
-// the local YAML policies plus every control-plane-synced listener whose
-// LISTEN, CLIENT_USER, and CLIENT_PASSWORD env vars are all present. Local YAML
-// policies win on a foreign_id/name conflict, and the conflicting synced entry
-// is dropped with a log line. A synced entry missing any required env var is
-// skipped (also logged) — that is how a proxy granted a secret it isn't meant
-// to serve locally simply ignores it. Returns ok=false only when the sync
-// payload itself is invalid, signaling the caller to keep the current
-// listeners.
-func postgresPoliciesFromSync(local []*postgres.Policy, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) ([]*postgres.Policy, bool) {
+// postgresListenersFromSync builds the full postgres listener set for managed
+// mode: the local YAML listeners plus a single control-plane listener whose
+// routes are derived from the sync payload. The managed listener binds the
+// address in IRON_PROXY_PG_LISTEN; each synced entry becomes a route keyed by
+// its database, with per-route client credentials read from
+// IRON_PROXY_PG_<FOREIGN_ID>_CLIENT_USER / _CLIENT_PASSWORD. An entry missing
+// either credential is skipped (logged) — that is how a proxy granted a secret
+// it isn't meant to serve locally simply ignores it. When IRON_PROXY_PG_LISTEN
+// is unset or no entry resolves to a usable route, no managed listener is added.
+// Returns ok=false only when the sync payload itself is invalid, signaling the
+// caller to keep the current listeners.
+func postgresListenersFromSync(local []*postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) ([]*postgres.Listener, bool) {
 	entries, err := config.PostgresFromSync(raw, logger)
 	if err != nil {
 		logger.Error("rejecting invalid postgres config from sync, keeping current listeners", slog.String("error", err.Error()))
 		return nil, false
 	}
 
-	localNames := make(map[string]bool, len(local))
-	for _, p := range local {
-		localNames[p.Name()] = true
+	listeners := make([]*postgres.Listener, 0, len(local)+1)
+	listeners = append(listeners, local...)
+
+	listen := getenv(pgListenEnv)
+	if listen == "" {
+		if len(entries) > 0 {
+			logger.Info("skipping control-plane postgres routes: IRON_PROXY_PG_LISTEN not set",
+				slog.Int("route_count", len(entries)))
+		}
+		return listeners, true
 	}
 
-	policies := make([]*postgres.Policy, 0, len(local)+len(entries))
-	policies = append(policies, local...)
+	seenDatabases := make(map[string]bool, len(entries))
+	routes := make([]*postgres.Route, 0, len(entries))
 	for _, e := range entries {
-		if localNames[e.ForeignID] {
-			logger.Warn("postgres listener defined in both local config and control plane; keeping local",
-				slog.String("foreign_id", e.ForeignID))
-			continue
-		}
-		listen := getenv(pgEnv(e.ForeignID, "LISTEN"))
 		clientUser := getenv(pgEnv(e.ForeignID, "CLIENT_USER"))
 		clientPassword := getenv(pgEnv(e.ForeignID, "CLIENT_PASSWORD"))
-		if listen == "" || clientUser == "" || clientPassword == "" {
-			logger.Info("skipping synced postgres listener: required env vars not set",
+		if clientUser == "" || clientPassword == "" {
+			logger.Info("skipping synced postgres route: client credentials not set",
 				slog.String("foreign_id", e.ForeignID),
-				slog.Bool("has_listen", listen != ""),
 				slog.Bool("has_client_user", clientUser != ""),
 				slog.Bool("has_client_password", clientPassword != ""),
 			)
 			continue
 		}
-		p, err := postgres.NewManagedPolicy(e.ForeignID, listen, e.DSN, clientUser, clientPassword, e.Role)
+		if seenDatabases[e.Database] {
+			logger.Warn("skipping synced postgres route: duplicate database",
+				slog.String("foreign_id", e.ForeignID),
+				slog.String("database", e.Database),
+			)
+			continue
+		}
+		r, err := postgres.NewManagedRoute(e.Database, e.DSN, clientUser, clientPassword, e.Role)
 		if err != nil {
-			logger.Error("skipping synced postgres listener: invalid policy",
+			logger.Error("skipping synced postgres route: invalid route",
 				slog.String("foreign_id", e.ForeignID),
 				slog.String("error", err.Error()),
 			)
 			continue
 		}
-		policies = append(policies, p)
+		seenDatabases[e.Database] = true
+		routes = append(routes, r)
 	}
-	return policies, true
+
+	if len(routes) == 0 {
+		return listeners, true
+	}
+
+	managed, err := postgres.NewListener(managedPgListenerName, listen, routes)
+	if err != nil {
+		logger.Error("skipping control-plane postgres listener: invalid listener",
+			slog.String("error", err.Error()))
+		return listeners, true
+	}
+	listeners = append(listeners, managed)
+	return listeners, true
 }
 
 // applyPostgresSync rebuilds the postgres listener set from a sync payload and
 // hot-reloads the manager. An invalid payload is logged and the running
 // listeners are preserved.
-func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local []*postgres.Policy, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) {
-	policies, ok := postgresPoliciesFromSync(local, getenv, logger, raw)
+func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local []*postgres.Listener, getenv func(string) string, logger *slog.Logger, raw json.RawMessage) {
+	listeners, ok := postgresListenersFromSync(local, getenv, logger, raw)
 	if !ok {
 		return
 	}
-	mgr.Reload(ctx, policies)
-	logger.Info("postgres listeners reloaded from sync", slog.Int("count", len(policies)))
+	mgr.Reload(ctx, listeners)
+	logger.Info("postgres listeners reloaded from sync", slog.Int("count", len(listeners)))
 }
 
 // newReloadFunc returns a management.ReloadFunc that re-reads the YAML config
@@ -591,17 +623,17 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolde
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
-		newPgPolicies, err := postgres.LoadFromNode(newCfg.Postgres, logger)
+		newPgListeners, err := postgres.LoadFromNode(newCfg.Postgres, logger)
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
 		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 		holder.Store(newPipeline)
 		mcpHolder.Store(newPolicy)
-		pgManager.Reload(ctx, newPgPolicies)
+		pgManager.Reload(ctx, newPgListeners)
 		logger.Info("pipeline reloaded via management API",
 			slog.String("transforms", newPipeline.Names()),
-			slog.Int("postgres_servers", len(newPgPolicies)),
+			slog.Int("postgres_listeners", len(newPgListeners)),
 		)
 		return nil
 	}

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -32,108 +32,114 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// localListener builds a single-upstream local listener for conflict/passthrough
-// tests.
+// localListener builds a single-upstream local listener (with its own shared
+// client credential) for conflict/passthrough tests.
 func localListener(t *testing.T, database string) *postgres.Listener {
 	t.Helper()
-	u, err := postgres.NewManagedUpstream(database, staticSource{name: "local", value: "host=local"}, "u", "p", "")
+	u, err := postgres.NewManagedUpstream(database, staticSource{name: "local", value: "host=local"}, "")
 	require.NoError(t, err)
-	l, err := postgres.NewListener("127.0.0.1:0", []*postgres.Upstream{u})
+	l, err := postgres.NewListener("127.0.0.1:0", "u", "p", []*postgres.Upstream{u})
 	require.NoError(t, err)
 	return l
 }
 
-func TestPostgresListenerFromSync_Basic(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"client_user":"app","client_password":"s3cret","role":"readonly"}]`)
-	// The single bind address is the only thing read from the environment.
-	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
+// pgListenerEnv is the env set needed to build a managed listener from sync when
+// there is no local YAML listener: bind address plus the shared client credential.
+func pgListenerEnv() map[string]string {
+	return map[string]string{
+		"IRON_PROXY_PG_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_CLIENT_PASSWORD": "s3cret",
+	}
+}
 
-	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
+func TestPostgresListenerFromSync_Basic(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
+
+	listener, ok := postgresListenerFromSync(nil, mapEnv(pgListenerEnv()), discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, "127.0.0.1:0", listener.Listen())
+	// The client credential is the single shared one from the environment.
+	require.True(t, listener.VerifyClient("app", "s3cret"))
 
 	// Routed by the synced database, which is independent of the foreign_id.
 	upstream := listener.Upstream("analytics")
 	require.NotNil(t, upstream)
 	require.Nil(t, listener.Upstream("pg-analytics"))
 	require.Equal(t, "readonly", upstream.Role())
-	require.True(t, upstream.VerifyClient("app", "s3cret"))
 }
 
 func TestPostgresListenerFromSync_NoRole(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","database":"maindb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
-	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","database":"maindb","dsn":{"type":"env","var":"PG_DSN"}}]`)
 
-	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
+	listener, ok := postgresListenerFromSync(nil, mapEnv(pgListenerEnv()), discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Empty(t, listener.Upstream("maindb").Role(), "absent role must be a no-op")
 }
 
-func TestPostgresListenerFromSync_MissingCredsRejectsPayload(t *testing.T) {
-	// Client credentials now come from the sync payload, so an entry missing
-	// them is an invalid payload, not a skip.
+func TestPostgresListenerFromSync_MissingClientEnvDropsUpstreams(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
+	// Bind address set but the shared client credential env is missing: with no
+	// local listener to source it from, no listener is built.
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
-	require.False(t, ok, "an entry missing client credentials is an invalid payload")
+	require.True(t, ok)
 	require.Nil(t, listener)
-	require.Contains(t, logBuf.String(), "rejecting invalid postgres config")
+	require.Contains(t, logBuf.String(), "listener env not fully set")
 }
 
-func TestPostgresListenerFromSync_NoListenAddressDropsUpstreams(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+func TestPostgresListenerFromSync_NoListenEnvDropsUpstreams(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	// No local listener and IRON_PROXY_PG_LISTEN unset: there is no address to
-	// bind, so the synced upstreams are dropped.
+	// No local listener and no env at all: nothing to bind, upstreams dropped.
 	listener, ok := postgresListenerFromSync(nil, mapEnv(nil), logger, raw)
 	require.True(t, ok)
 	require.Nil(t, listener)
-	require.Contains(t, logBuf.String(), "no listen address")
+	require.Contains(t, logBuf.String(), "listener env not fully set")
 }
 
 func TestPostgresListenerFromSync_MergesLocalAndSynced(t *testing.T) {
 	local := localListener(t, "appdb")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
-	// No IRON_PROXY_PG_LISTEN: the bind address comes from the local listener.
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	// No env: the bind address and client credential come from the local listener.
 	listener, ok := postgresListenerFromSync(local, mapEnv(nil), discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, local.Listen(), listener.Listen())
+	require.True(t, listener.VerifyClient("u", "p"), "local client credential carried over")
 	require.NotNil(t, listener.Upstream("appdb"), "local upstream preserved")
 	require.NotNil(t, listener.Upstream("analytics"), "synced upstream layered on")
 }
 
 func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
 	local := localListener(t, "shared")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
 	listener, ok := postgresListenerFromSync(local, mapEnv(nil), logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	// The local upstream (user "u") wins over the synced one (user "app").
-	require.True(t, listener.Upstream("shared").VerifyClient("u", "p"))
+	require.Len(t, listener.Upstreams(), 1, "the synced upstream colliding with the local one is dropped")
 	require.Contains(t, logBuf.String(), "duplicate database")
 }
 
 func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"},
-		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}
+		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"}},
+		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}
 	]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
-	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
+	listener, ok := postgresListenerFromSync(nil, mapEnv(pgListenerEnv()), logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Len(t, listener.Upstreams(), 1)
@@ -165,10 +171,9 @@ func TestApplyPostgresSync_ReloadsListener(t *testing.T) {
 	mgr := postgres.NewManager(discardLogger())
 	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
 
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
-	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 
-	applyPostgresSync(context.Background(), mgr, nil, getenv, discardLogger(), raw)
+	applyPostgresSync(context.Background(), mgr, nil, mapEnv(pgListenerEnv()), discardLogger(), raw)
 	require.True(t, mgr.Running())
 }
 

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -59,7 +59,7 @@ func TestPgEnv(t *testing.T) {
 }
 
 func TestPostgresListenerFromSync_EnvPresent(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
@@ -71,7 +71,7 @@ func TestPostgresListenerFromSync_EnvPresent(t *testing.T) {
 	require.NotNil(t, listener)
 	require.Equal(t, "127.0.0.1:0", listener.Listen())
 
-	// The foreign_id is the routing database when none is supplied.
+	// Routed by the synced database (here equal to the foreign_id).
 	upstream := listener.Upstream("pg-analytics")
 	require.NotNil(t, upstream)
 	require.Equal(t, "readonly", upstream.Role())
@@ -95,7 +95,7 @@ func TestPostgresListenerFromSync_ExplicitDatabase(t *testing.T) {
 }
 
 func TestPostgresListenerFromSync_NoRole(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","database":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                 "127.0.0.1:0",
 		"IRON_PROXY_PG_PGMAIN_CLIENT_USER":     "app",
@@ -109,7 +109,7 @@ func TestPostgresListenerFromSync_NoRole(t *testing.T) {
 }
 
 func TestPostgresListenerFromSync_MissingCredsSkipsUpstream(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
@@ -126,7 +126,7 @@ func TestPostgresListenerFromSync_MissingCredsSkipsUpstream(t *testing.T) {
 }
 
 func TestPostgresListenerFromSync_NoListenAddressDropsUpstreams(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
@@ -225,7 +225,7 @@ func TestApplyPostgresSync_ReloadsListener(t *testing.T) {
 	mgr := postgres.NewManager(discardLogger())
 	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
 
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -32,13 +32,13 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// localListener builds a single-route local listener for conflict/passthrough
+// localListener builds a single-upstream local listener for conflict/passthrough
 // tests.
 func localListener(t *testing.T, database string) *postgres.Listener {
 	t.Helper()
-	r, err := postgres.NewManagedRoute(database, staticSource{name: "local", value: "host=local"}, "u", "p", "")
+	u, err := postgres.NewManagedUpstream(database, staticSource{name: "local", value: "host=local"}, "u", "p", "")
 	require.NoError(t, err)
-	l, err := postgres.NewListener("127.0.0.1:0", []*postgres.Route{r})
+	l, err := postgres.NewListener("127.0.0.1:0", []*postgres.Upstream{u})
 	require.NoError(t, err)
 	return l
 }
@@ -72,10 +72,10 @@ func TestPostgresListenerFromSync_EnvPresent(t *testing.T) {
 	require.Equal(t, "127.0.0.1:0", listener.Listen())
 
 	// The foreign_id is the routing database when none is supplied.
-	route := listener.Route("pg-analytics")
-	require.NotNil(t, route)
-	require.Equal(t, "readonly", route.Role())
-	require.True(t, route.VerifyClient("app", "s3cret"))
+	upstream := listener.Upstream("pg-analytics")
+	require.NotNil(t, upstream)
+	require.Equal(t, "readonly", upstream.Role())
+	require.True(t, upstream.VerifyClient("app", "s3cret"))
 }
 
 func TestPostgresListenerFromSync_ExplicitDatabase(t *testing.T) {
@@ -90,8 +90,8 @@ func TestPostgresListenerFromSync_ExplicitDatabase(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	// Routing key is the explicit database, not the foreign_id.
-	require.NotNil(t, listener.Route("analytics"))
-	require.Nil(t, listener.Route("pg-analytics"))
+	require.NotNil(t, listener.Upstream("analytics"))
+	require.Nil(t, listener.Upstream("pg-analytics"))
 }
 
 func TestPostgresListenerFromSync_NoRole(t *testing.T) {
@@ -105,16 +105,16 @@ func TestPostgresListenerFromSync_NoRole(t *testing.T) {
 	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	require.Empty(t, listener.Route("pgmain").Role(), "absent role must be a no-op")
+	require.Empty(t, listener.Upstream("pgmain").Role(), "absent role must be a no-op")
 }
 
-func TestPostgresListenerFromSync_MissingCredsSkipsRoute(t *testing.T) {
+func TestPostgresListenerFromSync_MissingCredsSkipsUpstream(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	// IRON_PROXY_PG_LISTEN is set but client credentials are missing: the route
-	// is skipped, and with no usable routes no listener is built.
+	// IRON_PROXY_PG_LISTEN is set but client credentials are missing: the upstream
+	// is skipped, and with no usable upstreams no listener is built.
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN": "127.0.0.1:0",
 	})
@@ -122,16 +122,16 @@ func TestPostgresListenerFromSync_MissingCredsSkipsRoute(t *testing.T) {
 	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
 	require.Nil(t, listener)
-	require.Contains(t, logBuf.String(), "skipping synced postgres route")
+	require.Contains(t, logBuf.String(), "skipping synced postgres upstream")
 }
 
-func TestPostgresListenerFromSync_NoListenAddressDropsRoutes(t *testing.T) {
+func TestPostgresListenerFromSync_NoListenAddressDropsUpstreams(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
 	// Credentials present but no local listener and IRON_PROXY_PG_LISTEN unset:
-	// there is no address to bind, so the synced routes are dropped.
+	// there is no address to bind, so the synced upstreams are dropped.
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
@@ -156,8 +156,8 @@ func TestPostgresListenerFromSync_MergesLocalAndSynced(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, local.Listen(), listener.Listen())
-	require.NotNil(t, listener.Route("appdb"), "local route preserved")
-	require.NotNil(t, listener.Route("analytics"), "synced route layered on")
+	require.NotNil(t, listener.Upstream("appdb"), "local upstream preserved")
+	require.NotNil(t, listener.Upstream("analytics"), "synced upstream layered on")
 }
 
 func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
@@ -173,8 +173,8 @@ func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
 	listener, ok := postgresListenerFromSync(local, getenv, logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	// The local route (user "u") wins over the synced one (user "app").
-	require.True(t, listener.Route("shared").VerifyClient("u", "p"))
+	// The local upstream (user "u") wins over the synced one (user "app").
+	require.True(t, listener.Upstream("shared").VerifyClient("u", "p"))
 	require.Contains(t, logBuf.String(), "duplicate database")
 }
 
@@ -196,8 +196,8 @@ func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
 	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	require.Len(t, listener.Routes(), 1)
-	require.NotNil(t, listener.Route("shared"))
+	require.Len(t, listener.Upstreams(), 1)
+	require.NotNil(t, listener.Upstream("shared"))
 	require.Contains(t, logBuf.String(), "duplicate database")
 }
 
@@ -218,7 +218,7 @@ func TestPostgresListenerFromSync_NullPayloadKeepsLocal(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, local.Listen(), listener.Listen())
-	require.NotNil(t, listener.Route("appdb"))
+	require.NotNil(t, listener.Upstream("appdb"))
 }
 
 func TestApplyPostgresSync_ReloadsListener(t *testing.T) {

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -43,101 +43,56 @@ func localListener(t *testing.T, database string) *postgres.Listener {
 	return l
 }
 
-func TestPgEnv(t *testing.T) {
-	cases := []struct {
-		foreignID, suffix, want string
-	}{
-		{"pg-analytics", "CLIENT_USER", "IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER"},
-		{"PG.Main", "CLIENT_USER", "IRON_PROXY_PG_PG_MAIN_CLIENT_USER"},
-		{"warehouse~1", "CLIENT_PASSWORD", "IRON_PROXY_PG_WAREHOUSE_1_CLIENT_PASSWORD"},
-		{"already_snake", "CLIENT_PASSWORD", "IRON_PROXY_PG_ALREADY_SNAKE_CLIENT_PASSWORD"},
-		{"db123", "CLIENT_USER", "IRON_PROXY_PG_DB123_CLIENT_USER"},
-	}
-	for _, c := range cases {
-		require.Equalf(t, c.want, pgEnv(c.foreignID, c.suffix), "pgEnv(%q,%q)", c.foreignID, c.suffix)
-	}
-}
-
-func TestPostgresListenerFromSync_EnvPresent(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "s3cret",
-	})
+func TestPostgresListenerFromSync_Basic(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"client_user":"app","client_password":"s3cret","role":"readonly"}]`)
+	// The single bind address is the only thing read from the environment.
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
 	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, "127.0.0.1:0", listener.Listen())
 
-	// Routed by the synced database (here equal to the foreign_id).
-	upstream := listener.Upstream("pg-analytics")
+	// Routed by the synced database, which is independent of the foreign_id.
+	upstream := listener.Upstream("analytics")
 	require.NotNil(t, upstream)
+	require.Nil(t, listener.Upstream("pg-analytics"))
 	require.Equal(t, "readonly", upstream.Role())
 	require.True(t, upstream.VerifyClient("app", "s3cret"))
 }
 
-func TestPostgresListenerFromSync_ExplicitDatabase(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
-	})
-
-	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
-	require.True(t, ok)
-	require.NotNil(t, listener)
-	// Routing key is the explicit database, not the foreign_id.
-	require.NotNil(t, listener.Upstream("analytics"))
-	require.Nil(t, listener.Upstream("pg-analytics"))
-}
-
 func TestPostgresListenerFromSync_NoRole(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","database":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN":                 "127.0.0.1:0",
-		"IRON_PROXY_PG_PGMAIN_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PGMAIN_CLIENT_PASSWORD": "pw",
-	})
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","database":"maindb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
 	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	require.Empty(t, listener.Upstream("pgmain").Role(), "absent role must be a no-op")
+	require.Empty(t, listener.Upstream("maindb").Role(), "absent role must be a no-op")
 }
 
-func TestPostgresListenerFromSync_MissingCredsSkipsUpstream(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+func TestPostgresListenerFromSync_MissingCredsRejectsPayload(t *testing.T) {
+	// Client credentials now come from the sync payload, so an entry missing
+	// them is an invalid payload, not a skip.
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-
-	// IRON_PROXY_PG_LISTEN is set but client credentials are missing: the upstream
-	// is skipped, and with no usable upstreams no listener is built.
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN": "127.0.0.1:0",
-	})
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
 	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
-	require.True(t, ok)
+	require.False(t, ok, "an entry missing client credentials is an invalid payload")
 	require.Nil(t, listener)
-	require.Contains(t, logBuf.String(), "skipping synced postgres upstream")
+	require.Contains(t, logBuf.String(), "rejecting invalid postgres config")
 }
 
 func TestPostgresListenerFromSync_NoListenAddressDropsUpstreams(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	// Credentials present but no local listener and IRON_PROXY_PG_LISTEN unset:
-	// there is no address to bind, so the synced upstreams are dropped.
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
-	})
-
-	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
+	// No local listener and IRON_PROXY_PG_LISTEN unset: there is no address to
+	// bind, so the synced upstreams are dropped.
+	listener, ok := postgresListenerFromSync(nil, mapEnv(nil), logger, raw)
 	require.True(t, ok)
 	require.Nil(t, listener)
 	require.Contains(t, logBuf.String(), "no listen address")
@@ -145,14 +100,9 @@ func TestPostgresListenerFromSync_NoListenAddressDropsUpstreams(t *testing.T) {
 
 func TestPostgresListenerFromSync_MergesLocalAndSynced(t *testing.T) {
 	local := localListener(t, "appdb")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
-	getenv := mapEnv(map[string]string{
-		// No IRON_PROXY_PG_LISTEN: the bind address comes from the local listener.
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
-	})
-
-	listener, ok := postgresListenerFromSync(local, getenv, discardLogger(), raw)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	// No IRON_PROXY_PG_LISTEN: the bind address comes from the local listener.
+	listener, ok := postgresListenerFromSync(local, mapEnv(nil), discardLogger(), raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Equal(t, local.Listen(), listener.Listen())
@@ -162,15 +112,11 @@ func TestPostgresListenerFromSync_MergesLocalAndSynced(t *testing.T) {
 
 func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
 	local := localListener(t, "shared")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
-	})
 
-	listener, ok := postgresListenerFromSync(local, getenv, logger, raw)
+	listener, ok := postgresListenerFromSync(local, mapEnv(nil), logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	// The local upstream (user "u") wins over the synced one (user "app").
@@ -180,18 +126,12 @@ func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
 
 func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"}},
-		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}
+		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"},
+		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}
 	]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN":            "127.0.0.1:0",
-		"IRON_PROXY_PG_A_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_A_CLIENT_PASSWORD": "pw",
-		"IRON_PROXY_PG_B_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_B_CLIENT_PASSWORD": "pw",
-	})
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
 	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
@@ -225,12 +165,8 @@ func TestApplyPostgresSync_ReloadsListener(t *testing.T) {
 	mgr := postgres.NewManager(discardLogger())
 	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
 
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
-	})
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	getenv := mapEnv(map[string]string{"IRON_PROXY_PG_LISTEN": "127.0.0.1:0"})
 
 	applyPostgresSync(context.Background(), mgr, nil, getenv, discardLogger(), raw)
 	require.True(t, mgr.Running())

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -34,11 +34,11 @@ func discardLogger() *slog.Logger {
 
 // localListener builds a single-route local listener for conflict/passthrough
 // tests.
-func localListener(t *testing.T, name, database string) *postgres.Listener {
+func localListener(t *testing.T, database string) *postgres.Listener {
 	t.Helper()
 	r, err := postgres.NewManagedRoute(database, staticSource{name: "local", value: "host=local"}, "u", "p", "")
 	require.NoError(t, err)
-	l, err := postgres.NewListener(name, "127.0.0.1:0", []*postgres.Route{r})
+	l, err := postgres.NewListener("127.0.0.1:0", []*postgres.Route{r})
 	require.NoError(t, err)
 	return l
 }
@@ -58,7 +58,7 @@ func TestPgEnv(t *testing.T) {
 	}
 }
 
-func TestPostgresListenersFromSync_EnvPresent(t *testing.T) {
+func TestPostgresListenerFromSync_EnvPresent(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
@@ -66,20 +66,19 @@ func TestPostgresListenersFromSync_EnvPresent(t *testing.T) {
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "s3cret",
 	})
 
-	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
-	require.Len(t, listeners, 1)
-	require.Equal(t, managedPgListenerName, listeners[0].Name())
-	require.Equal(t, "127.0.0.1:0", listeners[0].Listen())
+	require.NotNil(t, listener)
+	require.Equal(t, "127.0.0.1:0", listener.Listen())
 
 	// The foreign_id is the routing database when none is supplied.
-	route := listeners[0].Route("pg-analytics")
+	route := listener.Route("pg-analytics")
 	require.NotNil(t, route)
 	require.Equal(t, "readonly", route.Role())
 	require.True(t, route.VerifyClient("app", "s3cret"))
 }
 
-func TestPostgresListenersFromSync_ExplicitDatabase(t *testing.T) {
+func TestPostgresListenerFromSync_ExplicitDatabase(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
@@ -87,15 +86,15 @@ func TestPostgresListenersFromSync_ExplicitDatabase(t *testing.T) {
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
 	})
 
-	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
-	require.Len(t, listeners, 1)
+	require.NotNil(t, listener)
 	// Routing key is the explicit database, not the foreign_id.
-	require.NotNil(t, listeners[0].Route("analytics"))
-	require.Nil(t, listeners[0].Route("pg-analytics"))
+	require.NotNil(t, listener.Route("analytics"))
+	require.Nil(t, listener.Route("pg-analytics"))
 }
 
-func TestPostgresListenersFromSync_NoRole(t *testing.T) {
+func TestPostgresListenerFromSync_NoRole(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN":                 "127.0.0.1:0",
@@ -103,49 +102,83 @@ func TestPostgresListenersFromSync_NoRole(t *testing.T) {
 		"IRON_PROXY_PG_PGMAIN_CLIENT_PASSWORD": "pw",
 	})
 
-	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
-	require.Len(t, listeners, 1)
-	require.Empty(t, listeners[0].Route("pgmain").Role(), "absent role must be a no-op")
+	require.NotNil(t, listener)
+	require.Empty(t, listener.Route("pgmain").Role(), "absent role must be a no-op")
 }
 
-func TestPostgresListenersFromSync_MissingCredsSkipsRoute(t *testing.T) {
+func TestPostgresListenerFromSync_MissingCredsSkipsRoute(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
 	// IRON_PROXY_PG_LISTEN is set but client credentials are missing: the route
-	// is skipped, and with no usable routes no managed listener is added.
+	// is skipped, and with no usable routes no listener is built.
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_LISTEN": "127.0.0.1:0",
 	})
 
-	listeners, ok := postgresListenersFromSync(nil, getenv, logger, raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
-	require.Empty(t, listeners)
+	require.Nil(t, listener)
 	require.Contains(t, logBuf.String(), "skipping synced postgres route")
 }
 
-func TestPostgresListenersFromSync_NoListenEnvKeepsLocal(t *testing.T) {
-	local := localListener(t, "local-main", "appdb")
+func TestPostgresListenerFromSync_NoListenAddressDropsRoutes(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	// Credentials present but IRON_PROXY_PG_LISTEN unset: no managed listener,
-	// local listeners preserved.
+	// Credentials present but no local listener and IRON_PROXY_PG_LISTEN unset:
+	// there is no address to bind, so the synced routes are dropped.
 	getenv := mapEnv(map[string]string{
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
 	})
 
-	listeners, ok := postgresListenersFromSync([]*postgres.Listener{local}, getenv, logger, raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
-	require.Equal(t, []*postgres.Listener{local}, listeners)
-	require.Contains(t, logBuf.String(), "IRON_PROXY_PG_LISTEN not set")
+	require.Nil(t, listener)
+	require.Contains(t, logBuf.String(), "no listen address")
 }
 
-func TestPostgresListenersFromSync_DuplicateDatabaseDropped(t *testing.T) {
+func TestPostgresListenerFromSync_MergesLocalAndSynced(t *testing.T) {
+	local := localListener(t, "appdb")
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	getenv := mapEnv(map[string]string{
+		// No IRON_PROXY_PG_LISTEN: the bind address comes from the local listener.
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
+	})
+
+	listener, ok := postgresListenerFromSync(local, getenv, discardLogger(), raw)
+	require.True(t, ok)
+	require.NotNil(t, listener)
+	require.Equal(t, local.Listen(), listener.Listen())
+	require.NotNil(t, listener.Route("appdb"), "local route preserved")
+	require.NotNil(t, listener.Route("analytics"), "synced route layered on")
+}
+
+func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
+	local := localListener(t, "shared")
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
+	})
+
+	listener, ok := postgresListenerFromSync(local, getenv, logger, raw)
+	require.True(t, ok)
+	require.NotNil(t, listener)
+	// The local route (user "u") wins over the synced one (user "app").
+	require.True(t, listener.Route("shared").VerifyClient("u", "p"))
+	require.Contains(t, logBuf.String(), "duplicate database")
+}
+
+func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
 	raw := json.RawMessage(`[
 		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"}},
 		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}
@@ -160,32 +193,35 @@ func TestPostgresListenersFromSync_DuplicateDatabaseDropped(t *testing.T) {
 		"IRON_PROXY_PG_B_CLIENT_PASSWORD": "pw",
 	})
 
-	listeners, ok := postgresListenersFromSync(nil, getenv, logger, raw)
+	listener, ok := postgresListenerFromSync(nil, getenv, logger, raw)
 	require.True(t, ok)
-	require.Len(t, listeners, 1)
-	require.NotNil(t, listeners[0].Route("shared"))
+	require.NotNil(t, listener)
+	require.Len(t, listener.Routes(), 1)
+	require.NotNil(t, listener.Route("shared"))
 	require.Contains(t, logBuf.String(), "duplicate database")
 }
 
-func TestPostgresListenersFromSync_InvalidPayload(t *testing.T) {
+func TestPostgresListenerFromSync_InvalidPayload(t *testing.T) {
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	listeners, ok := postgresListenersFromSync(nil, mapEnv(nil), logger, json.RawMessage(`{not an array`))
+	listener, ok := postgresListenerFromSync(nil, mapEnv(nil), logger, json.RawMessage(`{not an array`))
 	require.False(t, ok, "invalid payload must signal keep-current")
-	require.Nil(t, listeners)
+	require.Nil(t, listener)
 	require.Contains(t, logBuf.String(), "rejecting invalid postgres config")
 }
 
-func TestPostgresListenersFromSync_NullPayloadKeepsLocal(t *testing.T) {
-	local := localListener(t, "local-main", "appdb")
+func TestPostgresListenerFromSync_NullPayloadKeepsLocal(t *testing.T) {
+	local := localListener(t, "appdb")
 
-	listeners, ok := postgresListenersFromSync([]*postgres.Listener{local}, mapEnv(nil), discardLogger(), json.RawMessage("null"))
+	listener, ok := postgresListenerFromSync(local, mapEnv(nil), discardLogger(), json.RawMessage("null"))
 	require.True(t, ok)
-	require.Equal(t, []*postgres.Listener{local}, listeners)
+	require.NotNil(t, listener)
+	require.Equal(t, local.Listen(), listener.Listen())
+	require.NotNil(t, listener.Route("appdb"))
 }
 
-func TestApplyPostgresSync_ReloadsListeners(t *testing.T) {
+func TestApplyPostgresSync_ReloadsListener(t *testing.T) {
 	mgr := postgres.NewManager(discardLogger())
 	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
 
@@ -197,7 +233,7 @@ func TestApplyPostgresSync_ReloadsListeners(t *testing.T) {
 	})
 
 	applyPostgresSync(context.Background(), mgr, nil, getenv, discardLogger(), raw)
-	require.Equal(t, []string{managedPgListenerName}, mgr.Names())
+	require.True(t, mgr.Running())
 }
 
 var _ secrets.Source = staticSource{}

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -18,7 +18,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
-// staticSource is a no-op secrets.Source for building local test policies.
+// staticSource is a no-op secrets.Source for building local test listeners.
 type staticSource struct{ name, value string }
 
 func (s staticSource) Name() string                        { return s.name }
@@ -32,109 +32,157 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// localListener builds a single-route local listener for conflict/passthrough
+// tests.
+func localListener(t *testing.T, name, database string) *postgres.Listener {
+	t.Helper()
+	r, err := postgres.NewManagedRoute(database, staticSource{name: "local", value: "host=local"}, "u", "p", "")
+	require.NoError(t, err)
+	l, err := postgres.NewListener(name, "127.0.0.1:0", []*postgres.Route{r})
+	require.NoError(t, err)
+	return l
+}
+
 func TestPgEnv(t *testing.T) {
 	cases := []struct {
 		foreignID, suffix, want string
 	}{
-		{"pg-analytics", "LISTEN", "IRON_PROXY_PG_PG_ANALYTICS_LISTEN"},
+		{"pg-analytics", "CLIENT_USER", "IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER"},
 		{"PG.Main", "CLIENT_USER", "IRON_PROXY_PG_PG_MAIN_CLIENT_USER"},
 		{"warehouse~1", "CLIENT_PASSWORD", "IRON_PROXY_PG_WAREHOUSE_1_CLIENT_PASSWORD"},
-		{"already_snake", "LISTEN", "IRON_PROXY_PG_ALREADY_SNAKE_LISTEN"},
-		{"db123", "LISTEN", "IRON_PROXY_PG_DB123_LISTEN"},
+		{"already_snake", "CLIENT_PASSWORD", "IRON_PROXY_PG_ALREADY_SNAKE_CLIENT_PASSWORD"},
+		{"db123", "CLIENT_USER", "IRON_PROXY_PG_DB123_CLIENT_USER"},
 	}
 	for _, c := range cases {
 		require.Equalf(t, c.want, pgEnv(c.foreignID, c.suffix), "pgEnv(%q,%q)", c.foreignID, c.suffix)
 	}
 }
 
-func TestPostgresPoliciesFromSync_EnvPresent(t *testing.T) {
+func TestPostgresListenersFromSync_EnvPresent(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"}]`)
 	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "s3cret",
 	})
 
-	policies, ok := postgresPoliciesFromSync(nil, getenv, discardLogger(), raw)
+	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
-	require.Len(t, policies, 1)
-	require.Equal(t, "pg-analytics", policies[0].Name())
-	require.Equal(t, "127.0.0.1:0", policies[0].Listen())
-	require.Equal(t, "readonly", policies[0].Role())
-	require.True(t, policies[0].VerifyClient("app", "s3cret"))
+	require.Len(t, listeners, 1)
+	require.Equal(t, managedPgListenerName, listeners[0].Name())
+	require.Equal(t, "127.0.0.1:0", listeners[0].Listen())
+
+	// The foreign_id is the routing database when none is supplied.
+	route := listeners[0].Route("pg-analytics")
+	require.NotNil(t, route)
+	require.Equal(t, "readonly", route.Role())
+	require.True(t, route.VerifyClient("app", "s3cret"))
 }
 
-func TestPostgresPoliciesFromSync_NoRole(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
+func TestPostgresListenersFromSync_ExplicitDatabase(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PGMAIN_LISTEN":          "127.0.0.1:0",
-		"IRON_PROXY_PG_PGMAIN_CLIENT_USER":     "app",
-		"IRON_PROXY_PG_PGMAIN_CLIENT_PASSWORD": "pw",
-	})
-
-	policies, ok := postgresPoliciesFromSync(nil, getenv, discardLogger(), raw)
-	require.True(t, ok)
-	require.Len(t, policies, 1)
-	require.Empty(t, policies[0].Role(), "absent role must be a no-op")
-}
-
-func TestPostgresPoliciesFromSync_MissingEnvSkipped(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
-	logBuf := &bytes.Buffer{}
-	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-
-	// LISTEN is set but client credentials are missing: the entry is skipped,
-	// not an error.
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN": "127.0.0.1:0",
-	})
-
-	policies, ok := postgresPoliciesFromSync(nil, getenv, logger, raw)
-	require.True(t, ok)
-	require.Empty(t, policies)
-	require.Contains(t, logBuf.String(), "skipping synced postgres listener")
-}
-
-func TestPostgresPoliciesFromSync_LocalWinsOnConflict(t *testing.T) {
-	local, err := postgres.NewManagedPolicy("pg-analytics", "127.0.0.1:0",
-		staticSource{name: "local", value: "host=local"}, "localuser", "localpw", "")
-	require.NoError(t, err)
-
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"},"role":"readonly"}]`)
-	logBuf := &bytes.Buffer{}
-	logger := slog.New(slog.NewTextHandler(logBuf, nil))
-	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
 	})
 
-	policies, ok := postgresPoliciesFromSync([]*postgres.Policy{local}, getenv, logger, raw)
+	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
 	require.True(t, ok)
-	require.Len(t, policies, 1, "synced entry colliding with local must be dropped")
-	require.Same(t, local, policies[0])
-	require.Empty(t, policies[0].Role(), "the local policy (no role) must win")
-	require.Contains(t, logBuf.String(), "defined in both local config and control plane")
+	require.Len(t, listeners, 1)
+	// Routing key is the explicit database, not the foreign_id.
+	require.NotNil(t, listeners[0].Route("analytics"))
+	require.Nil(t, listeners[0].Route("pg-analytics"))
 }
 
-func TestPostgresPoliciesFromSync_InvalidPayload(t *testing.T) {
+func TestPostgresListenersFromSync_NoRole(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pgmain","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_LISTEN":                 "127.0.0.1:0",
+		"IRON_PROXY_PG_PGMAIN_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PGMAIN_CLIENT_PASSWORD": "pw",
+	})
+
+	listeners, ok := postgresListenersFromSync(nil, getenv, discardLogger(), raw)
+	require.True(t, ok)
+	require.Len(t, listeners, 1)
+	require.Empty(t, listeners[0].Route("pgmain").Role(), "absent role must be a no-op")
+}
+
+func TestPostgresListenersFromSync_MissingCredsSkipsRoute(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(logBuf, nil))
 
-	policies, ok := postgresPoliciesFromSync(nil, mapEnv(nil), logger, json.RawMessage(`{not an array`))
+	// IRON_PROXY_PG_LISTEN is set but client credentials are missing: the route
+	// is skipped, and with no usable routes no managed listener is added.
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_LISTEN": "127.0.0.1:0",
+	})
+
+	listeners, ok := postgresListenersFromSync(nil, getenv, logger, raw)
+	require.True(t, ok)
+	require.Empty(t, listeners)
+	require.Contains(t, logBuf.String(), "skipping synced postgres route")
+}
+
+func TestPostgresListenersFromSync_NoListenEnvKeepsLocal(t *testing.T) {
+	local := localListener(t, "local-main", "appdb")
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	// Credentials present but IRON_PROXY_PG_LISTEN unset: no managed listener,
+	// local listeners preserved.
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
+	})
+
+	listeners, ok := postgresListenersFromSync([]*postgres.Listener{local}, getenv, logger, raw)
+	require.True(t, ok)
+	require.Equal(t, []*postgres.Listener{local}, listeners)
+	require.Contains(t, logBuf.String(), "IRON_PROXY_PG_LISTEN not set")
+}
+
+func TestPostgresListenersFromSync_DuplicateDatabaseDropped(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"}},
+		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}
+	]`)
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+	getenv := mapEnv(map[string]string{
+		"IRON_PROXY_PG_LISTEN":            "127.0.0.1:0",
+		"IRON_PROXY_PG_A_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_A_CLIENT_PASSWORD": "pw",
+		"IRON_PROXY_PG_B_CLIENT_USER":     "app",
+		"IRON_PROXY_PG_B_CLIENT_PASSWORD": "pw",
+	})
+
+	listeners, ok := postgresListenersFromSync(nil, getenv, logger, raw)
+	require.True(t, ok)
+	require.Len(t, listeners, 1)
+	require.NotNil(t, listeners[0].Route("shared"))
+	require.Contains(t, logBuf.String(), "duplicate database")
+}
+
+func TestPostgresListenersFromSync_InvalidPayload(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, nil))
+
+	listeners, ok := postgresListenersFromSync(nil, mapEnv(nil), logger, json.RawMessage(`{not an array`))
 	require.False(t, ok, "invalid payload must signal keep-current")
-	require.Nil(t, policies)
+	require.Nil(t, listeners)
 	require.Contains(t, logBuf.String(), "rejecting invalid postgres config")
 }
 
-func TestPostgresPoliciesFromSync_NullPayloadKeepsLocal(t *testing.T) {
-	local, err := postgres.NewManagedPolicy("pgmain", "127.0.0.1:0",
-		staticSource{name: "local", value: "host=local"}, "u", "p", "")
-	require.NoError(t, err)
+func TestPostgresListenersFromSync_NullPayloadKeepsLocal(t *testing.T) {
+	local := localListener(t, "local-main", "appdb")
 
-	policies, ok := postgresPoliciesFromSync([]*postgres.Policy{local}, mapEnv(nil), discardLogger(), json.RawMessage("null"))
+	listeners, ok := postgresListenersFromSync([]*postgres.Listener{local}, mapEnv(nil), discardLogger(), json.RawMessage("null"))
 	require.True(t, ok)
-	require.Equal(t, []*postgres.Policy{local}, policies)
+	require.Equal(t, []*postgres.Listener{local}, listeners)
 }
 
 func TestApplyPostgresSync_ReloadsListeners(t *testing.T) {
@@ -143,13 +191,13 @@ func TestApplyPostgresSync_ReloadsListeners(t *testing.T) {
 
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	getenv := mapEnv(map[string]string{
-		"IRON_PROXY_PG_PG_ANALYTICS_LISTEN":          "127.0.0.1:0",
+		"IRON_PROXY_PG_LISTEN":                       "127.0.0.1:0",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_USER":     "app",
 		"IRON_PROXY_PG_PG_ANALYTICS_CLIENT_PASSWORD": "pw",
 	})
 
 	applyPostgresSync(context.Background(), mgr, nil, getenv, discardLogger(), raw)
-	require.Equal(t, []string{"pg-analytics"}, mgr.Names())
+	require.Equal(t, []string{managedPgListenerName}, mgr.Names())
 }
 
 var _ secrets.Source = staticSource{}

--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -374,14 +374,14 @@ func TestPostgresPolicy(t *testing.T) {
 	})
 }
 
-// TestPostgresMultipleRoutes boots one Postgres container and an iron-proxy
-// with a single postgres listener that fronts two routes — each keyed by a
+// TestPostgresMultipleUpstreams boots one Postgres container and an iron-proxy
+// with a single postgres listener that fronts two upstreams — each keyed by a
 // distinct database name and configured with a different injected role. Both
-// routes share the same physical upstream; the client selects between them by
-// the database name it requests. Verifies each route enforces its own role
+// upstreams share the same physical database; the client selects between them by
+// the database name it requests. Verifies each upstream enforces its own role
 // independently, including RLS scoping, and that an unknown database is
 // rejected.
-func TestPostgresMultipleRoutes(t *testing.T) {
+func TestPostgresMultipleUpstreams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
@@ -417,7 +417,7 @@ func TestPostgresMultipleRoutes(t *testing.T) {
 
 	pgAddr := proxy.AddrFor(t, "postgres proxy starting")
 
-	// connStrTo selects a route by the database name in the DSN. Both routes
+	// connStrTo selects an upstream by the database name in the DSN. Both
 	// live on the same listener; only the database differs.
 	connStrTo := func(database string) string {
 		host, port, _ := net.SplitHostPort(pgAddr)
@@ -439,37 +439,37 @@ func TestPostgresMultipleRoutes(t *testing.T) {
 		return string(results[0].Rows[0][0])
 	}
 
-	t.Run("each route enforces its own role", func(t *testing.T) {
+	t.Run("each upstream enforces its own role", func(t *testing.T) {
 		require.Equal(t, "tenant_role", queryRole(t, "tenant"))
 		require.Equal(t, "other_role", queryRole(t, "other"))
 	})
 
-	t.Run("rls scopes rows differently per route", func(t *testing.T) {
+	t.Run("rls scopes rows differently per upstream", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		// Through the tenant route: tenant_role sees only tenant_role's rows.
+		// Through the tenant upstream: tenant_role sees only tenant_role's rows.
 		tenant, err := pgx.Connect(ctx, connStrTo("tenant"))
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = tenant.Close(ctx) })
 		var tenantCount int
 		require.NoError(t, tenant.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&tenantCount))
-		require.Equal(t, 2, tenantCount, "tenant route should see only tenant_role's rows")
+		require.Equal(t, 2, tenantCount, "tenant upstream should see only tenant_role's rows")
 
-		// Through the other route: other_role sees only other_role's rows.
+		// Through the other upstream: other_role sees only other_role's rows.
 		other, err := pgx.Connect(ctx, connStrTo("other"))
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = other.Close(ctx) })
 		var otherCount int
 		require.NoError(t, other.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&otherCount))
-		require.Equal(t, 3, otherCount, "other route should see only other_role's rows")
+		require.Equal(t, 3, otherCount, "other upstream should see only other_role's rows")
 	})
 
 	t.Run("unknown database is rejected", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_, err := pgconn.Connect(ctx, connStrTo("nonexistent"))
-		require.Error(t, err, "a database with no matching route must be rejected")
+		require.Error(t, err, "a database with no matching upstream must be rejected")
 		var pgErr *pgconn.PgError
 		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
 		require.Equal(t, "3D000", pgErr.Code)

--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -374,12 +374,12 @@ func TestPostgresPolicy(t *testing.T) {
 	})
 }
 
-// TestPostgresMultipleUpstreams boots one Postgres container and an iron-proxy
-// with a single postgres listener that fronts two upstreams — each keyed by a
-// distinct database name and configured with a different injected role. Both
-// upstreams share the same physical database; the client selects between them by
-// the database name it requests. Verifies each upstream enforces its own role
-// independently, including RLS scoping, and that an unknown database is
+// TestPostgresMultipleUpstreams boots one Postgres container (with two
+// databases) and an iron-proxy whose single listener fronts two upstreams —
+// each routing to a distinct database with its own injected role. The client
+// selects between them by the database name it requests. Verifies routing lands
+// on the right database and role, that an upstream whose DSN database does not
+// match its routing database is rejected, and that an unknown database is
 // rejected.
 func TestPostgresMultipleUpstreams(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -407,62 +407,75 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 
 	cfgPath := renderConfig(t, t.TempDir(), "postgres_multi_pipeline.yaml", nil)
 
-	upstreamDSN := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
-		pgUpstreamUser, pgUpstreamPass, upstreamHost, upstreamPort.Num(), pgUpstreamDB)
+	dsnFor := func(database string) string {
+		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+			pgUpstreamUser, pgUpstreamPass, upstreamHost, upstreamPort.Num(), database)
+	}
 	env := []string{
-		"PG_UPSTREAM_DSN=" + upstreamDSN,
+		"PG_UPSTREAM_DSN=" + dsnFor(pgUpstreamDB), // appdb
+		"PG_OTHER_DSN=" + dsnFor("otherdb"),
 		"PG_PROXY_PASSWORD=" + pgClientPassword,
 	}
 	proxy := startProxy(t, proxyBinary(t), cfgPath, env)
 
 	pgAddr := proxy.AddrFor(t, "postgres proxy starting")
 
-	// connStrTo selects an upstream by the database name in the DSN. Both
-	// live on the same listener; only the database differs.
+	// connStrTo selects an upstream by the database name the client requests.
+	// Every upstream lives on the same listener; only the database differs.
 	connStrTo := func(database string) string {
 		host, port, _ := net.SplitHostPort(pgAddr)
 		return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
 			pgClientUser, pgClientPassword, host, port, database)
 	}
 
-	queryRole := func(t *testing.T, database string) string {
+	queryScalar := func(t *testing.T, database, sql string) string {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		conn, err := pgconn.Connect(ctx, connStrTo(database))
 		require.NoError(t, err)
 		defer func() { _ = conn.Close(context.Background()) }()
-		results, err := conn.Exec(ctx, "SELECT current_role").ReadAll()
+		results, err := conn.Exec(ctx, sql).ReadAll()
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 		require.Len(t, results[0].Rows, 1)
 		return string(results[0].Rows[0][0])
 	}
 
-	t.Run("each upstream enforces its own role", func(t *testing.T) {
-		require.Equal(t, "tenant_role", queryRole(t, "tenant"))
-		require.Equal(t, "other_role", queryRole(t, "other"))
+	t.Run("each upstream routes to its own database and role", func(t *testing.T) {
+		require.Equal(t, "appdb", queryScalar(t, "appdb", "SELECT current_database()"))
+		require.Equal(t, "tenant_role", queryScalar(t, "appdb", "SELECT current_role"))
+
+		require.Equal(t, "otherdb", queryScalar(t, "otherdb", "SELECT current_database()"))
+		require.Equal(t, "other_role", queryScalar(t, "otherdb", "SELECT current_role"))
 	})
 
-	t.Run("rls scopes rows differently per upstream", func(t *testing.T) {
+	t.Run("role scopes rows via rls on the appdb upstream", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		// Through the tenant upstream: tenant_role sees only tenant_role's rows.
-		tenant, err := pgx.Connect(ctx, connStrTo("tenant"))
+		// The appdb upstream injects tenant_role, so RLS scopes the client to
+		// tenant_role's rows.
+		client, err := pgx.Connect(ctx, connStrTo("appdb"))
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = tenant.Close(ctx) })
-		var tenantCount int
-		require.NoError(t, tenant.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&tenantCount))
-		require.Equal(t, 2, tenantCount, "tenant upstream should see only tenant_role's rows")
+		t.Cleanup(func() { _ = client.Close(ctx) })
+		var count int
+		require.NoError(t, client.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&count))
+		require.Equal(t, 2, count, "appdb upstream should see only tenant_role's rows")
+	})
 
-		// Through the other upstream: other_role sees only other_role's rows.
-		other, err := pgx.Connect(ctx, connStrTo("other"))
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = other.Close(ctx) })
-		var otherCount int
-		require.NoError(t, other.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&otherCount))
-		require.Equal(t, 3, otherCount, "other upstream should see only other_role's rows")
+	t.Run("database not matching the dsn is rejected", func(t *testing.T) {
+		// The "mismatch" upstream routes database "mismatch" to a DSN that
+		// connects to appdb. The proxy must refuse it rather than silently land
+		// the client on appdb.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := pgconn.Connect(ctx, connStrTo("mismatch"))
+		require.Error(t, err, "an upstream whose DSN database differs from its route database must be rejected")
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
+		require.Equal(t, "3D000", pgErr.Code)
+		require.Contains(t, pgErr.Message, "mismatch")
 	})
 
 	t.Run("unknown database is rejected", func(t *testing.T) {

--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -374,11 +374,14 @@ func TestPostgresPolicy(t *testing.T) {
 	})
 }
 
-// TestPostgresMultipleServers boots one Postgres container and an iron-proxy
-// with two postgres listeners pointing at it — each configured with a
-// different injected role. Verifies they enforce their own roles
-// independently, including RLS scoping.
-func TestPostgresMultipleServers(t *testing.T) {
+// TestPostgresMultipleRoutes boots one Postgres container and an iron-proxy
+// with a single postgres listener that fronts two routes — each keyed by a
+// distinct database name and configured with a different injected role. Both
+// routes share the same physical upstream; the client selects between them by
+// the database name it requests. Verifies each route enforces its own role
+// independently, including RLS scoping, and that an unknown database is
+// rejected.
+func TestPostgresMultipleRoutes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
@@ -412,21 +415,21 @@ func TestPostgresMultipleServers(t *testing.T) {
 	}
 	proxy := startProxy(t, proxyBinary(t), cfgPath, env)
 
-	primaryAddr := proxy.AddrForNamed(t, "postgres proxy starting", "primary")
-	secondaryAddr := proxy.AddrForNamed(t, "postgres proxy starting", "secondary")
-	require.NotEqual(t, primaryAddr, secondaryAddr, "each named server must bind a distinct port")
+	pgAddr := proxy.AddrFor(t, "postgres proxy starting")
 
-	connStrTo := func(addr string) string {
-		host, port, _ := net.SplitHostPort(addr)
+	// connStrTo selects a route by the database name in the DSN. Both routes
+	// live on the same listener; only the database differs.
+	connStrTo := func(database string) string {
+		host, port, _ := net.SplitHostPort(pgAddr)
 		return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-			pgClientUser, pgClientPassword, host, port, pgUpstreamDB)
+			pgClientUser, pgClientPassword, host, port, database)
 	}
 
-	queryRole := func(t *testing.T, addr string) string {
+	queryRole := func(t *testing.T, database string) string {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		conn, err := pgconn.Connect(ctx, connStrTo(addr))
+		conn, err := pgconn.Connect(ctx, connStrTo(database))
 		require.NoError(t, err)
 		defer func() { _ = conn.Close(context.Background()) }()
 		results, err := conn.Exec(ctx, "SELECT current_role").ReadAll()
@@ -436,29 +439,39 @@ func TestPostgresMultipleServers(t *testing.T) {
 		return string(results[0].Rows[0][0])
 	}
 
-	t.Run("each listener enforces its own role", func(t *testing.T) {
-		require.Equal(t, "tenant_role", queryRole(t, primaryAddr))
-		require.Equal(t, "other_role", queryRole(t, secondaryAddr))
+	t.Run("each route enforces its own role", func(t *testing.T) {
+		require.Equal(t, "tenant_role", queryRole(t, "tenant"))
+		require.Equal(t, "other_role", queryRole(t, "other"))
 	})
 
-	t.Run("rls scopes rows differently per listener", func(t *testing.T) {
+	t.Run("rls scopes rows differently per route", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		// Through the primary listener: tenant_role sees only tenant_role's rows.
-		primary, err := pgx.Connect(ctx, connStrTo(primaryAddr))
+		// Through the tenant route: tenant_role sees only tenant_role's rows.
+		tenant, err := pgx.Connect(ctx, connStrTo("tenant"))
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = primary.Close(ctx) })
-		var primaryCount int
-		require.NoError(t, primary.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&primaryCount))
-		require.Equal(t, 2, primaryCount, "primary listener should see only tenant_role's rows")
+		t.Cleanup(func() { _ = tenant.Close(ctx) })
+		var tenantCount int
+		require.NoError(t, tenant.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&tenantCount))
+		require.Equal(t, 2, tenantCount, "tenant route should see only tenant_role's rows")
 
-		// Through the secondary listener: other_role sees only other_role's rows.
-		secondary, err := pgx.Connect(ctx, connStrTo(secondaryAddr))
+		// Through the other route: other_role sees only other_role's rows.
+		other, err := pgx.Connect(ctx, connStrTo("other"))
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = secondary.Close(ctx) })
-		var secondaryCount int
-		require.NoError(t, secondary.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&secondaryCount))
-		require.Equal(t, 3, secondaryCount, "secondary listener should see only other_role's rows")
+		t.Cleanup(func() { _ = other.Close(ctx) })
+		var otherCount int
+		require.NoError(t, other.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&otherCount))
+		require.Equal(t, 3, otherCount, "other route should see only other_role's rows")
+	})
+
+	t.Run("unknown database is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := pgconn.Connect(ctx, connStrTo("nonexistent"))
+		require.Error(t, err, "a database with no matching route must be rejected")
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
+		require.Equal(t, "3D000", pgErr.Code)
 	})
 }

--- a/integration_test/testdata/postgres_init.sql
+++ b/integration_test/testdata/postgres_init.sql
@@ -34,3 +34,10 @@ INSERT INTO items (owner, data) VALUES
   ('other_role',  'theirs-1'),
   ('other_role',  'theirs-2'),
   ('other_role',  'theirs-3');
+
+-- A second database so the multi-upstream test can route to two distinct
+-- databases. The proxy requires each upstream's routing database to match the
+-- database its DSN connects to, so testing more than one upstream needs more
+-- than one real database. Roles are cluster-global, so tenant_role/other_role
+-- are usable here too.
+CREATE DATABASE otherdb;

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -13,6 +13,9 @@ tls:
 
 postgres:
   listen: "127.0.0.1:0"
+  client:
+    user: app_user
+    password_env: PG_PROXY_PASSWORD
   upstreams:
     # Two upstreams routing to two distinct databases, each injecting its own
     # role. Each upstream's database must match the database its DSN connects to.
@@ -20,18 +23,12 @@ postgres:
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
-      client:
-        user: app_user
-        password_env: PG_PROXY_PASSWORD
       role: tenant_role
 
     - database: otherdb
       dsn:
         type: env
         var: PG_OTHER_DSN
-      client:
-        user: app_user
-        password_env: PG_PROXY_PASSWORD
       role: other_role
 
     # Deliberately misconfigured: the routing database "mismatch" does not match
@@ -41,9 +38,6 @@ postgres:
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
-      client:
-        user: app_user
-        password_env: PG_PROXY_PASSWORD
       role: tenant_role
 
 metrics:

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -13,25 +13,23 @@ tls:
 
 postgres:
   listen: "127.0.0.1:0"
-  routes:
-    # Both routes front the same physical upstream (appdb) but inject a
-    # different role. The client picks the route by the database name it
+  upstreams:
+    # Both upstreams front the same physical database (appdb) but inject a
+    # different role. The client picks the upstream by the database name it
     # requests; the upstream database is whatever the DSN names.
     - database: tenant
-      upstream:
-        dsn:
-          type: env
-          var: PG_UPSTREAM_DSN
+      dsn:
+        type: env
+        var: PG_UPSTREAM_DSN
       client:
         user: app_user
         password_env: PG_PROXY_PASSWORD
       role: tenant_role
 
     - database: other
-      upstream:
-        dsn:
-          type: env
-          var: PG_UPSTREAM_DSN
+      dsn:
+        type: env
+        var: PG_UPSTREAM_DSN
       client:
         user: app_user
         password_env: PG_PROXY_PASSWORD

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -12,27 +12,31 @@ tls:
   ca_key: tmp/ca.key
 
 postgres:
-  - name: primary
+  - name: main
     listen: "127.0.0.1:0"
-    upstream:
-      dsn:
-        type: env
-        var: PG_UPSTREAM_DSN
-    client:
-      user: app_user
-      password_env: PG_PROXY_PASSWORD
-    role: tenant_role
+    routes:
+      # Both routes front the same physical upstream (appdb) but inject a
+      # different role. The client picks the route by the database name it
+      # requests; the upstream database is whatever the DSN names.
+      - database: tenant
+        upstream:
+          dsn:
+            type: env
+            var: PG_UPSTREAM_DSN
+        client:
+          user: app_user
+          password_env: PG_PROXY_PASSWORD
+        role: tenant_role
 
-  - name: secondary
-    listen: "127.0.0.1:0"
-    upstream:
-      dsn:
-        type: env
-        var: PG_UPSTREAM_DSN
-    client:
-      user: app_user
-      password_env: PG_PROXY_PASSWORD
-    role: other_role
+      - database: other
+        upstream:
+          dsn:
+            type: env
+            var: PG_UPSTREAM_DSN
+        client:
+          user: app_user
+          password_env: PG_PROXY_PASSWORD
+        role: other_role
 
 metrics:
   listen: "127.0.0.1:0"

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -12,31 +12,30 @@ tls:
   ca_key: tmp/ca.key
 
 postgres:
-  - name: main
-    listen: "127.0.0.1:0"
-    routes:
-      # Both routes front the same physical upstream (appdb) but inject a
-      # different role. The client picks the route by the database name it
-      # requests; the upstream database is whatever the DSN names.
-      - database: tenant
-        upstream:
-          dsn:
-            type: env
-            var: PG_UPSTREAM_DSN
-        client:
-          user: app_user
-          password_env: PG_PROXY_PASSWORD
-        role: tenant_role
+  listen: "127.0.0.1:0"
+  routes:
+    # Both routes front the same physical upstream (appdb) but inject a
+    # different role. The client picks the route by the database name it
+    # requests; the upstream database is whatever the DSN names.
+    - database: tenant
+      upstream:
+        dsn:
+          type: env
+          var: PG_UPSTREAM_DSN
+      client:
+        user: app_user
+        password_env: PG_PROXY_PASSWORD
+      role: tenant_role
 
-      - database: other
-        upstream:
-          dsn:
-            type: env
-            var: PG_UPSTREAM_DSN
-        client:
-          user: app_user
-          password_env: PG_PROXY_PASSWORD
-        role: other_role
+    - database: other
+      upstream:
+        dsn:
+          type: env
+          var: PG_UPSTREAM_DSN
+      client:
+        user: app_user
+        password_env: PG_PROXY_PASSWORD
+      role: other_role
 
 metrics:
   listen: "127.0.0.1:0"

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -14,10 +14,9 @@ tls:
 postgres:
   listen: "127.0.0.1:0"
   upstreams:
-    # Both upstreams front the same physical database (appdb) but inject a
-    # different role. The client picks the upstream by the database name it
-    # requests; the upstream database is whatever the DSN names.
-    - database: tenant
+    # Two upstreams routing to two distinct databases, each injecting its own
+    # role. Each upstream's database must match the database its DSN connects to.
+    - database: appdb
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
@@ -26,14 +25,26 @@ postgres:
         password_env: PG_PROXY_PASSWORD
       role: tenant_role
 
-    - database: other
+    - database: otherdb
+      dsn:
+        type: env
+        var: PG_OTHER_DSN
+      client:
+        user: app_user
+        password_env: PG_PROXY_PASSWORD
+      role: other_role
+
+    # Deliberately misconfigured: the routing database "mismatch" does not match
+    # the DSN's database (appdb). The proxy must reject clients that connect to
+    # it rather than silently land them on appdb.
+    - database: mismatch
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
       client:
         user: app_user
         password_env: PG_PROXY_PASSWORD
-      role: other_role
+      role: tenant_role
 
 metrics:
   listen: "127.0.0.1:0"

--- a/integration_test/testdata/postgres_pipeline.yaml
+++ b/integration_test/testdata/postgres_pipeline.yaml
@@ -13,14 +13,14 @@ tls:
 
 postgres:
   listen: "127.0.0.1:0"
+  client:
+    user: app_user
+    password_env: PG_PROXY_PASSWORD
   upstreams:
     - database: appdb
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
-      client:
-        user: app_user
-        password_env: PG_PROXY_PASSWORD
       role: tenant_role
 
 metrics:

--- a/integration_test/testdata/postgres_pipeline.yaml
+++ b/integration_test/testdata/postgres_pipeline.yaml
@@ -13,12 +13,11 @@ tls:
 
 postgres:
   listen: "127.0.0.1:0"
-  routes:
+  upstreams:
     - database: appdb
-      upstream:
-        dsn:
-          type: env
-          var: PG_UPSTREAM_DSN
+      dsn:
+        type: env
+        var: PG_UPSTREAM_DSN
       client:
         user: app_user
         password_env: PG_PROXY_PASSWORD

--- a/integration_test/testdata/postgres_pipeline.yaml
+++ b/integration_test/testdata/postgres_pipeline.yaml
@@ -12,18 +12,17 @@ tls:
   ca_key: tmp/ca.key
 
 postgres:
-  - name: main
-    listen: "127.0.0.1:0"
-    routes:
-      - database: appdb
-        upstream:
-          dsn:
-            type: env
-            var: PG_UPSTREAM_DSN
-        client:
-          user: app_user
-          password_env: PG_PROXY_PASSWORD
-        role: tenant_role
+  listen: "127.0.0.1:0"
+  routes:
+    - database: appdb
+      upstream:
+        dsn:
+          type: env
+          var: PG_UPSTREAM_DSN
+      client:
+        user: app_user
+        password_env: PG_PROXY_PASSWORD
+      role: tenant_role
 
 metrics:
   listen: "127.0.0.1:0"

--- a/integration_test/testdata/postgres_pipeline.yaml
+++ b/integration_test/testdata/postgres_pipeline.yaml
@@ -12,16 +12,18 @@ tls:
   ca_key: tmp/ca.key
 
 postgres:
-  - name: primary
+  - name: main
     listen: "127.0.0.1:0"
-    upstream:
-      dsn:
-        type: env
-        var: PG_UPSTREAM_DSN
-    client:
-      user: app_user
-      password_env: PG_PROXY_PASSWORD
-    role: tenant_role
+    routes:
+      - database: appdb
+        upstream:
+          dsn:
+            type: env
+            var: PG_UPSTREAM_DSN
+        client:
+          user: app_user
+          password_env: PG_PROXY_PASSWORD
+        role: tenant_role
 
 metrics:
   listen: "127.0.0.1:0"

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -126,8 +126,9 @@ func MCPFromSync(raw json.RawMessage) (node yaml.Node, present bool, err error) 
 // managed-mode env convention in cmd/iron-proxy).
 type PostgresSyncEntry struct {
 	ForeignID string
-	// Database is the routing key clients use to reach this upstream. It
-	// defaults to ForeignID when the control plane omits an explicit database.
+	// Database is the routing key clients use to reach this upstream. Required:
+	// it must equal the database the DSN connects to, so the control plane must
+	// supply it explicitly.
 	Database string
 	DSN      secrets.Source
 	Role     string
@@ -169,6 +170,9 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if !isNonNullJSON(e.DSN) {
 			return nil, fmt.Errorf("postgres[%q]: dsn is required", e.ForeignID)
 		}
+		if e.Database == "" {
+			return nil, fmt.Errorf("postgres[%q]: database is required", e.ForeignID)
+		}
 		node, err := yamlNodeFromRawJSON(e.DSN)
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: parsing dsn: %w", e.ForeignID, err)
@@ -177,15 +181,9 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
 		}
-		// The control plane may omit database; the foreign_id is the routing
-		// key in that case.
-		database := e.Database
-		if database == "" {
-			database = e.ForeignID
-		}
 		entries = append(entries, PostgresSyncEntry{
 			ForeignID: e.ForeignID,
-			Database:  database,
+			Database:  e.Database,
 			DSN:       src,
 			Role:      e.Role,
 		})

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -131,12 +131,7 @@ type PostgresSyncEntry struct {
 	// supply it explicitly.
 	Database string
 	DSN      secrets.Source
-	// ClientUser and ClientPassword are the credentials clients present to the
-	// proxy for this upstream. Both required: the control plane delivers them so
-	// no per-upstream proxy configuration is needed.
-	ClientUser     string
-	ClientPassword string
-	Role           string
+	Role     string
 }
 
 // PostgresFromSync parses the top-level postgres: array from the control
@@ -161,12 +156,10 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 			continue
 		}
 		var e struct {
-			ForeignID      string          `json:"foreign_id"`
-			Database       string          `json:"database"`
-			DSN            json.RawMessage `json:"dsn"`
-			ClientUser     string          `json:"client_user"`
-			ClientPassword string          `json:"client_password"`
-			Role           string          `json:"role"`
+			ForeignID string          `json:"foreign_id"`
+			Database  string          `json:"database"`
+			DSN       json.RawMessage `json:"dsn"`
+			Role      string          `json:"role"`
 		}
 		if err := json.Unmarshal(re, &e); err != nil {
 			return nil, fmt.Errorf("parsing postgres[%d]: %w", i, err)
@@ -180,12 +173,6 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if e.Database == "" {
 			return nil, fmt.Errorf("postgres[%q]: database is required", e.ForeignID)
 		}
-		if e.ClientUser == "" {
-			return nil, fmt.Errorf("postgres[%q]: client_user is required", e.ForeignID)
-		}
-		if e.ClientPassword == "" {
-			return nil, fmt.Errorf("postgres[%q]: client_password is required", e.ForeignID)
-		}
 		node, err := yamlNodeFromRawJSON(e.DSN)
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: parsing dsn: %w", e.ForeignID, err)
@@ -195,12 +182,10 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
 		}
 		entries = append(entries, PostgresSyncEntry{
-			ForeignID:      e.ForeignID,
-			Database:       e.Database,
-			DSN:            src,
-			ClientUser:     e.ClientUser,
-			ClientPassword: e.ClientPassword,
-			Role:           e.Role,
+			ForeignID: e.ForeignID,
+			Database:  e.Database,
+			DSN:       src,
+			Role:      e.Role,
 		})
 	}
 	return entries, nil

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -131,7 +131,12 @@ type PostgresSyncEntry struct {
 	// supply it explicitly.
 	Database string
 	DSN      secrets.Source
-	Role     string
+	// ClientUser and ClientPassword are the credentials clients present to the
+	// proxy for this upstream. Both required: the control plane delivers them so
+	// no per-upstream proxy configuration is needed.
+	ClientUser     string
+	ClientPassword string
+	Role           string
 }
 
 // PostgresFromSync parses the top-level postgres: array from the control
@@ -156,10 +161,12 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 			continue
 		}
 		var e struct {
-			ForeignID string          `json:"foreign_id"`
-			Database  string          `json:"database"`
-			DSN       json.RawMessage `json:"dsn"`
-			Role      string          `json:"role"`
+			ForeignID      string          `json:"foreign_id"`
+			Database       string          `json:"database"`
+			DSN            json.RawMessage `json:"dsn"`
+			ClientUser     string          `json:"client_user"`
+			ClientPassword string          `json:"client_password"`
+			Role           string          `json:"role"`
 		}
 		if err := json.Unmarshal(re, &e); err != nil {
 			return nil, fmt.Errorf("parsing postgres[%d]: %w", i, err)
@@ -173,6 +180,12 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if e.Database == "" {
 			return nil, fmt.Errorf("postgres[%q]: database is required", e.ForeignID)
 		}
+		if e.ClientUser == "" {
+			return nil, fmt.Errorf("postgres[%q]: client_user is required", e.ForeignID)
+		}
+		if e.ClientPassword == "" {
+			return nil, fmt.Errorf("postgres[%q]: client_password is required", e.ForeignID)
+		}
 		node, err := yamlNodeFromRawJSON(e.DSN)
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: parsing dsn: %w", e.ForeignID, err)
@@ -182,10 +195,12 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
 		}
 		entries = append(entries, PostgresSyncEntry{
-			ForeignID: e.ForeignID,
-			Database:  e.Database,
-			DSN:       src,
-			Role:      e.Role,
+			ForeignID:      e.ForeignID,
+			Database:       e.Database,
+			DSN:            src,
+			ClientUser:     e.ClientUser,
+			ClientPassword: e.ClientPassword,
+			Role:           e.Role,
 		})
 	}
 	return entries, nil

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -119,14 +119,18 @@ func MCPFromSync(raw json.RawMessage) (node yaml.Node, present bool, err error) 
 	return node, true, nil
 }
 
-// PostgresSyncEntry is one control-plane-synced postgres upstream. The DSN and
-// optional role come from the control plane; the listener and client knobs are
+// PostgresSyncEntry is one control-plane-synced postgres upstream, mapped to a
+// single route under the managed listener. The DSN, optional role, and routing
+// database come from the control plane; the per-route client credentials are
 // supplied separately via environment variables keyed off ForeignID (see the
 // managed-mode env convention in cmd/iron-proxy).
 type PostgresSyncEntry struct {
 	ForeignID string
-	DSN       secrets.Source
-	Role      string
+	// Database is the routing key clients use to reach this upstream. It
+	// defaults to ForeignID when the control plane omits an explicit database.
+	Database string
+	DSN      secrets.Source
+	Role     string
 }
 
 // PostgresFromSync parses the top-level postgres: array from the control
@@ -152,6 +156,7 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		}
 		var e struct {
 			ForeignID string          `json:"foreign_id"`
+			Database  string          `json:"database"`
 			DSN       json.RawMessage `json:"dsn"`
 			Role      string          `json:"role"`
 		}
@@ -172,8 +177,15 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
 		}
+		// The control plane may omit database; the foreign_id is the routing
+		// key in that case.
+		database := e.Database
+		if database == "" {
+			database = e.ForeignID
+		}
 		entries = append(entries, PostgresSyncEntry{
 			ForeignID: e.ForeignID,
+			Database:  database,
 			DSN:       src,
 			Role:      e.Role,
 		})

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -29,8 +29,8 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	t.Setenv("PG_MAIN_DSN", "host=main")
 
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"client_user":"app","client_password":"s3cret","role":"readonly"},
-		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"},"client_user":"app2","client_password":"pw2"}
+		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
+		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
 	]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
@@ -39,8 +39,6 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 
 	require.Equal(t, "pg-analytics", entries[0].ForeignID)
 	require.Equal(t, "analytics", entries[0].Database)
-	require.Equal(t, "app", entries[0].ClientUser)
-	require.Equal(t, "s3cret", entries[0].ClientPassword)
 	require.Equal(t, "readonly", entries[0].Role)
 	require.NotNil(t, entries[0].DSN)
 	got, err := entries[0].DSN.Get(context.Background())
@@ -49,14 +47,12 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 
 	require.Equal(t, "pg-main", entries[1].ForeignID)
 	require.Equal(t, "maindb", entries[1].Database)
-	require.Equal(t, "app2", entries[1].ClientUser)
-	require.Equal(t, "pw2", entries[1].ClientPassword)
 	require.Empty(t, entries[1].Role)
 }
 
 func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
 	require.NoError(t, err)
@@ -66,26 +62,14 @@ func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {
 }
 
 func TestPostgresFromSync_MissingDatabase(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"}}]`)
 	_, err := PostgresFromSync(raw, syncTestLogger())
 	require.ErrorContains(t, err, "database is required")
 }
 
-func TestPostgresFromSync_MissingClientUser(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_password":"pw"}]`)
-	_, err := PostgresFromSync(raw, syncTestLogger())
-	require.ErrorContains(t, err, "client_user is required")
-}
-
-func TestPostgresFromSync_MissingClientPassword(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app"}]`)
-	_, err := PostgresFromSync(raw, syncTestLogger())
-	require.ErrorContains(t, err, "client_password is required")
-}
-
 func TestPostgresFromSync_SkipsNullElements(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
-	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"},null]`)
+	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"}},null]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
 	require.NoError(t, err)
@@ -106,7 +90,7 @@ func TestPostgresFromSync_MissingDSN(t *testing.T) {
 }
 
 func TestPostgresFromSync_UnknownSourceType(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"bogus"},"client_user":"app","client_password":"pw"}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"bogus"}}]`)
 	_, err := PostgresFromSync(raw, syncTestLogger())
 	require.ErrorContains(t, err, "building dsn source")
 }

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -29,8 +29,8 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	t.Setenv("PG_MAIN_DSN", "host=main")
 
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"pg-analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
-		{"id":"pgs_2","foreign_id":"pg-main","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
+		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
+		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
 	]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
@@ -38,7 +38,7 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	require.Len(t, entries, 2)
 
 	require.Equal(t, "pg-analytics", entries[0].ForeignID)
-	require.Equal(t, "pg-analytics", entries[0].Database, "database defaults to foreign_id")
+	require.Equal(t, "analytics", entries[0].Database)
 	require.Equal(t, "readonly", entries[0].Role)
 	require.NotNil(t, entries[0].DSN)
 	got, err := entries[0].DSN.Get(context.Background())
@@ -46,11 +46,11 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	require.Equal(t, "host=analytics", got)
 
 	require.Equal(t, "pg-main", entries[1].ForeignID)
-	require.Equal(t, "pg-main", entries[1].Database)
+	require.Equal(t, "maindb", entries[1].Database)
 	require.Empty(t, entries[1].Role)
 }
 
-func TestPostgresFromSync_ExplicitDatabase(t *testing.T) {
+func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
 	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
 
@@ -58,12 +58,18 @@ func TestPostgresFromSync_ExplicitDatabase(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	require.Equal(t, "pg-analytics", entries[0].ForeignID)
-	require.Equal(t, "analytics", entries[0].Database, "explicit database overrides the foreign_id default")
+	require.Equal(t, "analytics", entries[0].Database, "database is the routing key, independent of foreign_id")
+}
+
+func TestPostgresFromSync_MissingDatabase(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "database is required")
 }
 
 func TestPostgresFromSync_SkipsNullElements(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
-	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"}},null]`)
+	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"}},null]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
 	require.NoError(t, err)
@@ -84,7 +90,7 @@ func TestPostgresFromSync_MissingDSN(t *testing.T) {
 }
 
 func TestPostgresFromSync_UnknownSourceType(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"bogus"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"bogus"}}]`)
 	_, err := PostgresFromSync(raw, syncTestLogger())
 	require.ErrorContains(t, err, "building dsn source")
 }

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -29,8 +29,8 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	t.Setenv("PG_MAIN_DSN", "host=main")
 
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
-		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
+		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"client_user":"app","client_password":"s3cret","role":"readonly"},
+		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"},"client_user":"app2","client_password":"pw2"}
 	]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
@@ -39,6 +39,8 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 
 	require.Equal(t, "pg-analytics", entries[0].ForeignID)
 	require.Equal(t, "analytics", entries[0].Database)
+	require.Equal(t, "app", entries[0].ClientUser)
+	require.Equal(t, "s3cret", entries[0].ClientPassword)
 	require.Equal(t, "readonly", entries[0].Role)
 	require.NotNil(t, entries[0].DSN)
 	got, err := entries[0].DSN.Get(context.Background())
@@ -47,12 +49,14 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 
 	require.Equal(t, "pg-main", entries[1].ForeignID)
 	require.Equal(t, "maindb", entries[1].Database)
+	require.Equal(t, "app2", entries[1].ClientUser)
+	require.Equal(t, "pw2", entries[1].ClientPassword)
 	require.Empty(t, entries[1].Role)
 }
 
 func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
 	require.NoError(t, err)
@@ -62,14 +66,26 @@ func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {
 }
 
 func TestPostgresFromSync_MissingDatabase(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"}]`)
 	_, err := PostgresFromSync(raw, syncTestLogger())
 	require.ErrorContains(t, err, "database is required")
 }
 
+func TestPostgresFromSync_MissingClientUser(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_password":"pw"}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "client_user is required")
+}
+
+func TestPostgresFromSync_MissingClientPassword(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app"}]`)
+	_, err := PostgresFromSync(raw, syncTestLogger())
+	require.ErrorContains(t, err, "client_password is required")
+}
+
 func TestPostgresFromSync_SkipsNullElements(t *testing.T) {
 	t.Setenv("PG_DSN", "host=x")
-	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"}},null]`)
+	raw := json.RawMessage(`[null,{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"env","var":"PG_DSN"},"client_user":"app","client_password":"pw"},null]`)
 
 	entries, err := PostgresFromSync(raw, syncTestLogger())
 	require.NoError(t, err)
@@ -90,7 +106,7 @@ func TestPostgresFromSync_MissingDSN(t *testing.T) {
 }
 
 func TestPostgresFromSync_UnknownSourceType(t *testing.T) {
-	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"bogus"}}]`)
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-x","database":"xdb","dsn":{"type":"bogus"},"client_user":"app","client_password":"pw"}]`)
 	_, err := PostgresFromSync(raw, syncTestLogger())
 	require.ErrorContains(t, err, "building dsn source")
 }

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -38,6 +38,7 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	require.Len(t, entries, 2)
 
 	require.Equal(t, "pg-analytics", entries[0].ForeignID)
+	require.Equal(t, "pg-analytics", entries[0].Database, "database defaults to foreign_id")
 	require.Equal(t, "readonly", entries[0].Role)
 	require.NotNil(t, entries[0].DSN)
 	got, err := entries[0].DSN.Get(context.Background())
@@ -45,7 +46,19 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	require.Equal(t, "host=analytics", got)
 
 	require.Equal(t, "pg-main", entries[1].ForeignID)
+	require.Equal(t, "pg-main", entries[1].Database)
 	require.Empty(t, entries[1].Role)
+}
+
+func TestPostgresFromSync_ExplicitDatabase(t *testing.T) {
+	t.Setenv("PG_DSN", "host=x")
+	raw := json.RawMessage(`[{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_DSN"}}]`)
+
+	entries, err := PostgresFromSync(raw, syncTestLogger())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "pg-analytics", entries[0].ForeignID)
+	require.Equal(t, "analytics", entries[0].Database, "explicit database overrides the foreign_id default")
 }
 
 func TestPostgresFromSync_SkipsNullElements(t *testing.T) {

--- a/internal/postgres/auth.go
+++ b/internal/postgres/auth.go
@@ -19,13 +19,13 @@ import (
 // On failure, an ErrorResponse describing the auth failure has already been
 // written to the client; callers should close the connection without further
 // protocol exchange.
-func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, route *Route) error {
+func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, upstream *Upstream) error {
 	user := startup.Parameters["user"]
 	if user == "" {
 		writeFatal(backend, "28000", "no user provided in startup message")
 		return errors.New("missing user in startup message")
 	}
-	if user != route.ClientUser() {
+	if user != upstream.ClientUser() {
 		writeFatal(backend, "28000", fmt.Sprintf("unknown user %q", user))
 		return fmt.Errorf("unknown user %q", user)
 	}
@@ -45,7 +45,7 @@ func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMess
 		return fmt.Errorf("expected PasswordMessage; got %T", msg)
 	}
 
-	if !route.VerifyClient(user, pwMsg.Password) {
+	if !upstream.VerifyClient(user, pwMsg.Password) {
 		writeFatal(backend, "28P01", "password authentication failed")
 		return errors.New("client password mismatch")
 	}

--- a/internal/postgres/auth.go
+++ b/internal/postgres/auth.go
@@ -19,13 +19,13 @@ import (
 // On failure, an ErrorResponse describing the auth failure has already been
 // written to the client; callers should close the connection without further
 // protocol exchange.
-func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, upstream *Upstream) error {
+func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, listener *Listener) error {
 	user := startup.Parameters["user"]
 	if user == "" {
 		writeFatal(backend, "28000", "no user provided in startup message")
 		return errors.New("missing user in startup message")
 	}
-	if user != upstream.ClientUser() {
+	if user != listener.ClientUser() {
 		writeFatal(backend, "28000", fmt.Sprintf("unknown user %q", user))
 		return fmt.Errorf("unknown user %q", user)
 	}
@@ -45,7 +45,7 @@ func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMess
 		return fmt.Errorf("expected PasswordMessage; got %T", msg)
 	}
 
-	if !upstream.VerifyClient(user, pwMsg.Password) {
+	if !listener.VerifyClient(user, pwMsg.Password) {
 		writeFatal(backend, "28P01", "password authentication failed")
 		return errors.New("client password mismatch")
 	}

--- a/internal/postgres/auth.go
+++ b/internal/postgres/auth.go
@@ -19,13 +19,13 @@ import (
 // On failure, an ErrorResponse describing the auth failure has already been
 // written to the client; callers should close the connection without further
 // protocol exchange.
-func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, policy *Policy) error {
+func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMessage, route *Route) error {
 	user := startup.Parameters["user"]
 	if user == "" {
 		writeFatal(backend, "28000", "no user provided in startup message")
 		return errors.New("missing user in startup message")
 	}
-	if user != policy.ClientUser() {
+	if user != route.ClientUser() {
 		writeFatal(backend, "28000", fmt.Sprintf("unknown user %q", user))
 		return fmt.Errorf("unknown user %q", user)
 	}
@@ -45,7 +45,7 @@ func authenticateClient(backend *pgproto3.Backend, startup *pgproto3.StartupMess
 		return fmt.Errorf("expected PasswordMessage; got %T", msg)
 	}
 
-	if !policy.VerifyClient(user, pwMsg.Password) {
+	if !route.VerifyClient(user, pwMsg.Password) {
 		writeFatal(backend, "28P01", "password authentication failed")
 		return errors.New("client password mismatch")
 	}

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -22,13 +22,12 @@
 // a batch is rejected if any statement mutates the role or is a DO block.
 // Extended Query, COPY, and prepared statements pass through unchanged.
 //
-// A single listener fronts multiple upstream databases: the top-level
-// postgres: key is a list of listeners, and each listener holds a list of
-// routes. A route is selected by the database name the client supplies in its
-// startup message; each route has its own upstream DSN, client credentials,
-// and optional injected role. One listen address therefore serves many
-// databases. The proxy runs a single postgres listener: the top-level
-// postgres: block is one object with a listen address and a list of routes.
+// The proxy runs a single postgres listener fronting multiple upstream
+// databases: the top-level postgres: block is one object with a listen address
+// and a list of upstreams. An upstream is selected by the database name the
+// client supplies in its startup message; each upstream has its own DSN, client
+// credentials, and optional injected role. One listen address therefore serves
+// many databases.
 package postgres
 
 import (
@@ -51,49 +50,43 @@ type SourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 const listenerName = "postgres"
 
 // ListenerConfig is the top-level postgres: block — a single bind address
-// fronting a set of database-keyed routes.
+// fronting a set of database-keyed upstreams.
 type ListenerConfig struct {
 	// Listen is the proxy's bind address for client connections, e.g. ":5432".
 	Listen string `yaml:"listen"`
 
-	// Routes is the set of upstream databases this listener fronts. A route is
-	// selected by the database name the client sends in its startup message.
-	// At least one route is required.
-	Routes []RouteConfig `yaml:"routes"`
+	// Upstreams is the set of upstream databases this listener fronts. An
+	// upstream is selected by the database name the client sends in its startup
+	// message. At least one upstream is required.
+	Upstreams []UpstreamConfig `yaml:"upstreams"`
 }
 
-// RouteConfig describes one upstream database reachable through a listener. The
-// client selects it by sending its Database value as the startup "database"
+// UpstreamConfig describes one upstream database reachable through the listener.
+// The client selects it by sending its Database value as the startup "database"
 // parameter.
-type RouteConfig struct {
+type UpstreamConfig struct {
 	// Database is the routing key: the database name a client must request to
-	// reach this upstream. Required and must be unique within a listener.
+	// reach this upstream. Required and must be unique across upstreams.
 	Database string `yaml:"database"`
 
-	// Upstream is the database the proxy connects to on behalf of clients
-	// routed here.
-	Upstream UpstreamConfig `yaml:"upstream"`
+	// DSN is the upstream connection string, loaded from any registered secret
+	// source (env, aws_sm, aws_ssm, 1password, 1password_connect) and passed
+	// verbatim to pgconn.ParseConfig — both URL-style
+	// (postgres://user:pw@host:port/db?sslmode=...) and keyword/value strings
+	// (host=... port=... user=... password=... dbname=... sslmode=...) are
+	// accepted.
+	DSN yaml.Node `yaml:"dsn"`
 
-	// Client describes the credentials clients must present to use this route.
-	// The proxy verifies a single shared user/password pair per route —
-	// per-user credentials are not supported.
+	// Client describes the credentials clients must present to use this
+	// upstream. The proxy verifies a single shared user/password pair per
+	// upstream — per-user credentials are not supported.
 	Client ClientConfig `yaml:"client"`
 
-	// Role is the Postgres role the proxy SETs at session start for this route.
-	// When set, every query the client subsequently issues runs as this role on
-	// the upstream database. Optional: when empty, the proxy issues no SET ROLE
-	// and the upstream session runs as the connecting user.
+	// Role is the Postgres role the proxy SETs at session start for this
+	// upstream. When set, every query the client subsequently issues runs as
+	// this role on the upstream database. Optional: when empty, the proxy issues
+	// no SET ROLE and the upstream session runs as the connecting user.
 	Role string `yaml:"role,omitempty"`
-}
-
-// UpstreamConfig describes the database the proxy forwards to. The DSN is
-// loaded from any registered secret source (env, aws_sm, aws_ssm, 1password,
-// 1password_connect) and is passed verbatim to pgconn.ParseConfig — both
-// URL-style (postgres://user:pw@host:port/db?sslmode=...) and keyword/value
-// strings (host=... port=... user=... password=... dbname=... sslmode=...)
-// are accepted.
-type UpstreamConfig struct {
-	DSN yaml.Node `yaml:"dsn"`
 }
 
 // ClientConfig describes the credentials the proxy demands from clients.
@@ -103,11 +96,11 @@ type ClientConfig struct {
 }
 
 // Listener is the compiled, runtime form of a single ListenerConfig: a bind
-// address and the database-keyed routes reachable through it.
+// address and the database-keyed upstreams reachable through it.
 type Listener struct {
-	name   string
-	listen string
-	routes map[string]*Route
+	name      string
+	listen    string
+	upstreams map[string]*Upstream
 }
 
 // Name returns the listener's name (a fixed identifier surfaced in logs).
@@ -116,60 +109,60 @@ func (l *Listener) Name() string { return l.name }
 // Listen returns the bind address.
 func (l *Listener) Listen() string { return l.listen }
 
-// Route returns the route for the given database name, or nil if no route on
-// this listener serves it.
-func (l *Listener) Route(database string) *Route { return l.routes[database] }
+// Upstream returns the upstream for the given database name, or nil if no
+// upstream on this listener serves it.
+func (l *Listener) Upstream(database string) *Upstream { return l.upstreams[database] }
 
-// Routes returns all of the listener's routes. The order is unspecified.
-func (l *Listener) Routes() []*Route {
-	out := make([]*Route, 0, len(l.routes))
-	for _, r := range l.routes {
-		out = append(out, r)
+// Upstreams returns all of the listener's upstreams. The order is unspecified.
+func (l *Listener) Upstreams() []*Upstream {
+	out := make([]*Upstream, 0, len(l.upstreams))
+	for _, u := range l.upstreams {
+		out = append(out, u)
 	}
 	return out
 }
 
-// Route is the compiled, runtime form of a single RouteConfig: one upstream
-// database with its own credentials and optional injected role.
-type Route struct {
+// Upstream is the compiled, runtime form of a single UpstreamConfig: one
+// upstream database with its own credentials and optional injected role.
+type Upstream struct {
 	database string
 	role     string
 
-	upstreamDSN secrets.Source
+	dsn secrets.Source
 
 	clientUser     string
 	clientPassword string
 }
 
-// Database returns the route's routing key — the database name a client
-// requests to reach this upstream.
-func (r *Route) Database() string { return r.database }
+// Database returns the upstream's routing key — the database name a client
+// requests to reach it.
+func (u *Upstream) Database() string { return u.database }
 
 // Role returns the role the proxy SETs upstream at session start. Empty
 // means no role is set (the upstream session runs as the connecting user).
-func (r *Route) Role() string { return r.role }
+func (u *Upstream) Role() string { return u.role }
 
-// UpstreamDSN returns the upstream connection string, fetched from the
-// configured secret source. The result is cached by the source; repeated
-// calls do not necessarily round-trip to the backend.
-func (r *Route) UpstreamDSN(ctx context.Context) (string, error) {
-	return r.upstreamDSN.Get(ctx)
+// DSN returns the upstream connection string, fetched from the configured
+// secret source. The result is cached by the source; repeated calls do not
+// necessarily round-trip to the backend.
+func (u *Upstream) DSN(ctx context.Context) (string, error) {
+	return u.dsn.Get(ctx)
 }
 
 // VerifyClient returns whether the given (user, password) pair matches the
-// route's configured client credentials.
-func (r *Route) VerifyClient(user, password string) bool {
-	return user == r.clientUser && password == r.clientPassword
+// upstream's configured client credentials.
+func (u *Upstream) VerifyClient(user, password string) bool {
+	return user == u.clientUser && password == u.clientPassword
 }
 
-// ClientUser returns the user clients must present to use this route.
-func (r *Route) ClientUser() string { return r.clientUser }
+// ClientUser returns the user clients must present to use this upstream.
+func (u *Upstream) ClientUser() string { return u.clientUser }
 
 // LoadFromNode decodes the raw postgres: yaml.Node into a ListenerConfig and
 // compiles it into a Listener. An empty node (the postgres: key absent from the
 // source document) returns (nil, nil) so callers can treat "no postgres
-// listener" as a normal case. An empty block (no listen and no routes) returns
-// the same.
+// listener" as a normal case. An empty block (no listen and no upstreams)
+// returns the same.
 func LoadFromNode(node yaml.Node, logger *slog.Logger) (*Listener, error) {
 	if node.Kind == 0 {
 		return nil, nil
@@ -182,101 +175,101 @@ func LoadFromNode(node yaml.Node, logger *slog.Logger) (*Listener, error) {
 }
 
 // Compile validates and compiles a ListenerConfig into a Listener. Returns
-// (nil, nil) when the block is empty (no listen and no routes) so callers can
+// (nil, nil) when the block is empty (no listen and no upstreams) so callers can
 // treat "not configured" as a no-op without a sentinel error.
 func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (*Listener, error) {
-	if c.Listen == "" && len(c.Routes) == 0 {
+	if c.Listen == "" && len(c.Upstreams) == 0 {
 		return nil, nil
 	}
 	if c.Listen == "" {
 		return nil, fmt.Errorf("postgres: listen is required")
 	}
-	if len(c.Routes) == 0 {
-		return nil, fmt.Errorf("postgres: at least one route is required")
+	if len(c.Upstreams) == 0 {
+		return nil, fmt.Errorf("postgres: at least one upstream is required")
 	}
 
-	routes := make(map[string]*Route, len(c.Routes))
-	for j, rc := range c.Routes {
-		rctx := fmt.Sprintf("postgres.routes[%d]", j)
-		if rc.Database != "" {
-			rctx = fmt.Sprintf("postgres.routes[%q]", rc.Database)
+	upstreams := make(map[string]*Upstream, len(c.Upstreams))
+	for j, uc := range c.Upstreams {
+		uctx := fmt.Sprintf("postgres.upstreams[%d]", j)
+		if uc.Database != "" {
+			uctx = fmt.Sprintf("postgres.upstreams[%q]", uc.Database)
 		}
 
-		if rc.Database == "" {
-			return nil, fmt.Errorf("%s: database is required", rctx)
+		if uc.Database == "" {
+			return nil, fmt.Errorf("%s: database is required", uctx)
 		}
-		if rc.Upstream.DSN.Kind == 0 {
-			return nil, fmt.Errorf("%s: upstream.dsn is required", rctx)
+		if uc.DSN.Kind == 0 {
+			return nil, fmt.Errorf("%s: dsn is required", uctx)
 		}
-		if rc.Client.User == "" {
-			return nil, fmt.Errorf("%s: client.user is required", rctx)
+		if uc.Client.User == "" {
+			return nil, fmt.Errorf("%s: client.user is required", uctx)
 		}
-		if rc.Client.PasswordEnv == "" {
-			return nil, fmt.Errorf("%s: client.password_env is required", rctx)
+		if uc.Client.PasswordEnv == "" {
+			return nil, fmt.Errorf("%s: client.password_env is required", uctx)
 		}
-		if _, ok := routes[rc.Database]; ok {
-			return nil, fmt.Errorf("postgres: duplicate route database %q", rc.Database)
+		if _, ok := upstreams[uc.Database]; ok {
+			return nil, fmt.Errorf("postgres: duplicate upstream database %q", uc.Database)
 		}
 
-		dsnSource, err := buildSource(rc.Upstream.DSN, logger)
+		dsnSource, err := buildSource(uc.DSN, logger)
 		if err != nil {
-			return nil, fmt.Errorf("%s: building upstream.dsn source: %w", rctx, err)
+			return nil, fmt.Errorf("%s: building dsn source: %w", uctx, err)
 		}
 
-		clientPassword := os.Getenv(rc.Client.PasswordEnv)
+		clientPassword := os.Getenv(uc.Client.PasswordEnv)
 		if clientPassword == "" {
-			return nil, fmt.Errorf("%s: client.password_env %q is not set in the environment", rctx, rc.Client.PasswordEnv)
+			return nil, fmt.Errorf("%s: client.password_env %q is not set in the environment", uctx, uc.Client.PasswordEnv)
 		}
 
-		routes[rc.Database] = &Route{
-			database:       rc.Database,
-			role:           rc.Role,
-			upstreamDSN:    dsnSource,
-			clientUser:     rc.Client.User,
+		upstreams[uc.Database] = &Upstream{
+			database:       uc.Database,
+			role:           uc.Role,
+			dsn:            dsnSource,
+			clientUser:     uc.Client.User,
 			clientPassword: clientPassword,
 		}
 	}
 
 	return &Listener{
-		name:   listenerName,
-		listen: c.Listen,
-		routes: routes,
+		name:      listenerName,
+		listen:    c.Listen,
+		upstreams: upstreams,
 	}, nil
 }
 
 // NewListener builds the postgres listener from a bind address and a set of
-// routes. It is the construction path for control-plane-synced listeners, whose
-// routes are built one at a time via NewManagedRoute. The listen address is
-// required, and at least one route must be supplied; a route whose Database
-// collides with an earlier one is an error.
-func NewListener(listen string, routes []*Route) (*Listener, error) {
+// upstreams. It is the construction path for control-plane-synced listeners,
+// whose upstreams are built one at a time via NewManagedUpstream. The listen
+// address is required, and at least one upstream must be supplied; an upstream
+// whose Database collides with an earlier one is an error.
+func NewListener(listen string, upstreams []*Upstream) (*Listener, error) {
 	if listen == "" {
 		return nil, fmt.Errorf("postgres: listen is required")
 	}
-	if len(routes) == 0 {
-		return nil, fmt.Errorf("postgres: at least one route is required")
+	if len(upstreams) == 0 {
+		return nil, fmt.Errorf("postgres: at least one upstream is required")
 	}
-	m := make(map[string]*Route, len(routes))
-	for _, r := range routes {
-		if _, ok := m[r.database]; ok {
-			return nil, fmt.Errorf("postgres: duplicate route database %q", r.database)
+	m := make(map[string]*Upstream, len(upstreams))
+	for _, u := range upstreams {
+		if _, ok := m[u.database]; ok {
+			return nil, fmt.Errorf("postgres: duplicate upstream database %q", u.database)
 		}
-		m[r.database] = r
+		m[u.database] = u
 	}
-	return &Listener{name: listenerName, listen: listen, routes: m}, nil
+	return &Listener{name: listenerName, listen: listen, upstreams: m}, nil
 }
 
-// NewManagedRoute builds a Route for a control-plane-synced listener. The
-// upstream DSN source and optional role come from the control plane; the client
+// NewManagedUpstream builds an Upstream for a control-plane-synced listener. The
+// DSN source and optional role come from the control plane; the client
 // credentials come from the proxy's environment. Unlike the YAML path,
 // clientPassword is the literal password value, not the name of an env var —
 // managed mode has no second level of indirection. All fields except role are
 // required.
-func NewManagedRoute(database string, dsn secrets.Source, clientUser, clientPassword, role string) (*Route, error) {
+func NewManagedUpstream(database string, dsn secrets.Source, clientUser, clientPassword, role string) (*Upstream, error) {
 	if database == "" {
-		return nil, fmt.Errorf("postgres: managed route database is required")
+		return nil, fmt.Errorf("postgres: managed upstream database is required")
 	}
-	ctx := fmt.Sprintf("postgres route[%q]", database)
+	ctx := fmt.Sprintf("postgres upstream[%q]", database)
 	if dsn == nil {
 		return nil, fmt.Errorf("%s: dsn source is required", ctx)
 	}
@@ -286,10 +279,10 @@ func NewManagedRoute(database string, dsn secrets.Source, clientUser, clientPass
 	if clientPassword == "" {
 		return nil, fmt.Errorf("%s: client password is required", ctx)
 	}
-	return &Route{
+	return &Upstream{
 		database:       database,
 		role:           role,
-		upstreamDSN:    dsn,
+		dsn:            dsn,
 		clientUser:     clientUser,
 		clientPassword: clientPassword,
 	}, nil

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -49,11 +49,17 @@ type SourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 // logs. The proxy runs at most one listener, so the name is not configurable.
 const listenerName = "postgres"
 
-// ListenerConfig is the top-level postgres: block — a single bind address
-// fronting a set of database-keyed upstreams.
+// ListenerConfig is the top-level postgres: block — a single bind address and
+// one shared client credential fronting a set of database-keyed upstreams.
 type ListenerConfig struct {
 	// Listen is the proxy's bind address for client connections, e.g. ":5432".
 	Listen string `yaml:"listen"`
+
+	// Client describes the single credential clients present to the proxy. It is
+	// shared across every upstream on the listener: routing is by database, so
+	// per-database credentials add nothing. The proxy verifies one user/password
+	// pair; per-user credentials are not supported.
+	Client ClientConfig `yaml:"client"`
 
 	// Upstreams is the set of upstream databases this listener fronts. An
 	// upstream is selected by the database name the client sends in its startup
@@ -80,11 +86,6 @@ type UpstreamConfig struct {
 	// accepted.
 	DSN yaml.Node `yaml:"dsn"`
 
-	// Client describes the credentials clients must present to use this
-	// upstream. The proxy verifies a single shared user/password pair per
-	// upstream — per-user credentials are not supported.
-	Client ClientConfig `yaml:"client"`
-
 	// Role is the Postgres role the proxy SETs at session start for this
 	// upstream. When set, every query the client subsequently issues runs as
 	// this role on the upstream database. Optional: when empty, the proxy issues
@@ -99,10 +100,15 @@ type ClientConfig struct {
 }
 
 // Listener is the compiled, runtime form of a single ListenerConfig: a bind
-// address and the database-keyed upstreams reachable through it.
+// address, the shared client credential, and the database-keyed upstreams
+// reachable through it.
 type Listener struct {
-	name      string
-	listen    string
+	name   string
+	listen string
+
+	clientUser     string
+	clientPassword string
+
 	upstreams map[string]*Upstream
 }
 
@@ -125,16 +131,47 @@ func (l *Listener) Upstreams() []*Upstream {
 	return out
 }
 
+// ClientUser returns the user clients must present to the listener.
+func (l *Listener) ClientUser() string { return l.clientUser }
+
+// VerifyClient returns whether the given (user, password) pair matches the
+// listener's shared client credential.
+func (l *Listener) VerifyClient(user, password string) bool {
+	return user == l.clientUser && password == l.clientPassword
+}
+
+// WithUpstreams returns a copy of the listener with extra upstreams added,
+// keeping the listener's address and client credential. An extra upstream whose
+// database already exists is skipped (the existing one wins); its database is
+// returned in dropped so the caller can log it.
+func (l *Listener) WithUpstreams(extra []*Upstream) (listener *Listener, dropped []string) {
+	m := make(map[string]*Upstream, len(l.upstreams)+len(extra))
+	for db, u := range l.upstreams {
+		m[db] = u
+	}
+	for _, u := range extra {
+		if _, ok := m[u.database]; ok {
+			dropped = append(dropped, u.database)
+			continue
+		}
+		m[u.database] = u
+	}
+	return &Listener{
+		name:           l.name,
+		listen:         l.listen,
+		clientUser:     l.clientUser,
+		clientPassword: l.clientPassword,
+		upstreams:      m,
+	}, dropped
+}
+
 // Upstream is the compiled, runtime form of a single UpstreamConfig: one
-// upstream database with its own credentials and optional injected role.
+// upstream database with its DSN and optional injected role.
 type Upstream struct {
 	database string
 	role     string
 
 	dsn secrets.Source
-
-	clientUser     string
-	clientPassword string
 }
 
 // Database returns the upstream's routing key — the database name a client
@@ -151,15 +188,6 @@ func (u *Upstream) Role() string { return u.role }
 func (u *Upstream) DSN(ctx context.Context) (string, error) {
 	return u.dsn.Get(ctx)
 }
-
-// VerifyClient returns whether the given (user, password) pair matches the
-// upstream's configured client credentials.
-func (u *Upstream) VerifyClient(user, password string) bool {
-	return user == u.clientUser && password == u.clientPassword
-}
-
-// ClientUser returns the user clients must present to use this upstream.
-func (u *Upstream) ClientUser() string { return u.clientUser }
 
 // LoadFromNode decodes the raw postgres: yaml.Node into a ListenerConfig and
 // compiles it into a Listener. An empty node (the postgres: key absent from the
@@ -181,14 +209,25 @@ func LoadFromNode(node yaml.Node, logger *slog.Logger) (*Listener, error) {
 // (nil, nil) when the block is empty (no listen and no upstreams) so callers can
 // treat "not configured" as a no-op without a sentinel error.
 func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (*Listener, error) {
-	if c.Listen == "" && len(c.Upstreams) == 0 {
+	if c.Listen == "" && len(c.Upstreams) == 0 && c.Client.User == "" && c.Client.PasswordEnv == "" {
 		return nil, nil
 	}
 	if c.Listen == "" {
 		return nil, fmt.Errorf("postgres: listen is required")
 	}
+	if c.Client.User == "" {
+		return nil, fmt.Errorf("postgres: client.user is required")
+	}
+	if c.Client.PasswordEnv == "" {
+		return nil, fmt.Errorf("postgres: client.password_env is required")
+	}
 	if len(c.Upstreams) == 0 {
 		return nil, fmt.Errorf("postgres: at least one upstream is required")
+	}
+
+	clientPassword := os.Getenv(c.Client.PasswordEnv)
+	if clientPassword == "" {
+		return nil, fmt.Errorf("postgres: client.password_env %q is not set in the environment", c.Client.PasswordEnv)
 	}
 
 	upstreams := make(map[string]*Upstream, len(c.Upstreams))
@@ -204,12 +243,6 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 		if uc.DSN.Kind == 0 {
 			return nil, fmt.Errorf("%s: dsn is required", uctx)
 		}
-		if uc.Client.User == "" {
-			return nil, fmt.Errorf("%s: client.user is required", uctx)
-		}
-		if uc.Client.PasswordEnv == "" {
-			return nil, fmt.Errorf("%s: client.password_env is required", uctx)
-		}
 		if _, ok := upstreams[uc.Database]; ok {
 			return nil, fmt.Errorf("postgres: duplicate upstream database %q", uc.Database)
 		}
@@ -219,35 +252,37 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 			return nil, fmt.Errorf("%s: building dsn source: %w", uctx, err)
 		}
 
-		clientPassword := os.Getenv(uc.Client.PasswordEnv)
-		if clientPassword == "" {
-			return nil, fmt.Errorf("%s: client.password_env %q is not set in the environment", uctx, uc.Client.PasswordEnv)
-		}
-
 		upstreams[uc.Database] = &Upstream{
-			database:       uc.Database,
-			role:           uc.Role,
-			dsn:            dsnSource,
-			clientUser:     uc.Client.User,
-			clientPassword: clientPassword,
+			database: uc.Database,
+			role:     uc.Role,
+			dsn:      dsnSource,
 		}
 	}
 
 	return &Listener{
-		name:      listenerName,
-		listen:    c.Listen,
-		upstreams: upstreams,
+		name:           listenerName,
+		listen:         c.Listen,
+		clientUser:     c.Client.User,
+		clientPassword: clientPassword,
+		upstreams:      upstreams,
 	}, nil
 }
 
-// NewListener builds the postgres listener from a bind address and a set of
-// upstreams. It is the construction path for control-plane-synced listeners,
-// whose upstreams are built one at a time via NewManagedUpstream. The listen
-// address is required, and at least one upstream must be supplied; an upstream
-// whose Database collides with an earlier one is an error.
-func NewListener(listen string, upstreams []*Upstream) (*Listener, error) {
+// NewListener builds the postgres listener from a bind address, the shared
+// client credential, and a set of upstreams. It is the construction path for
+// control-plane-synced listeners, whose upstreams are built one at a time via
+// NewManagedUpstream. The listen address and client credential are required,
+// and at least one upstream must be supplied; an upstream whose Database
+// collides with an earlier one is an error.
+func NewListener(listen, clientUser, clientPassword string, upstreams []*Upstream) (*Listener, error) {
 	if listen == "" {
 		return nil, fmt.Errorf("postgres: listen is required")
+	}
+	if clientUser == "" {
+		return nil, fmt.Errorf("postgres: client user is required")
+	}
+	if clientPassword == "" {
+		return nil, fmt.Errorf("postgres: client password is required")
 	}
 	if len(upstreams) == 0 {
 		return nil, fmt.Errorf("postgres: at least one upstream is required")
@@ -259,35 +294,29 @@ func NewListener(listen string, upstreams []*Upstream) (*Listener, error) {
 		}
 		m[u.database] = u
 	}
-	return &Listener{name: listenerName, listen: listen, upstreams: m}, nil
+	return &Listener{
+		name:           listenerName,
+		listen:         listen,
+		clientUser:     clientUser,
+		clientPassword: clientPassword,
+		upstreams:      m,
+	}, nil
 }
 
 // NewManagedUpstream builds an Upstream for a control-plane-synced listener. The
-// DSN source and optional role come from the control plane; the client
-// credentials come from the proxy's environment. Unlike the YAML path,
-// clientPassword is the literal password value, not the name of an env var —
-// managed mode has no second level of indirection. All fields except role are
-// required.
-func NewManagedUpstream(database string, dsn secrets.Source, clientUser, clientPassword, role string) (*Upstream, error) {
+// DSN source and optional role come from the control plane. Database is the
+// routing key and is required; role is optional.
+func NewManagedUpstream(database string, dsn secrets.Source, role string) (*Upstream, error) {
 	if database == "" {
 		return nil, fmt.Errorf("postgres: managed upstream database is required")
 	}
-	ctx := fmt.Sprintf("postgres upstream[%q]", database)
 	if dsn == nil {
-		return nil, fmt.Errorf("%s: dsn source is required", ctx)
-	}
-	if clientUser == "" {
-		return nil, fmt.Errorf("%s: client user is required", ctx)
-	}
-	if clientPassword == "" {
-		return nil, fmt.Errorf("%s: client password is required", ctx)
+		return nil, fmt.Errorf("postgres upstream[%q]: dsn source is required", database)
 	}
 	return &Upstream{
-		database:       database,
-		role:           role,
-		dsn:            dsn,
-		clientUser:     clientUser,
-		clientPassword: clientPassword,
+		database: database,
+		role:     role,
+		dsn:      dsn,
 	}, nil
 }
 

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -22,9 +22,14 @@
 // a batch is rejected if any statement mutates the role or is a DO block.
 // Extended Query, COPY, and prepared statements pass through unchanged.
 //
-// Multiple servers are supported: the top-level postgres: key is a list, so
-// one proxy process can front several databases (each with its own listen
-// address, upstream, client credentials, and optional injected role).
+// A single listener fronts multiple upstream databases: the top-level
+// postgres: key is a list of listeners, and each listener holds a list of
+// routes. A route is selected by the database name the client supplies in its
+// startup message; each route has its own upstream DSN, client credentials,
+// and optional injected role. One listen address can therefore serve many
+// databases. The top-level list still permits more than one listener (e.g. a
+// separate bind address per network segment), but most deployments configure
+// exactly one.
 package postgres
 
 import (
@@ -42,28 +47,42 @@ import (
 // can inject a stub instead of constructing real source backends.
 type SourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 
-// ServerConfig is one entry in the top-level postgres: list — a single
-// listener fronting a single upstream database.
-type ServerConfig struct {
-	// Name identifies the server in logs and error messages. Required and
-	// must be unique across all postgres servers in the config.
+// ListenerConfig is one entry in the top-level postgres: list — a single bind
+// address fronting a set of database-keyed routes.
+type ListenerConfig struct {
+	// Name identifies the listener in logs and error messages. Required and
+	// must be unique across all postgres listeners in the config.
 	Name string `yaml:"name"`
 
 	// Listen is the proxy's bind address for client connections, e.g. ":5432".
-	// Must be unique across all postgres servers.
 	Listen string `yaml:"listen"`
 
-	// Upstream is the database the proxy connects to on behalf of clients.
+	// Routes is the set of upstream databases this listener fronts. A route is
+	// selected by the database name the client sends in its startup message.
+	// At least one route is required.
+	Routes []RouteConfig `yaml:"routes"`
+}
+
+// RouteConfig describes one upstream database reachable through a listener. The
+// client selects it by sending its Database value as the startup "database"
+// parameter.
+type RouteConfig struct {
+	// Database is the routing key: the database name a client must request to
+	// reach this upstream. Required and must be unique within a listener.
+	Database string `yaml:"database"`
+
+	// Upstream is the database the proxy connects to on behalf of clients
+	// routed here.
 	Upstream UpstreamConfig `yaml:"upstream"`
 
-	// Client describes the credentials clients must present when authenticating
-	// to the proxy. The proxy verifies a single shared user/password pair —
+	// Client describes the credentials clients must present to use this route.
+	// The proxy verifies a single shared user/password pair per route —
 	// per-user credentials are not supported.
 	Client ClientConfig `yaml:"client"`
 
-	// Role is the Postgres role the proxy SETs at session start. When set,
-	// every query the client subsequently issues runs as this role on the
-	// upstream database. Optional: when empty, the proxy issues no SET ROLE
+	// Role is the Postgres role the proxy SETs at session start for this route.
+	// When set, every query the client subsequently issues runs as this role on
+	// the upstream database. Optional: when empty, the proxy issues no SET ROLE
 	// and the upstream session runs as the connecting user.
 	Role string `yaml:"role,omitempty"`
 }
@@ -84,11 +103,29 @@ type ClientConfig struct {
 	PasswordEnv string `yaml:"password_env"`
 }
 
-// Policy is the compiled, runtime form of a single ServerConfig.
-type Policy struct {
+// Listener is the compiled, runtime form of a single ListenerConfig: a bind
+// address and the database-keyed routes reachable through it.
+type Listener struct {
 	name   string
 	listen string
-	role   string
+	routes map[string]*Route
+}
+
+// Name returns the listener's configured name.
+func (l *Listener) Name() string { return l.name }
+
+// Listen returns the bind address.
+func (l *Listener) Listen() string { return l.listen }
+
+// Route returns the route for the given database name, or nil if no route on
+// this listener serves it.
+func (l *Listener) Route(database string) *Route { return l.routes[database] }
+
+// Route is the compiled, runtime form of a single RouteConfig: one upstream
+// database with its own credentials and optional injected role.
+type Route struct {
+	database string
+	role     string
 
 	upstreamDSN secrets.Source
 
@@ -96,69 +133,67 @@ type Policy struct {
 	clientPassword string
 }
 
-// Name returns the server's configured name.
-func (p *Policy) Name() string { return p.name }
-
-// Listen returns the bind address.
-func (p *Policy) Listen() string { return p.listen }
+// Database returns the route's routing key — the database name a client
+// requests to reach this upstream.
+func (r *Route) Database() string { return r.database }
 
 // Role returns the role the proxy SETs upstream at session start. Empty
 // means no role is set (the upstream session runs as the connecting user).
-func (p *Policy) Role() string { return p.role }
+func (r *Route) Role() string { return r.role }
 
 // UpstreamDSN returns the upstream connection string, fetched from the
 // configured secret source. The result is cached by the source; repeated
 // calls do not necessarily round-trip to the backend.
-func (p *Policy) UpstreamDSN(ctx context.Context) (string, error) {
-	return p.upstreamDSN.Get(ctx)
+func (r *Route) UpstreamDSN(ctx context.Context) (string, error) {
+	return r.upstreamDSN.Get(ctx)
 }
 
 // VerifyClient returns whether the given (user, password) pair matches the
-// configured client credentials.
-func (p *Policy) VerifyClient(user, password string) bool {
-	return user == p.clientUser && password == p.clientPassword
+// route's configured client credentials.
+func (r *Route) VerifyClient(user, password string) bool {
+	return user == r.clientUser && password == r.clientPassword
 }
 
-// ClientUser returns the user clients must present to the proxy.
-func (p *Policy) ClientUser() string { return p.clientUser }
+// ClientUser returns the user clients must present to use this route.
+func (r *Route) ClientUser() string { return r.clientUser }
 
-// LoadFromNode decodes a raw yaml.Node into a list of ServerConfigs and
-// compiles each into a Policy. An empty node (the postgres: key absent from
+// LoadFromNode decodes a raw yaml.Node into a list of ListenerConfigs and
+// compiles each into a Listener. An empty node (the postgres: key absent from
 // the source document) returns (nil, nil) so callers can treat "no postgres
 // listeners" as a normal case. An empty list (`postgres: []`) returns the
 // same.
-func LoadFromNode(node yaml.Node, logger *slog.Logger) ([]*Policy, error) {
+func LoadFromNode(node yaml.Node, logger *slog.Logger) ([]*Listener, error) {
 	if node.Kind == 0 {
 		return nil, nil
 	}
-	var servers []ServerConfig
-	if err := node.Decode(&servers); err != nil {
+	var listeners []ListenerConfig
+	if err := node.Decode(&listeners); err != nil {
 		return nil, fmt.Errorf("decoding postgres config: %w", err)
 	}
-	return Compile(servers, logger, secrets.BuildSource)
+	return Compile(listeners, logger, secrets.BuildSource)
 }
 
-// Compile validates and compiles ServerConfigs into Policies. Returns
+// Compile validates and compiles ListenerConfigs into Listeners. Returns
 // (nil, nil) when the input list is empty so callers can treat "not
 // configured" as a no-op without a sentinel error.
-func Compile(servers []ServerConfig, logger *slog.Logger, buildSource SourceBuilder) ([]*Policy, error) {
-	if len(servers) == 0 {
+func Compile(listeners []ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) ([]*Listener, error) {
+	if len(listeners) == 0 {
 		return nil, nil
 	}
 
-	seenNames := make(map[string]bool, len(servers))
-	policies := make([]*Policy, 0, len(servers))
+	seenNames := make(map[string]bool, len(listeners))
+	out := make([]*Listener, 0, len(listeners))
 
-	for i, s := range servers {
-		p, err := compileOne(s, i, logger, buildSource)
+	for i, c := range listeners {
+		l, err := compileOne(c, i, logger, buildSource)
 		if err != nil {
 			return nil, err
 		}
-		if seenNames[p.name] {
-			return nil, fmt.Errorf("postgres[%d]: duplicate server name %q", i, p.name)
+		if seenNames[l.name] {
+			return nil, fmt.Errorf("postgres[%d]: duplicate listener name %q", i, l.name)
 		}
-		seenNames[p.name] = true
-		policies = append(policies, p)
+		seenNames[l.name] = true
+		out = append(out, l)
 	}
 
 	// We deliberately don't validate listen-address uniqueness here: ":0"
@@ -166,10 +201,10 @@ func Compile(servers []ServerConfig, logger *slog.Logger, buildSource SourceBuil
 	// legitimate (and used by tests). Real conflicts surface as a clean
 	// "address already in use" from net.Listen at startup.
 
-	return policies, nil
+	return out, nil
 }
 
-func compileOne(c ServerConfig, idx int, logger *slog.Logger, buildSource SourceBuilder) (*Policy, error) {
+func compileOne(c ListenerConfig, idx int, logger *slog.Logger, buildSource SourceBuilder) (*Listener, error) {
 	ctx := fmt.Sprintf("postgres[%d]", idx)
 	if c.Name != "" {
 		ctx = fmt.Sprintf("postgres[%q]", c.Name)
@@ -181,50 +216,96 @@ func compileOne(c ServerConfig, idx int, logger *slog.Logger, buildSource Source
 	if c.Listen == "" {
 		return nil, fmt.Errorf("%s: listen is required", ctx)
 	}
-	if c.Upstream.DSN.Kind == 0 {
-		return nil, fmt.Errorf("%s: upstream.dsn is required", ctx)
-	}
-	if c.Client.User == "" {
-		return nil, fmt.Errorf("%s: client.user is required", ctx)
-	}
-	if c.Client.PasswordEnv == "" {
-		return nil, fmt.Errorf("%s: client.password_env is required", ctx)
+	if len(c.Routes) == 0 {
+		return nil, fmt.Errorf("%s: at least one route is required", ctx)
 	}
 
-	dsnSource, err := buildSource(c.Upstream.DSN, logger)
-	if err != nil {
-		return nil, fmt.Errorf("%s: building upstream.dsn source: %w", ctx, err)
+	routes := make(map[string]*Route, len(c.Routes))
+	for j, rc := range c.Routes {
+		rctx := fmt.Sprintf("%s.routes[%d]", ctx, j)
+		if rc.Database != "" {
+			rctx = fmt.Sprintf("%s.routes[%q]", ctx, rc.Database)
+		}
+
+		if rc.Database == "" {
+			return nil, fmt.Errorf("%s: database is required", rctx)
+		}
+		if rc.Upstream.DSN.Kind == 0 {
+			return nil, fmt.Errorf("%s: upstream.dsn is required", rctx)
+		}
+		if rc.Client.User == "" {
+			return nil, fmt.Errorf("%s: client.user is required", rctx)
+		}
+		if rc.Client.PasswordEnv == "" {
+			return nil, fmt.Errorf("%s: client.password_env is required", rctx)
+		}
+		if _, ok := routes[rc.Database]; ok {
+			return nil, fmt.Errorf("%s: duplicate route database %q", ctx, rc.Database)
+		}
+
+		dsnSource, err := buildSource(rc.Upstream.DSN, logger)
+		if err != nil {
+			return nil, fmt.Errorf("%s: building upstream.dsn source: %w", rctx, err)
+		}
+
+		clientPassword := os.Getenv(rc.Client.PasswordEnv)
+		if clientPassword == "" {
+			return nil, fmt.Errorf("%s: client.password_env %q is not set in the environment", rctx, rc.Client.PasswordEnv)
+		}
+
+		routes[rc.Database] = &Route{
+			database:       rc.Database,
+			role:           rc.Role,
+			upstreamDSN:    dsnSource,
+			clientUser:     rc.Client.User,
+			clientPassword: clientPassword,
+		}
 	}
 
-	clientPassword := os.Getenv(c.Client.PasswordEnv)
-	if clientPassword == "" {
-		return nil, fmt.Errorf("%s: client.password_env %q is not set in the environment", ctx, c.Client.PasswordEnv)
-	}
-
-	return &Policy{
-		name:           c.Name,
-		listen:         c.Listen,
-		role:           c.Role,
-		upstreamDSN:    dsnSource,
-		clientUser:     c.Client.User,
-		clientPassword: clientPassword,
+	return &Listener{
+		name:   c.Name,
+		listen: c.Listen,
+		routes: routes,
 	}, nil
 }
 
-// NewManagedPolicy builds a Policy for a control-plane-synced listener. The
-// upstream DSN source and optional role come from the control plane; the listen
-// address and client credentials come from the proxy's environment. Unlike the
-// YAML path, clientPassword is the literal password value, not the name of an
-// env var — managed mode has no second level of indirection. All fields except
-// role are required.
-func NewManagedPolicy(name, listen string, dsn secrets.Source, clientUser, clientPassword, role string) (*Policy, error) {
+// NewListener builds a Listener from a name, bind address, and a set of routes.
+// It is the construction path for control-plane-synced listeners, whose routes
+// are built one at a time via NewManagedRoute. The name and listen address are
+// required, and at least one route must be supplied; a route whose Database
+// collides with an earlier one is an error.
+func NewListener(name, listen string, routes []*Route) (*Listener, error) {
 	if name == "" {
-		return nil, fmt.Errorf("postgres: managed policy name is required")
+		return nil, fmt.Errorf("postgres: listener name is required")
 	}
 	ctx := fmt.Sprintf("postgres[%q]", name)
 	if listen == "" {
 		return nil, fmt.Errorf("%s: listen is required", ctx)
 	}
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("%s: at least one route is required", ctx)
+	}
+	m := make(map[string]*Route, len(routes))
+	for _, r := range routes {
+		if _, ok := m[r.database]; ok {
+			return nil, fmt.Errorf("%s: duplicate route database %q", ctx, r.database)
+		}
+		m[r.database] = r
+	}
+	return &Listener{name: name, listen: listen, routes: m}, nil
+}
+
+// NewManagedRoute builds a Route for a control-plane-synced listener. The
+// upstream DSN source and optional role come from the control plane; the client
+// credentials come from the proxy's environment. Unlike the YAML path,
+// clientPassword is the literal password value, not the name of an env var —
+// managed mode has no second level of indirection. All fields except role are
+// required.
+func NewManagedRoute(database string, dsn secrets.Source, clientUser, clientPassword, role string) (*Route, error) {
+	if database == "" {
+		return nil, fmt.Errorf("postgres: managed route database is required")
+	}
+	ctx := fmt.Sprintf("postgres route[%q]", database)
 	if dsn == nil {
 		return nil, fmt.Errorf("%s: dsn source is required", ctx)
 	}
@@ -234,9 +315,8 @@ func NewManagedPolicy(name, listen string, dsn secrets.Source, clientUser, clien
 	if clientPassword == "" {
 		return nil, fmt.Errorf("%s: client password is required", ctx)
 	}
-	return &Policy{
-		name:           name,
-		listen:         listen,
+	return &Route{
+		database:       database,
 		role:           role,
 		upstreamDSN:    dsn,
 		clientUser:     clientUser,

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -26,10 +26,9 @@
 // postgres: key is a list of listeners, and each listener holds a list of
 // routes. A route is selected by the database name the client supplies in its
 // startup message; each route has its own upstream DSN, client credentials,
-// and optional injected role. One listen address can therefore serve many
-// databases. The top-level list still permits more than one listener (e.g. a
-// separate bind address per network segment), but most deployments configure
-// exactly one.
+// and optional injected role. One listen address therefore serves many
+// databases. The proxy runs a single postgres listener: the top-level
+// postgres: block is one object with a listen address and a list of routes.
 package postgres
 
 import (
@@ -47,13 +46,13 @@ import (
 // can inject a stub instead of constructing real source backends.
 type SourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 
-// ListenerConfig is one entry in the top-level postgres: list — a single bind
-// address fronting a set of database-keyed routes.
-type ListenerConfig struct {
-	// Name identifies the listener in logs and error messages. Required and
-	// must be unique across all postgres listeners in the config.
-	Name string `yaml:"name"`
+// listenerName is the fixed name of the single postgres listener, surfaced in
+// logs. The proxy runs at most one listener, so the name is not configurable.
+const listenerName = "postgres"
 
+// ListenerConfig is the top-level postgres: block — a single bind address
+// fronting a set of database-keyed routes.
+type ListenerConfig struct {
 	// Listen is the proxy's bind address for client connections, e.g. ":5432".
 	Listen string `yaml:"listen"`
 
@@ -111,7 +110,7 @@ type Listener struct {
 	routes map[string]*Route
 }
 
-// Name returns the listener's configured name.
+// Name returns the listener's name (a fixed identifier surfaced in logs).
 func (l *Listener) Name() string { return l.name }
 
 // Listen returns the bind address.
@@ -120,6 +119,15 @@ func (l *Listener) Listen() string { return l.listen }
 // Route returns the route for the given database name, or nil if no route on
 // this listener serves it.
 func (l *Listener) Route(database string) *Route { return l.routes[database] }
+
+// Routes returns all of the listener's routes. The order is unspecified.
+func (l *Listener) Routes() []*Route {
+	out := make([]*Route, 0, len(l.routes))
+	for _, r := range l.routes {
+		out = append(out, r)
+	}
+	return out
+}
 
 // Route is the compiled, runtime form of a single RouteConfig: one upstream
 // database with its own credentials and optional injected role.
@@ -157,74 +165,41 @@ func (r *Route) VerifyClient(user, password string) bool {
 // ClientUser returns the user clients must present to use this route.
 func (r *Route) ClientUser() string { return r.clientUser }
 
-// LoadFromNode decodes a raw yaml.Node into a list of ListenerConfigs and
-// compiles each into a Listener. An empty node (the postgres: key absent from
-// the source document) returns (nil, nil) so callers can treat "no postgres
-// listeners" as a normal case. An empty list (`postgres: []`) returns the
-// same.
-func LoadFromNode(node yaml.Node, logger *slog.Logger) ([]*Listener, error) {
+// LoadFromNode decodes the raw postgres: yaml.Node into a ListenerConfig and
+// compiles it into a Listener. An empty node (the postgres: key absent from the
+// source document) returns (nil, nil) so callers can treat "no postgres
+// listener" as a normal case. An empty block (no listen and no routes) returns
+// the same.
+func LoadFromNode(node yaml.Node, logger *slog.Logger) (*Listener, error) {
 	if node.Kind == 0 {
 		return nil, nil
 	}
-	var listeners []ListenerConfig
-	if err := node.Decode(&listeners); err != nil {
+	var c ListenerConfig
+	if err := node.Decode(&c); err != nil {
 		return nil, fmt.Errorf("decoding postgres config: %w", err)
 	}
-	return Compile(listeners, logger, secrets.BuildSource)
+	return Compile(c, logger, secrets.BuildSource)
 }
 
-// Compile validates and compiles ListenerConfigs into Listeners. Returns
-// (nil, nil) when the input list is empty so callers can treat "not
-// configured" as a no-op without a sentinel error.
-func Compile(listeners []ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) ([]*Listener, error) {
-	if len(listeners) == 0 {
+// Compile validates and compiles a ListenerConfig into a Listener. Returns
+// (nil, nil) when the block is empty (no listen and no routes) so callers can
+// treat "not configured" as a no-op without a sentinel error.
+func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (*Listener, error) {
+	if c.Listen == "" && len(c.Routes) == 0 {
 		return nil, nil
 	}
-
-	seenNames := make(map[string]bool, len(listeners))
-	out := make([]*Listener, 0, len(listeners))
-
-	for i, c := range listeners {
-		l, err := compileOne(c, i, logger, buildSource)
-		if err != nil {
-			return nil, err
-		}
-		if seenNames[l.name] {
-			return nil, fmt.Errorf("postgres[%d]: duplicate listener name %q", i, l.name)
-		}
-		seenNames[l.name] = true
-		out = append(out, l)
-	}
-
-	// We deliberately don't validate listen-address uniqueness here: ":0"
-	// asks the OS to assign an ephemeral port, so two ":0" entries are
-	// legitimate (and used by tests). Real conflicts surface as a clean
-	// "address already in use" from net.Listen at startup.
-
-	return out, nil
-}
-
-func compileOne(c ListenerConfig, idx int, logger *slog.Logger, buildSource SourceBuilder) (*Listener, error) {
-	ctx := fmt.Sprintf("postgres[%d]", idx)
-	if c.Name != "" {
-		ctx = fmt.Sprintf("postgres[%q]", c.Name)
-	}
-
-	if c.Name == "" {
-		return nil, fmt.Errorf("%s: name is required", ctx)
-	}
 	if c.Listen == "" {
-		return nil, fmt.Errorf("%s: listen is required", ctx)
+		return nil, fmt.Errorf("postgres: listen is required")
 	}
 	if len(c.Routes) == 0 {
-		return nil, fmt.Errorf("%s: at least one route is required", ctx)
+		return nil, fmt.Errorf("postgres: at least one route is required")
 	}
 
 	routes := make(map[string]*Route, len(c.Routes))
 	for j, rc := range c.Routes {
-		rctx := fmt.Sprintf("%s.routes[%d]", ctx, j)
+		rctx := fmt.Sprintf("postgres.routes[%d]", j)
 		if rc.Database != "" {
-			rctx = fmt.Sprintf("%s.routes[%q]", ctx, rc.Database)
+			rctx = fmt.Sprintf("postgres.routes[%q]", rc.Database)
 		}
 
 		if rc.Database == "" {
@@ -240,7 +215,7 @@ func compileOne(c ListenerConfig, idx int, logger *slog.Logger, buildSource Sour
 			return nil, fmt.Errorf("%s: client.password_env is required", rctx)
 		}
 		if _, ok := routes[rc.Database]; ok {
-			return nil, fmt.Errorf("%s: duplicate route database %q", ctx, rc.Database)
+			return nil, fmt.Errorf("postgres: duplicate route database %q", rc.Database)
 		}
 
 		dsnSource, err := buildSource(rc.Upstream.DSN, logger)
@@ -263,36 +238,32 @@ func compileOne(c ListenerConfig, idx int, logger *slog.Logger, buildSource Sour
 	}
 
 	return &Listener{
-		name:   c.Name,
+		name:   listenerName,
 		listen: c.Listen,
 		routes: routes,
 	}, nil
 }
 
-// NewListener builds a Listener from a name, bind address, and a set of routes.
-// It is the construction path for control-plane-synced listeners, whose routes
-// are built one at a time via NewManagedRoute. The name and listen address are
+// NewListener builds the postgres listener from a bind address and a set of
+// routes. It is the construction path for control-plane-synced listeners, whose
+// routes are built one at a time via NewManagedRoute. The listen address is
 // required, and at least one route must be supplied; a route whose Database
 // collides with an earlier one is an error.
-func NewListener(name, listen string, routes []*Route) (*Listener, error) {
-	if name == "" {
-		return nil, fmt.Errorf("postgres: listener name is required")
-	}
-	ctx := fmt.Sprintf("postgres[%q]", name)
+func NewListener(listen string, routes []*Route) (*Listener, error) {
 	if listen == "" {
-		return nil, fmt.Errorf("%s: listen is required", ctx)
+		return nil, fmt.Errorf("postgres: listen is required")
 	}
 	if len(routes) == 0 {
-		return nil, fmt.Errorf("%s: at least one route is required", ctx)
+		return nil, fmt.Errorf("postgres: at least one route is required")
 	}
 	m := make(map[string]*Route, len(routes))
 	for _, r := range routes {
 		if _, ok := m[r.database]; ok {
-			return nil, fmt.Errorf("%s: duplicate route database %q", ctx, r.database)
+			return nil, fmt.Errorf("postgres: duplicate route database %q", r.database)
 		}
 		m[r.database] = r
 	}
-	return &Listener{name: name, listen: listen, routes: m}, nil
+	return &Listener{name: listenerName, listen: listen, routes: m}, nil
 }
 
 // NewManagedRoute builds a Route for a control-plane-synced listener. The

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -66,7 +66,10 @@ type ListenerConfig struct {
 // parameter.
 type UpstreamConfig struct {
 	// Database is the routing key: the database name a client must request to
-	// reach this upstream. Required and must be unique across upstreams.
+	// reach this upstream. Required and must be unique across upstreams. It must
+	// also equal the database the DSN connects to (the dbname in the DSN); the
+	// proxy rejects a connection whose upstream session would land on a
+	// different database than the client named.
 	Database string `yaml:"database"`
 
 	// DSN is the upstream connection string, loaded from any registered secret

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -33,26 +33,24 @@ func TestCompile(t *testing.T) {
 	t.Setenv("PG_PW", "secret")
 
 	upstream := func(database string) UpstreamConfig {
-		return UpstreamConfig{
-			Database: database,
-			DSN:      dsnNode(t),
-			Client:   ClientConfig{User: "u", PasswordEnv: "PG_PW"},
-			Role:     "r",
-		}
+		return UpstreamConfig{Database: database, DSN: dsnNode(t), Role: "r"}
+	}
+	client := ClientConfig{User: "u", PasswordEnv: "PG_PW"}
+	cfg := func(upstreams ...UpstreamConfig) ListenerConfig {
+		return ListenerConfig{Listen: "127.0.0.1:0", Client: client, Upstreams: upstreams}
 	}
 
 	t.Run("valid single listener many upstreams", func(t *testing.T) {
-		l, err := Compile(ListenerConfig{
-			Listen:    "127.0.0.1:0",
-			Upstreams: []UpstreamConfig{upstream("analytics"), upstream("reporting")},
-		}, logger, stubSource)
+		l, err := Compile(cfg(upstream("analytics"), upstream("reporting")), logger, stubSource)
 		require.NoError(t, err)
 		require.NotNil(t, l)
 		require.Equal(t, "127.0.0.1:0", l.Listen())
 		require.Equal(t, "analytics", l.Upstream("analytics").Database())
 		require.Equal(t, "reporting", l.Upstream("reporting").Database())
 		require.Nil(t, l.Upstream("missing"))
-		require.True(t, l.Upstream("analytics").VerifyClient("u", "secret"))
+		// The client credential is shared across the listener, not per-upstream.
+		require.True(t, l.VerifyClient("u", "secret"))
+		require.False(t, l.VerifyClient("u", "wrong"))
 	})
 
 	t.Run("empty block is a no-op", func(t *testing.T) {
@@ -62,54 +60,50 @@ func TestCompile(t *testing.T) {
 	})
 
 	t.Run("listen is required", func(t *testing.T) {
-		_, err := Compile(ListenerConfig{Upstreams: []UpstreamConfig{upstream("a")}}, logger, stubSource)
+		c := cfg(upstream("a"))
+		c.Listen = ""
+		_, err := Compile(c, logger, stubSource)
 		require.ErrorContains(t, err, "listen is required")
 	})
 
+	t.Run("client fields required", func(t *testing.T) {
+		c := cfg(upstream("a"))
+		c.Client.User = ""
+		_, err := Compile(c, logger, stubSource)
+		require.ErrorContains(t, err, "client.user is required")
+
+		c = cfg(upstream("a"))
+		c.Client.PasswordEnv = ""
+		_, err = Compile(c, logger, stubSource)
+		require.ErrorContains(t, err, "client.password_env is required")
+	})
+
+	t.Run("unset password env rejected", func(t *testing.T) {
+		c := cfg(upstream("a"))
+		c.Client.PasswordEnv = "PG_PW_UNSET"
+		_, err := Compile(c, logger, stubSource)
+		require.ErrorContains(t, err, "is not set in the environment")
+	})
+
 	t.Run("at least one upstream is required", func(t *testing.T) {
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0"}, logger, stubSource)
+		_, err := Compile(cfg(), logger, stubSource)
 		require.ErrorContains(t, err, "at least one upstream is required")
 	})
 
 	t.Run("duplicate upstream database rejected", func(t *testing.T) {
-		_, err := Compile(ListenerConfig{
-			Listen:    "127.0.0.1:0",
-			Upstreams: []UpstreamConfig{upstream("dup"), upstream("dup")},
-		}, logger, stubSource)
+		_, err := Compile(cfg(upstream("dup"), upstream("dup")), logger, stubSource)
 		require.ErrorContains(t, err, `duplicate upstream database "dup"`)
 	})
 
 	t.Run("upstream database is required", func(t *testing.T) {
-		_, err := Compile(ListenerConfig{
-			Listen:    "127.0.0.1:0",
-			Upstreams: []UpstreamConfig{upstream("")},
-		}, logger, stubSource)
+		_, err := Compile(cfg(upstream("")), logger, stubSource)
 		require.ErrorContains(t, err, "database is required")
 	})
 
 	t.Run("upstream dsn is required", func(t *testing.T) {
 		u := upstream("a")
 		u.DSN = yaml.Node{}
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
+		_, err := Compile(cfg(u), logger, stubSource)
 		require.ErrorContains(t, err, "dsn is required")
-	})
-
-	t.Run("upstream client fields required", func(t *testing.T) {
-		u := upstream("a")
-		u.Client.User = ""
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
-		require.ErrorContains(t, err, "client.user is required")
-
-		u = upstream("a")
-		u.Client.PasswordEnv = ""
-		_, err = Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
-		require.ErrorContains(t, err, "client.password_env is required")
-	})
-
-	t.Run("unset password env rejected", func(t *testing.T) {
-		u := upstream("a")
-		u.Client.PasswordEnv = "PG_PW_UNSET"
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
-		require.ErrorContains(t, err, "is not set in the environment")
 	})
 }

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
-// dsnNode builds a non-zero yaml.Node so the upstream.dsn presence check
-// (Kind != 0) passes. The stub buildSource ignores its contents.
+// dsnNode builds a non-zero yaml.Node so the dsn presence check (Kind != 0)
+// passes. The stub buildSource ignores its contents.
 func dsnNode(t *testing.T) yaml.Node {
 	t.Helper()
 	var n yaml.Node
@@ -32,27 +32,27 @@ func TestCompile(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	t.Setenv("PG_PW", "secret")
 
-	route := func(database string) RouteConfig {
-		return RouteConfig{
+	upstream := func(database string) UpstreamConfig {
+		return UpstreamConfig{
 			Database: database,
-			Upstream: UpstreamConfig{DSN: dsnNode(t)},
+			DSN:      dsnNode(t),
 			Client:   ClientConfig{User: "u", PasswordEnv: "PG_PW"},
 			Role:     "r",
 		}
 	}
 
-	t.Run("valid single listener many routes", func(t *testing.T) {
+	t.Run("valid single listener many upstreams", func(t *testing.T) {
 		l, err := Compile(ListenerConfig{
-			Listen: "127.0.0.1:0",
-			Routes: []RouteConfig{route("analytics"), route("reporting")},
+			Listen:    "127.0.0.1:0",
+			Upstreams: []UpstreamConfig{upstream("analytics"), upstream("reporting")},
 		}, logger, stubSource)
 		require.NoError(t, err)
 		require.NotNil(t, l)
 		require.Equal(t, "127.0.0.1:0", l.Listen())
-		require.Equal(t, "analytics", l.Route("analytics").Database())
-		require.Equal(t, "reporting", l.Route("reporting").Database())
-		require.Nil(t, l.Route("missing"))
-		require.True(t, l.Route("analytics").VerifyClient("u", "secret"))
+		require.Equal(t, "analytics", l.Upstream("analytics").Database())
+		require.Equal(t, "reporting", l.Upstream("reporting").Database())
+		require.Nil(t, l.Upstream("missing"))
+		require.True(t, l.Upstream("analytics").VerifyClient("u", "secret"))
 	})
 
 	t.Run("empty block is a no-op", func(t *testing.T) {
@@ -62,54 +62,54 @@ func TestCompile(t *testing.T) {
 	})
 
 	t.Run("listen is required", func(t *testing.T) {
-		_, err := Compile(ListenerConfig{Routes: []RouteConfig{route("a")}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Upstreams: []UpstreamConfig{upstream("a")}}, logger, stubSource)
 		require.ErrorContains(t, err, "listen is required")
 	})
 
-	t.Run("at least one route is required", func(t *testing.T) {
+	t.Run("at least one upstream is required", func(t *testing.T) {
 		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0"}, logger, stubSource)
-		require.ErrorContains(t, err, "at least one route is required")
+		require.ErrorContains(t, err, "at least one upstream is required")
 	})
 
-	t.Run("duplicate route database rejected", func(t *testing.T) {
+	t.Run("duplicate upstream database rejected", func(t *testing.T) {
 		_, err := Compile(ListenerConfig{
-			Listen: "127.0.0.1:0",
-			Routes: []RouteConfig{route("dup"), route("dup")},
+			Listen:    "127.0.0.1:0",
+			Upstreams: []UpstreamConfig{upstream("dup"), upstream("dup")},
 		}, logger, stubSource)
-		require.ErrorContains(t, err, `duplicate route database "dup"`)
+		require.ErrorContains(t, err, `duplicate upstream database "dup"`)
 	})
 
-	t.Run("route database is required", func(t *testing.T) {
+	t.Run("upstream database is required", func(t *testing.T) {
 		_, err := Compile(ListenerConfig{
-			Listen: "127.0.0.1:0",
-			Routes: []RouteConfig{route("")},
+			Listen:    "127.0.0.1:0",
+			Upstreams: []UpstreamConfig{upstream("")},
 		}, logger, stubSource)
 		require.ErrorContains(t, err, "database is required")
 	})
 
-	t.Run("route upstream dsn is required", func(t *testing.T) {
-		r := route("a")
-		r.Upstream.DSN = yaml.Node{}
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
-		require.ErrorContains(t, err, "upstream.dsn is required")
+	t.Run("upstream dsn is required", func(t *testing.T) {
+		u := upstream("a")
+		u.DSN = yaml.Node{}
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
+		require.ErrorContains(t, err, "dsn is required")
 	})
 
-	t.Run("route client fields required", func(t *testing.T) {
-		r := route("a")
-		r.Client.User = ""
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
+	t.Run("upstream client fields required", func(t *testing.T) {
+		u := upstream("a")
+		u.Client.User = ""
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
 		require.ErrorContains(t, err, "client.user is required")
 
-		r = route("a")
-		r.Client.PasswordEnv = ""
-		_, err = Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
+		u = upstream("a")
+		u.Client.PasswordEnv = ""
+		_, err = Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
 		require.ErrorContains(t, err, "client.password_env is required")
 	})
 
 	t.Run("unset password env rejected", func(t *testing.T) {
-		r := route("a")
-		r.Client.PasswordEnv = "PG_PW_UNSET"
-		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
+		u := upstream("a")
+		u.Client.PasswordEnv = "PG_PW_UNSET"
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Upstreams: []UpstreamConfig{u}}, logger, stubSource)
 		require.ErrorContains(t, err, "is not set in the environment")
 	})
 }

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+// dsnNode builds a non-zero yaml.Node so the upstream.dsn presence check
+// (Kind != 0) passes. The stub buildSource ignores its contents.
+func dsnNode(t *testing.T) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("{type: env, var: X}"), &n))
+	// Unmarshal yields a DocumentNode wrapping the mapping; unwrap it.
+	require.NotEmpty(t, n.Content)
+	return *n.Content[0]
+}
+
+// stubSource returns a no-op secrets.Source for every node, so Compile never
+// touches a real backend.
+func stubSource(yaml.Node, *slog.Logger) (secrets.Source, error) {
+	return staticDSN{name: "stub", value: "host=db"}, nil
+}
+
+func TestCompile(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	t.Setenv("PG_PW", "secret")
+
+	route := func(database string) RouteConfig {
+		return RouteConfig{
+			Database: database,
+			Upstream: UpstreamConfig{DSN: dsnNode(t)},
+			Client:   ClientConfig{User: "u", PasswordEnv: "PG_PW"},
+			Role:     "r",
+		}
+	}
+
+	t.Run("valid single listener many routes", func(t *testing.T) {
+		listeners, err := Compile([]ListenerConfig{{
+			Name:   "main",
+			Listen: "127.0.0.1:0",
+			Routes: []RouteConfig{route("analytics"), route("reporting")},
+		}}, logger, stubSource)
+		require.NoError(t, err)
+		require.Len(t, listeners, 1)
+		require.Equal(t, "main", listeners[0].Name())
+		require.Equal(t, "analytics", listeners[0].Route("analytics").Database())
+		require.Equal(t, "reporting", listeners[0].Route("reporting").Database())
+		require.Nil(t, listeners[0].Route("missing"))
+		require.True(t, listeners[0].Route("analytics").VerifyClient("u", "secret"))
+	})
+
+	t.Run("empty input is a no-op", func(t *testing.T) {
+		listeners, err := Compile(nil, logger, stubSource)
+		require.NoError(t, err)
+		require.Nil(t, listeners)
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := Compile([]ListenerConfig{{Listen: "127.0.0.1:0", Routes: []RouteConfig{route("a")}}}, logger, stubSource)
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("listen is required", func(t *testing.T) {
+		_, err := Compile([]ListenerConfig{{Name: "main", Routes: []RouteConfig{route("a")}}}, logger, stubSource)
+		require.ErrorContains(t, err, "listen is required")
+	})
+
+	t.Run("at least one route is required", func(t *testing.T) {
+		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0"}}, logger, stubSource)
+		require.ErrorContains(t, err, "at least one route is required")
+	})
+
+	t.Run("duplicate listener name rejected", func(t *testing.T) {
+		l := ListenerConfig{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{route("a")}}
+		_, err := Compile([]ListenerConfig{l, l}, logger, stubSource)
+		require.ErrorContains(t, err, "duplicate listener name")
+	})
+
+	t.Run("duplicate route database rejected", func(t *testing.T) {
+		_, err := Compile([]ListenerConfig{{
+			Name:   "main",
+			Listen: "127.0.0.1:0",
+			Routes: []RouteConfig{route("dup"), route("dup")},
+		}}, logger, stubSource)
+		require.ErrorContains(t, err, `duplicate route database "dup"`)
+	})
+
+	t.Run("route database is required", func(t *testing.T) {
+		_, err := Compile([]ListenerConfig{{
+			Name:   "main",
+			Listen: "127.0.0.1:0",
+			Routes: []RouteConfig{route("")},
+		}}, logger, stubSource)
+		require.ErrorContains(t, err, "database is required")
+	})
+
+	t.Run("route upstream dsn is required", func(t *testing.T) {
+		r := route("a")
+		r.Upstream.DSN = yaml.Node{}
+		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		require.ErrorContains(t, err, "upstream.dsn is required")
+	})
+
+	t.Run("route client fields required", func(t *testing.T) {
+		r := route("a")
+		r.Client.User = ""
+		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		require.ErrorContains(t, err, "client.user is required")
+
+		r = route("a")
+		r.Client.PasswordEnv = ""
+		_, err = Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		require.ErrorContains(t, err, "client.password_env is required")
+	})
+
+	t.Run("unset password env rejected", func(t *testing.T) {
+		r := route("a")
+		r.Client.PasswordEnv = "PG_PW_UNSET"
+		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		require.ErrorContains(t, err, "is not set in the environment")
+	})
+}

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -42,88 +42,74 @@ func TestCompile(t *testing.T) {
 	}
 
 	t.Run("valid single listener many routes", func(t *testing.T) {
-		listeners, err := Compile([]ListenerConfig{{
-			Name:   "main",
+		l, err := Compile(ListenerConfig{
 			Listen: "127.0.0.1:0",
 			Routes: []RouteConfig{route("analytics"), route("reporting")},
-		}}, logger, stubSource)
+		}, logger, stubSource)
 		require.NoError(t, err)
-		require.Len(t, listeners, 1)
-		require.Equal(t, "main", listeners[0].Name())
-		require.Equal(t, "analytics", listeners[0].Route("analytics").Database())
-		require.Equal(t, "reporting", listeners[0].Route("reporting").Database())
-		require.Nil(t, listeners[0].Route("missing"))
-		require.True(t, listeners[0].Route("analytics").VerifyClient("u", "secret"))
+		require.NotNil(t, l)
+		require.Equal(t, "127.0.0.1:0", l.Listen())
+		require.Equal(t, "analytics", l.Route("analytics").Database())
+		require.Equal(t, "reporting", l.Route("reporting").Database())
+		require.Nil(t, l.Route("missing"))
+		require.True(t, l.Route("analytics").VerifyClient("u", "secret"))
 	})
 
-	t.Run("empty input is a no-op", func(t *testing.T) {
-		listeners, err := Compile(nil, logger, stubSource)
+	t.Run("empty block is a no-op", func(t *testing.T) {
+		l, err := Compile(ListenerConfig{}, logger, stubSource)
 		require.NoError(t, err)
-		require.Nil(t, listeners)
-	})
-
-	t.Run("name is required", func(t *testing.T) {
-		_, err := Compile([]ListenerConfig{{Listen: "127.0.0.1:0", Routes: []RouteConfig{route("a")}}}, logger, stubSource)
-		require.ErrorContains(t, err, "name is required")
+		require.Nil(t, l)
 	})
 
 	t.Run("listen is required", func(t *testing.T) {
-		_, err := Compile([]ListenerConfig{{Name: "main", Routes: []RouteConfig{route("a")}}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Routes: []RouteConfig{route("a")}}, logger, stubSource)
 		require.ErrorContains(t, err, "listen is required")
 	})
 
 	t.Run("at least one route is required", func(t *testing.T) {
-		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0"}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0"}, logger, stubSource)
 		require.ErrorContains(t, err, "at least one route is required")
 	})
 
-	t.Run("duplicate listener name rejected", func(t *testing.T) {
-		l := ListenerConfig{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{route("a")}}
-		_, err := Compile([]ListenerConfig{l, l}, logger, stubSource)
-		require.ErrorContains(t, err, "duplicate listener name")
-	})
-
 	t.Run("duplicate route database rejected", func(t *testing.T) {
-		_, err := Compile([]ListenerConfig{{
-			Name:   "main",
+		_, err := Compile(ListenerConfig{
 			Listen: "127.0.0.1:0",
 			Routes: []RouteConfig{route("dup"), route("dup")},
-		}}, logger, stubSource)
+		}, logger, stubSource)
 		require.ErrorContains(t, err, `duplicate route database "dup"`)
 	})
 
 	t.Run("route database is required", func(t *testing.T) {
-		_, err := Compile([]ListenerConfig{{
-			Name:   "main",
+		_, err := Compile(ListenerConfig{
 			Listen: "127.0.0.1:0",
 			Routes: []RouteConfig{route("")},
-		}}, logger, stubSource)
+		}, logger, stubSource)
 		require.ErrorContains(t, err, "database is required")
 	})
 
 	t.Run("route upstream dsn is required", func(t *testing.T) {
 		r := route("a")
 		r.Upstream.DSN = yaml.Node{}
-		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
 		require.ErrorContains(t, err, "upstream.dsn is required")
 	})
 
 	t.Run("route client fields required", func(t *testing.T) {
 		r := route("a")
 		r.Client.User = ""
-		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
 		require.ErrorContains(t, err, "client.user is required")
 
 		r = route("a")
 		r.Client.PasswordEnv = ""
-		_, err = Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		_, err = Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
 		require.ErrorContains(t, err, "client.password_env is required")
 	})
 
 	t.Run("unset password env rejected", func(t *testing.T) {
 		r := route("a")
 		r.Client.PasswordEnv = "PG_PW_UNSET"
-		_, err := Compile([]ListenerConfig{{Name: "main", Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}}, logger, stubSource)
+		_, err := Compile(ListenerConfig{Listen: "127.0.0.1:0", Routes: []RouteConfig{r}}, logger, stubSource)
 		require.ErrorContains(t, err, "is not set in the environment")
 	})
 }

--- a/internal/postgres/manager.go
+++ b/internal/postgres/manager.go
@@ -7,84 +7,78 @@ import (
 	"sync"
 )
 
-// Manager owns the running set of postgres listener servers and supports
-// hot reload by closing the old set and starting a new one from updated
-// listeners. Safe for concurrent use.
+// Manager owns the single running postgres listener server and supports hot
+// reload by closing the old one and starting a new one from an updated
+// listener. Safe for concurrent use.
 type Manager struct {
 	logger *slog.Logger
 
-	mu      sync.Mutex
-	servers []*Server
+	mu     sync.Mutex
+	server *Server
 }
 
-// NewManager returns a Manager with no running servers.
+// NewManager returns a Manager with no running server.
 func NewManager(logger *slog.Logger) *Manager {
 	return &Manager{logger: logger}
 }
 
-// Start launches a server for each listener. A server that exits with a
-// non-nil error sends it to errc so the calling process can treat it as
-// fatal; bind failures during a subsequent Reload are logged instead.
-func (m *Manager) Start(listeners []*Listener, errc chan<- error) {
+// Start launches the listener server. A nil listener is a no-op. A server that
+// exits with a non-nil error sends it to errc so the calling process can treat
+// it as fatal; bind failures during a subsequent Reload are logged instead.
+func (m *Manager) Start(listener *Listener, errc chan<- error) {
+	if listener == nil {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, l := range listeners {
-		srv := NewServer(l, m.logger)
-		m.servers = append(m.servers, srv)
-		go m.run(srv, errc)
-	}
+	srv := NewServer(listener, m.logger)
+	m.server = srv
+	go m.run(srv, errc)
 }
 
-// Reload closes all running listeners and starts a new set from the given
-// listeners. In-flight client sessions on the closed listeners are not
-// interrupted, but no new connections will be accepted on the old addresses.
-// ctx bounds the shutdown of the old listeners. Listener failures during reload
-// (e.g. address already in use) are logged, not fatal: the management /v1/reload
-// caller has already received a 200.
-func (m *Manager) Reload(ctx context.Context, listeners []*Listener) {
+// Reload closes the running listener and starts a new one from the given
+// listener (nil means "no listener"). In-flight client sessions on the closed
+// listener are not interrupted, but no new connections will be accepted on the
+// old address. ctx bounds the shutdown of the old listener. A bind failure
+// during reload (e.g. address already in use) is logged, not fatal: the
+// management /v1/reload caller has already received a 200.
+func (m *Manager) Reload(ctx context.Context, listener *Listener) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for _, s := range m.servers {
-		if err := s.Shutdown(ctx); err != nil {
+	if m.server != nil {
+		if err := m.server.Shutdown(ctx); err != nil {
 			m.logger.Error("postgres listener shutdown during reload",
-				slog.String("name", s.Name()),
+				slog.String("name", m.server.Name()),
 				slog.String("error", err.Error()),
 			)
 		}
+		m.server = nil
 	}
 
-	m.servers = make([]*Server, 0, len(listeners))
-	for _, l := range listeners {
-		srv := NewServer(l, m.logger)
-		m.servers = append(m.servers, srv)
-		go m.run(srv, nil)
+	if listener == nil {
+		return
 	}
+	srv := NewServer(listener, m.logger)
+	m.server = srv
+	go m.run(srv, nil)
 }
 
-// Shutdown closes all running listeners. The first error from any server is
-// returned; remaining listeners are still asked to shut down.
+// Shutdown closes the running listener, if any.
 func (m *Manager) Shutdown(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var firstErr error
-	for _, s := range m.servers {
-		if err := s.Shutdown(ctx); err != nil && firstErr == nil {
-			firstErr = err
-		}
+	if m.server == nil {
+		return nil
 	}
-	return firstErr
+	return m.server.Shutdown(ctx)
 }
 
-// Names returns the names of the currently running servers. Test-only.
-func (m *Manager) Names() []string {
+// Running reports whether a listener server is currently running. Test-only.
+func (m *Manager) Running() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]string, 0, len(m.servers))
-	for _, s := range m.servers {
-		out = append(out, s.Name())
-	}
-	return out
+	return m.server != nil
 }
 
 func (m *Manager) run(s *Server, errc chan<- error) {

--- a/internal/postgres/manager.go
+++ b/internal/postgres/manager.go
@@ -9,7 +9,7 @@ import (
 
 // Manager owns the running set of postgres listener servers and supports
 // hot reload by closing the old set and starting a new one from updated
-// policies. Safe for concurrent use.
+// listeners. Safe for concurrent use.
 type Manager struct {
 	logger *slog.Logger
 
@@ -22,26 +22,26 @@ func NewManager(logger *slog.Logger) *Manager {
 	return &Manager{logger: logger}
 }
 
-// Start launches a listener for each policy. A listener that exits with a
+// Start launches a server for each listener. A server that exits with a
 // non-nil error sends it to errc so the calling process can treat it as
 // fatal; bind failures during a subsequent Reload are logged instead.
-func (m *Manager) Start(policies []*Policy, errc chan<- error) {
+func (m *Manager) Start(listeners []*Listener, errc chan<- error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, p := range policies {
-		srv := NewServer(p, m.logger)
+	for _, l := range listeners {
+		srv := NewServer(l, m.logger)
 		m.servers = append(m.servers, srv)
 		go m.run(srv, errc)
 	}
 }
 
-// Reload closes all running listeners and starts a new set from policies.
-// In-flight client sessions on the closed listeners are not interrupted, but
-// no new connections will be accepted on the old addresses. ctx bounds the
-// shutdown of the old listeners. Listener failures during reload (e.g.
-// address already in use) are logged, not fatal: the management /v1/reload
+// Reload closes all running listeners and starts a new set from the given
+// listeners. In-flight client sessions on the closed listeners are not
+// interrupted, but no new connections will be accepted on the old addresses.
+// ctx bounds the shutdown of the old listeners. Listener failures during reload
+// (e.g. address already in use) are logged, not fatal: the management /v1/reload
 // caller has already received a 200.
-func (m *Manager) Reload(ctx context.Context, policies []*Policy) {
+func (m *Manager) Reload(ctx context.Context, listeners []*Listener) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -54,9 +54,9 @@ func (m *Manager) Reload(ctx context.Context, policies []*Policy) {
 		}
 	}
 
-	m.servers = make([]*Server, 0, len(policies))
-	for _, p := range policies {
-		srv := NewServer(p, m.logger)
+	m.servers = make([]*Server, 0, len(listeners))
+	for _, l := range listeners {
+		srv := NewServer(l, m.logger)
 		m.servers = append(m.servers, srv)
 		go m.run(srv, nil)
 	}

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -23,10 +23,10 @@ func testListener(listen string) *Listener {
 	return &Listener{
 		name:   listenerName,
 		listen: listen,
-		routes: map[string]*Route{
+		upstreams: map[string]*Upstream{
 			"appdb": {
 				database:       "appdb",
-				upstreamDSN:    staticDSN{name: "test", value: "host=127.0.0.1"},
+				dsn:            staticDSN{name: "test", value: "host=127.0.0.1"},
 				clientUser:     "u",
 				clientPassword: "p",
 			},

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -21,14 +21,14 @@ func (s staticDSN) Get(context.Context) (string, error) { return s.value, nil }
 
 func testListener(listen string) *Listener {
 	return &Listener{
-		name:   listenerName,
-		listen: listen,
+		name:           listenerName,
+		listen:         listen,
+		clientUser:     "u",
+		clientPassword: "p",
 		upstreams: map[string]*Upstream{
 			"appdb": {
-				database:       "appdb",
-				dsn:            staticDSN{name: "test", value: "host=127.0.0.1"},
-				clientUser:     "u",
-				clientPassword: "p",
+				database: "appdb",
+				dsn:      staticDSN{name: "test", value: "host=127.0.0.1"},
 			},
 		},
 	}

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -11,21 +11,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// staticDSN is a no-op secrets.Source used to build test policies. The
+// staticDSN is a no-op secrets.Source used to build test listeners. The
 // manager tests never complete a postgres handshake; they only verify that
 // the listener is accepting TCP connections, so the DSN value is never read.
 type staticDSN struct{ name, value string }
 
-func (s staticDSN) Name() string                       { return s.name }
+func (s staticDSN) Name() string                        { return s.name }
 func (s staticDSN) Get(context.Context) (string, error) { return s.value, nil }
 
-func testPolicy(name, listen string) *Policy {
-	return &Policy{
-		name:           name,
-		listen:         listen,
-		upstreamDSN:    staticDSN{name: "test", value: "host=127.0.0.1"},
-		clientUser:     "u",
-		clientPassword: "p",
+func testListener(name, listen string) *Listener {
+	return &Listener{
+		name:   name,
+		listen: listen,
+		routes: map[string]*Route{
+			"appdb": {
+				database:       "appdb",
+				upstreamDSN:    staticDSN{name: "test", value: "host=127.0.0.1"},
+				clientUser:     "u",
+				clientPassword: "p",
+			},
+		},
 	}
 }
 
@@ -56,7 +61,7 @@ func TestManagerReload(t *testing.T) {
 	m := NewManager(logger)
 	errc := make(chan error, 2)
 
-	m.Start([]*Policy{testPolicy("initial", "127.0.0.1:0")}, errc)
+	m.Start([]*Listener{testListener("initial", "127.0.0.1:0")}, errc)
 	oldAddr := waitForListener(t, m)
 
 	// Old listener is accepting connections.
@@ -65,7 +70,7 @@ func TestManagerReload(t *testing.T) {
 	require.NoError(t, c.Close())
 
 	// Reload swaps in a new policy. The old listener closes; a new one binds.
-	m.Reload(context.Background(), []*Policy{testPolicy("reloaded", "127.0.0.1:0")})
+	m.Reload(context.Background(), []*Listener{testListener("reloaded", "127.0.0.1:0")})
 	newAddr := waitForListener(t, m)
 	require.NotEqual(t, oldAddr, newAddr)
 	require.Equal(t, []string{"reloaded"}, m.Names())
@@ -93,7 +98,7 @@ func TestManagerReloadToEmpty(t *testing.T) {
 	m := NewManager(logger)
 	errc := make(chan error, 1)
 
-	m.Start([]*Policy{testPolicy("initial", "127.0.0.1:0")}, errc)
+	m.Start([]*Listener{testListener("initial", "127.0.0.1:0")}, errc)
 	oldAddr := waitForListener(t, m)
 
 	m.Reload(context.Background(), nil)

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -19,9 +19,9 @@ type staticDSN struct{ name, value string }
 func (s staticDSN) Name() string                        { return s.name }
 func (s staticDSN) Get(context.Context) (string, error) { return s.value, nil }
 
-func testListener(name, listen string) *Listener {
+func testListener(listen string) *Listener {
 	return &Listener{
-		name:   name,
+		name:   listenerName,
 		listen: listen,
 		routes: map[string]*Route{
 			"appdb": {
@@ -34,21 +34,19 @@ func testListener(name, listen string) *Listener {
 	}
 }
 
-// waitForListener returns the bound address once the first server in m is
-// listening. Fails the test if the bind never completes in time.
+// waitForListener returns the bound address once m's server is listening. Fails
+// the test if the bind never completes in time.
 func waitForListener(t *testing.T, m *Manager) string {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		m.mu.Lock()
-		if len(m.servers) > 0 {
-			addr := m.servers[0].Addr()
-			m.mu.Unlock()
-			if addr != "" {
+		srv := m.server
+		m.mu.Unlock()
+		if srv != nil {
+			if addr := srv.Addr(); addr != "" {
 				return addr
 			}
-		} else {
-			m.mu.Unlock()
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -61,7 +59,7 @@ func TestManagerReload(t *testing.T) {
 	m := NewManager(logger)
 	errc := make(chan error, 2)
 
-	m.Start([]*Listener{testListener("initial", "127.0.0.1:0")}, errc)
+	m.Start(testListener("127.0.0.1:0"), errc)
 	oldAddr := waitForListener(t, m)
 
 	// Old listener is accepting connections.
@@ -69,11 +67,11 @@ func TestManagerReload(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.Close())
 
-	// Reload swaps in a new policy. The old listener closes; a new one binds.
-	m.Reload(context.Background(), []*Listener{testListener("reloaded", "127.0.0.1:0")})
+	// Reload swaps in a new listener. The old listener closes; a new one binds.
+	m.Reload(context.Background(), testListener("127.0.0.1:0"))
 	newAddr := waitForListener(t, m)
 	require.NotEqual(t, oldAddr, newAddr)
-	require.Equal(t, []string{"reloaded"}, m.Names())
+	require.True(t, m.Running())
 
 	// New listener accepts.
 	c, err = net.DialTimeout("tcp", newAddr, time.Second)
@@ -98,11 +96,11 @@ func TestManagerReloadToEmpty(t *testing.T) {
 	m := NewManager(logger)
 	errc := make(chan error, 1)
 
-	m.Start([]*Listener{testListener("initial", "127.0.0.1:0")}, errc)
+	m.Start(testListener("127.0.0.1:0"), errc)
 	oldAddr := waitForListener(t, m)
 
 	m.Reload(context.Background(), nil)
-	require.Empty(t, m.Names())
+	require.False(t, m.Running())
 
 	_, err := net.DialTimeout("tcp", oldAddr, 200*time.Millisecond)
 	require.Error(t, err)

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -63,55 +63,55 @@ func TestClassifyClientStatement(t *testing.T) {
 	}
 }
 
-func TestNewManagedRoute(t *testing.T) {
+func TestNewManagedUpstream(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 
-	r, err := NewManagedRoute("analytics", dsn, "app", "pw", "readonly")
+	u, err := NewManagedUpstream("analytics", dsn, "app", "pw", "readonly")
 	require.NoError(t, err)
-	require.Equal(t, "analytics", r.Database())
-	require.Equal(t, "readonly", r.Role())
-	require.True(t, r.VerifyClient("app", "pw"))
-	require.False(t, r.VerifyClient("app", "wrong"))
+	require.Equal(t, "analytics", u.Database())
+	require.Equal(t, "readonly", u.Role())
+	require.True(t, u.VerifyClient("app", "pw"))
+	require.False(t, u.VerifyClient("app", "wrong"))
 
 	// Absent role is allowed (no SET ROLE issued).
-	r, err = NewManagedRoute("main", dsn, "app", "pw", "")
+	u, err = NewManagedUpstream("main", dsn, "app", "pw", "")
 	require.NoError(t, err)
-	require.Empty(t, r.Role())
+	require.Empty(t, u.Role())
 
 	// Required fields.
-	_, err = NewManagedRoute("", dsn, "app", "pw", "")
+	_, err = NewManagedUpstream("", dsn, "app", "pw", "")
 	require.ErrorContains(t, err, "database is required")
-	_, err = NewManagedRoute("d", nil, "app", "pw", "")
+	_, err = NewManagedUpstream("d", nil, "app", "pw", "")
 	require.ErrorContains(t, err, "dsn source is required")
-	_, err = NewManagedRoute("d", dsn, "", "pw", "")
+	_, err = NewManagedUpstream("d", dsn, "", "pw", "")
 	require.ErrorContains(t, err, "client user is required")
-	_, err = NewManagedRoute("d", dsn, "app", "", "")
+	_, err = NewManagedUpstream("d", dsn, "app", "", "")
 	require.ErrorContains(t, err, "client password is required")
 }
 
 func TestNewListener(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
-	mustRoute := func(database string) *Route {
-		r, err := NewManagedRoute(database, dsn, "app", "pw", "")
+	mustUpstream := func(database string) *Upstream {
+		u, err := NewManagedUpstream(database, dsn, "app", "pw", "")
 		require.NoError(t, err)
-		return r
+		return u
 	}
 
-	l, err := NewListener("127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("b")})
+	l, err := NewListener("127.0.0.1:0", []*Upstream{mustUpstream("a"), mustUpstream("b")})
 	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1:0", l.Listen())
-	require.Equal(t, "a", l.Route("a").Database())
-	require.Equal(t, "b", l.Route("b").Database())
-	require.Nil(t, l.Route("missing"))
-	require.Len(t, l.Routes(), 2)
+	require.Equal(t, "a", l.Upstream("a").Database())
+	require.Equal(t, "b", l.Upstream("b").Database())
+	require.Nil(t, l.Upstream("missing"))
+	require.Len(t, l.Upstreams(), 2)
 
 	// Required fields and duplicate-database guard.
-	_, err = NewListener("", []*Route{mustRoute("a")})
+	_, err = NewListener("", []*Upstream{mustUpstream("a")})
 	require.ErrorContains(t, err, "listen is required")
 	_, err = NewListener("127.0.0.1:0", nil)
-	require.ErrorContains(t, err, "at least one route is required")
-	_, err = NewListener("127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("a")})
-	require.ErrorContains(t, err, `duplicate route database "a"`)
+	require.ErrorContains(t, err, "at least one upstream is required")
+	_, err = NewListener("127.0.0.1:0", []*Upstream{mustUpstream("a"), mustUpstream("a")})
+	require.ErrorContains(t, err, `duplicate upstream database "a"`)
 }
 
 func TestQuoteIdent(t *testing.T) {

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -66,52 +66,72 @@ func TestClassifyClientStatement(t *testing.T) {
 func TestNewManagedUpstream(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 
-	u, err := NewManagedUpstream("analytics", dsn, "app", "pw", "readonly")
+	u, err := NewManagedUpstream("analytics", dsn, "readonly")
 	require.NoError(t, err)
 	require.Equal(t, "analytics", u.Database())
 	require.Equal(t, "readonly", u.Role())
-	require.True(t, u.VerifyClient("app", "pw"))
-	require.False(t, u.VerifyClient("app", "wrong"))
 
 	// Absent role is allowed (no SET ROLE issued).
-	u, err = NewManagedUpstream("main", dsn, "app", "pw", "")
+	u, err = NewManagedUpstream("main", dsn, "")
 	require.NoError(t, err)
 	require.Empty(t, u.Role())
 
 	// Required fields.
-	_, err = NewManagedUpstream("", dsn, "app", "pw", "")
+	_, err = NewManagedUpstream("", dsn, "")
 	require.ErrorContains(t, err, "database is required")
-	_, err = NewManagedUpstream("d", nil, "app", "pw", "")
+	_, err = NewManagedUpstream("d", nil, "")
 	require.ErrorContains(t, err, "dsn source is required")
-	_, err = NewManagedUpstream("d", dsn, "", "pw", "")
-	require.ErrorContains(t, err, "client user is required")
-	_, err = NewManagedUpstream("d", dsn, "app", "", "")
-	require.ErrorContains(t, err, "client password is required")
 }
 
 func TestNewListener(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 	mustUpstream := func(database string) *Upstream {
-		u, err := NewManagedUpstream(database, dsn, "app", "pw", "")
+		u, err := NewManagedUpstream(database, dsn, "")
 		require.NoError(t, err)
 		return u
 	}
 
-	l, err := NewListener("127.0.0.1:0", []*Upstream{mustUpstream("a"), mustUpstream("b")})
+	l, err := NewListener("127.0.0.1:0", "app", "pw", []*Upstream{mustUpstream("a"), mustUpstream("b")})
 	require.NoError(t, err)
 	require.Equal(t, "127.0.0.1:0", l.Listen())
 	require.Equal(t, "a", l.Upstream("a").Database())
 	require.Equal(t, "b", l.Upstream("b").Database())
 	require.Nil(t, l.Upstream("missing"))
 	require.Len(t, l.Upstreams(), 2)
+	// The client credential is on the listener, shared across upstreams.
+	require.True(t, l.VerifyClient("app", "pw"))
 
 	// Required fields and duplicate-database guard.
-	_, err = NewListener("", []*Upstream{mustUpstream("a")})
+	_, err = NewListener("", "app", "pw", []*Upstream{mustUpstream("a")})
 	require.ErrorContains(t, err, "listen is required")
-	_, err = NewListener("127.0.0.1:0", nil)
+	_, err = NewListener("127.0.0.1:0", "", "pw", []*Upstream{mustUpstream("a")})
+	require.ErrorContains(t, err, "client user is required")
+	_, err = NewListener("127.0.0.1:0", "app", "", []*Upstream{mustUpstream("a")})
+	require.ErrorContains(t, err, "client password is required")
+	_, err = NewListener("127.0.0.1:0", "app", "pw", nil)
 	require.ErrorContains(t, err, "at least one upstream is required")
-	_, err = NewListener("127.0.0.1:0", []*Upstream{mustUpstream("a"), mustUpstream("a")})
+	_, err = NewListener("127.0.0.1:0", "app", "pw", []*Upstream{mustUpstream("a"), mustUpstream("a")})
 	require.ErrorContains(t, err, `duplicate upstream database "a"`)
+}
+
+func TestListenerWithUpstreams(t *testing.T) {
+	dsn := staticDSN{name: "dsn", value: "host=db"}
+	mustUpstream := func(database string) *Upstream {
+		u, err := NewManagedUpstream(database, dsn, "")
+		require.NoError(t, err)
+		return u
+	}
+
+	base, err := NewListener("127.0.0.1:0", "app", "pw", []*Upstream{mustUpstream("a")})
+	require.NoError(t, err)
+
+	merged, dropped := base.WithUpstreams([]*Upstream{mustUpstream("b"), mustUpstream("a")})
+	require.Equal(t, []string{"a"}, dropped, "existing database wins")
+	require.Len(t, merged.Upstreams(), 2)
+	require.NotNil(t, merged.Upstream("a"))
+	require.NotNil(t, merged.Upstream("b"))
+	require.Equal(t, "127.0.0.1:0", merged.Listen())
+	require.True(t, merged.VerifyClient("app", "pw"), "client credential is carried over")
 }
 
 func TestQuoteIdent(t *testing.T) {

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -63,33 +63,57 @@ func TestClassifyClientStatement(t *testing.T) {
 	}
 }
 
-func TestNewManagedPolicy(t *testing.T) {
+func TestNewManagedRoute(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 
-	p, err := NewManagedPolicy("pg-analytics", "127.0.0.1:6432", dsn, "app", "pw", "readonly")
+	r, err := NewManagedRoute("analytics", dsn, "app", "pw", "readonly")
 	require.NoError(t, err)
-	require.Equal(t, "pg-analytics", p.Name())
-	require.Equal(t, "127.0.0.1:6432", p.Listen())
-	require.Equal(t, "readonly", p.Role())
-	require.True(t, p.VerifyClient("app", "pw"))
-	require.False(t, p.VerifyClient("app", "wrong"))
+	require.Equal(t, "analytics", r.Database())
+	require.Equal(t, "readonly", r.Role())
+	require.True(t, r.VerifyClient("app", "pw"))
+	require.False(t, r.VerifyClient("app", "wrong"))
 
 	// Absent role is allowed (no SET ROLE issued).
-	p, err = NewManagedPolicy("pg-main", "127.0.0.1:6433", dsn, "app", "pw", "")
+	r, err = NewManagedRoute("main", dsn, "app", "pw", "")
 	require.NoError(t, err)
-	require.Empty(t, p.Role())
+	require.Empty(t, r.Role())
 
 	// Required fields.
-	_, err = NewManagedPolicy("", "127.0.0.1:0", dsn, "app", "pw", "")
-	require.ErrorContains(t, err, "name is required")
-	_, err = NewManagedPolicy("n", "", dsn, "app", "pw", "")
-	require.ErrorContains(t, err, "listen is required")
-	_, err = NewManagedPolicy("n", "127.0.0.1:0", nil, "app", "pw", "")
+	_, err = NewManagedRoute("", dsn, "app", "pw", "")
+	require.ErrorContains(t, err, "database is required")
+	_, err = NewManagedRoute("d", nil, "app", "pw", "")
 	require.ErrorContains(t, err, "dsn source is required")
-	_, err = NewManagedPolicy("n", "127.0.0.1:0", dsn, "", "pw", "")
+	_, err = NewManagedRoute("d", dsn, "", "pw", "")
 	require.ErrorContains(t, err, "client user is required")
-	_, err = NewManagedPolicy("n", "127.0.0.1:0", dsn, "app", "", "")
+	_, err = NewManagedRoute("d", dsn, "app", "", "")
 	require.ErrorContains(t, err, "client password is required")
+}
+
+func TestNewListener(t *testing.T) {
+	dsn := staticDSN{name: "dsn", value: "host=db"}
+	mustRoute := func(database string) *Route {
+		r, err := NewManagedRoute(database, dsn, "app", "pw", "")
+		require.NoError(t, err)
+		return r
+	}
+
+	l, err := NewListener("main", "127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("b")})
+	require.NoError(t, err)
+	require.Equal(t, "main", l.Name())
+	require.Equal(t, "127.0.0.1:0", l.Listen())
+	require.Equal(t, "a", l.Route("a").Database())
+	require.Equal(t, "b", l.Route("b").Database())
+	require.Nil(t, l.Route("missing"))
+
+	// Required fields and duplicate-database guard.
+	_, err = NewListener("", "127.0.0.1:0", []*Route{mustRoute("a")})
+	require.ErrorContains(t, err, "listener name is required")
+	_, err = NewListener("n", "", []*Route{mustRoute("a")})
+	require.ErrorContains(t, err, "listen is required")
+	_, err = NewListener("n", "127.0.0.1:0", nil)
+	require.ErrorContains(t, err, "at least one route is required")
+	_, err = NewListener("n", "127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("a")})
+	require.ErrorContains(t, err, `duplicate route database "a"`)
 }
 
 func TestQuoteIdent(t *testing.T) {

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -97,22 +97,20 @@ func TestNewListener(t *testing.T) {
 		return r
 	}
 
-	l, err := NewListener("main", "127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("b")})
+	l, err := NewListener("127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("b")})
 	require.NoError(t, err)
-	require.Equal(t, "main", l.Name())
 	require.Equal(t, "127.0.0.1:0", l.Listen())
 	require.Equal(t, "a", l.Route("a").Database())
 	require.Equal(t, "b", l.Route("b").Database())
 	require.Nil(t, l.Route("missing"))
+	require.Len(t, l.Routes(), 2)
 
 	// Required fields and duplicate-database guard.
-	_, err = NewListener("", "127.0.0.1:0", []*Route{mustRoute("a")})
-	require.ErrorContains(t, err, "listener name is required")
-	_, err = NewListener("n", "", []*Route{mustRoute("a")})
+	_, err = NewListener("", []*Route{mustRoute("a")})
 	require.ErrorContains(t, err, "listen is required")
-	_, err = NewListener("n", "127.0.0.1:0", nil)
+	_, err = NewListener("127.0.0.1:0", nil)
 	require.ErrorContains(t, err, "at least one route is required")
-	_, err = NewListener("n", "127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("a")})
+	_, err = NewListener("127.0.0.1:0", []*Route{mustRoute("a"), mustRoute("a")})
 	require.ErrorContains(t, err, `duplicate route database "a"`)
 }
 

--- a/internal/postgres/server.go
+++ b/internal/postgres/server.go
@@ -61,7 +61,7 @@ func (s *Server) ListenAndServe() error {
 	s.logger.Info("postgres proxy starting",
 		slog.String("name", s.listener.Name()),
 		slog.String("addr", ln.Addr().String()),
-		slog.Int("routes", len(s.listener.routes)),
+		slog.Int("upstreams", len(s.listener.upstreams)),
 	)
 
 	for {

--- a/internal/postgres/server.go
+++ b/internal/postgres/server.go
@@ -18,22 +18,22 @@ const handshakeTimeout = 30 * time.Second
 // Server is the listener that accepts incoming PostgreSQL client connections
 // and dispatches them to per-conn session handlers.
 type Server struct {
-	policy *Policy
-	logger *slog.Logger
+	listener *Listener
+	logger   *slog.Logger
 
 	mu       sync.Mutex
-	listener net.Listener
+	netLn    net.Listener
 	shutdown bool
 }
 
-// NewServer constructs a postgres listener bound to policy.
-func NewServer(policy *Policy, logger *slog.Logger) *Server {
-	return &Server{policy: policy, logger: logger}
+// NewServer constructs a postgres server bound to the given listener config.
+func NewServer(listener *Listener, logger *slog.Logger) *Server {
+	return &Server{listener: listener, logger: logger}
 }
 
-// Name returns the configured server name. Used in logs and error wrapping
-// when multiple postgres servers are running.
-func (s *Server) Name() string { return s.policy.Name() }
+// Name returns the configured listener name. Used in logs and error wrapping
+// when multiple postgres listeners are running.
+func (s *Server) Name() string { return s.listener.Name() }
 
 // Addr returns the address the server is bound to. Useful in tests where the
 // configured listen address is ":0" — the actual port is only known after
@@ -41,31 +41,28 @@ func (s *Server) Name() string { return s.policy.Name() }
 func (s *Server) Addr() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.listener == nil {
+	if s.netLn == nil {
 		return ""
 	}
-	return s.listener.Addr().String()
+	return s.netLn.Addr().String()
 }
 
 // ListenAndServe binds to the configured listen address and serves clients
 // until Shutdown is called or the listener returns a fatal error.
 func (s *Server) ListenAndServe() error {
-	ln, err := net.Listen("tcp", s.policy.Listen())
+	ln, err := net.Listen("tcp", s.listener.Listen())
 	if err != nil {
 		return fmt.Errorf("postgres listen: %w", err)
 	}
 	s.mu.Lock()
-	s.listener = ln
+	s.netLn = ln
 	s.mu.Unlock()
 
-	startAttrs := []any{
-		slog.String("name", s.policy.Name()),
+	s.logger.Info("postgres proxy starting",
+		slog.String("name", s.listener.Name()),
 		slog.String("addr", ln.Addr().String()),
-	}
-	if role := s.policy.Role(); role != "" {
-		startAttrs = append(startAttrs, slog.String("role", role))
-	}
-	s.logger.Info("postgres proxy starting", startAttrs...)
+		slog.Int("routes", len(s.listener.routes)),
+	)
 
 	for {
 		conn, err := ln.Accept()
@@ -91,7 +88,7 @@ func (s *Server) ListenAndServe() error {
 func (s *Server) Shutdown(_ context.Context) error {
 	s.mu.Lock()
 	s.shutdown = true
-	ln := s.listener
+	ln := s.netLn
 	s.mu.Unlock()
 	if ln == nil {
 		return nil
@@ -108,5 +105,5 @@ func (s *Server) handle(conn net.Conn) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	runSession(ctx, conn, s.policy, s.logger)
+	runSession(ctx, conn, s.listener, s.logger)
 }

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -68,11 +68,11 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 
 	upstreamConn, err := dialUpstream(ctx, upstream)
 	if err != nil {
-		var mismatch *databaseMismatchError
-		if errors.As(err, &mismatch) {
+		var cfgErr upstreamConfigError
+		if errors.As(err, &cfgErr) {
 			// Configuration error, but surface it clearly to the client rather
 			// than as a generic connection failure.
-			writeFatal(backend, "3D000", mismatch.Error())
+			writeFatal(backend, "3D000", cfgErr.Error())
 		} else {
 			writeFatal(backend, "08006", "upstream connection failed")
 		}
@@ -145,6 +145,30 @@ func receiveStartup(rawConn net.Conn, backend *pgproto3.Backend) (*pgproto3.Star
 	return nil, errors.New("startup message preceded by too many SSL/GSS requests")
 }
 
+// upstreamConfigError marks a dial failure caused by upstream configuration —
+// a DSN that names no database, or one whose database disagrees with the
+// upstream's routing database — rather than a transient connection problem. The
+// session surfaces these to the client as a clear database error.
+type upstreamConfigError interface {
+	error
+	isUpstreamConfigError()
+}
+
+// missingDSNDatabaseError reports that an upstream's DSN does not name a
+// database. The DSN must name the database it connects to, both so the upstream
+// session lands somewhere deterministic and so it can be validated against the
+// upstream's routing database.
+type missingDSNDatabaseError struct {
+	configured string // the upstream's routing database
+}
+
+func (e *missingDSNDatabaseError) Error() string {
+	return fmt.Sprintf("upstream DSN for database %q does not name a database; the DSN must specify the database it connects to",
+		e.configured)
+}
+
+func (*missingDSNDatabaseError) isUpstreamConfigError() {}
+
 // databaseMismatchError reports that an upstream's routing database does not
 // match the database its DSN connects to. The two must always be equal: the
 // routing database is the name the client connected with, so if the upstream
@@ -160,11 +184,13 @@ func (e *databaseMismatchError) Error() string {
 		e.configured, e.dsn)
 }
 
+func (*databaseMismatchError) isUpstreamConfigError() {}
+
 // dialUpstream opens an authenticated PgConn to the upstream database using
 // the DSN resolved from the upstream's configured secret source. It refuses to
-// connect when the DSN's database does not match the upstream's routing
-// database, since that would land the client on a different database than the
-// one it named.
+// connect when the DSN names no database, or when the DSN's database does not
+// match the upstream's routing database, since that would land the client on a
+// different database than the one it named.
 func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, error) {
 	dsn, err := upstream.DSN(ctx)
 	if err != nil {
@@ -173,6 +199,9 @@ func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, erro
 	cfg, err := pgconn.ParseConfig(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream DSN: %w", err)
+	}
+	if cfg.Database == "" {
+		return nil, &missingDSNDatabaseError{configured: upstream.Database()}
 	}
 	if cfg.Database != upstream.Database() {
 		return nil, &databaseMismatchError{configured: upstream.Database(), dsn: cfg.Database}

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -36,7 +36,7 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	// Select the route by the requested database. The client must name a
+	// Select the upstream by the requested database. The client must name a
 	// database explicitly; the proxy does not infer one from the user.
 	dbName := startup.Parameters["database"]
 	if dbName == "" {
@@ -47,10 +47,10 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		)
 		return
 	}
-	route := listener.Route(dbName)
-	if route == nil {
-		writeFatal(backend, "3D000", fmt.Sprintf("no route for database %q", dbName))
-		logger.Info("postgres: no route for database",
+	upstream := listener.Upstream(dbName)
+	if upstream == nil {
+		writeFatal(backend, "3D000", fmt.Sprintf("no upstream for database %q", dbName))
+		logger.Info("postgres: no upstream for database",
 			slog.String("database", dbName),
 			slog.String("listener", listener.Name()),
 			slog.String("remote", clientConn.RemoteAddr().String()),
@@ -58,7 +58,7 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	if err := authenticateClient(backend, startup, route); err != nil {
+	if err := authenticateClient(backend, startup, upstream); err != nil {
 		logger.Info("postgres: client auth failed",
 			slog.String("error", err.Error()),
 			slog.String("remote", clientConn.RemoteAddr().String()),
@@ -66,26 +66,26 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	upstream, err := dialUpstream(ctx, route)
+	upstreamConn, err := dialUpstream(ctx, upstream)
 	if err != nil {
 		writeFatal(backend, "08006", "upstream connection failed")
 		logger.Error("postgres: upstream connect failed", slog.String("error", err.Error()))
 		return
 	}
 
-	if route.Role() != "" {
-		if err := setUpstreamRole(ctx, upstream, route); err != nil {
+	if upstream.Role() != "" {
+		if err := setUpstreamRole(ctx, upstreamConn, upstream); err != nil {
 			writeFatal(backend, "08006", err.Error())
 			logger.Error("postgres: set role failed",
 				slog.String("error", err.Error()),
 				slog.String("remote", clientConn.RemoteAddr().String()),
 			)
-			_ = upstream.Close(ctx)
+			_ = upstreamConn.Close(ctx)
 			return
 		}
 	}
 
-	hijacked, err := upstream.Hijack()
+	hijacked, err := upstreamConn.Hijack()
 	if err != nil {
 		writeFatal(backend, "08006", "upstream hijack failed")
 		logger.Error("postgres: upstream hijack failed", slog.String("error", err.Error()))
@@ -102,7 +102,7 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 	// truncated by it. The relay loop drives I/O end-to-end from here.
 	_ = clientConn.SetDeadline(time.Time{})
 
-	relay := newRelay(clientConn, hijacked.Conn, backend, hijacked.Frontend, route, logger)
+	relay := newRelay(clientConn, hijacked.Conn, backend, hijacked.Frontend, upstream, logger)
 	relay.run()
 }
 
@@ -139,9 +139,9 @@ func receiveStartup(rawConn net.Conn, backend *pgproto3.Backend) (*pgproto3.Star
 }
 
 // dialUpstream opens an authenticated PgConn to the upstream database using
-// the DSN resolved from the route's configured secret source.
-func dialUpstream(ctx context.Context, route *Route) (*pgconn.PgConn, error) {
-	dsn, err := route.UpstreamDSN(ctx)
+// the DSN resolved from the upstream's configured secret source.
+func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, error) {
+	dsn, err := upstream.DSN(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loading upstream DSN: %w", err)
 	}
@@ -163,10 +163,10 @@ func dialUpstream(ctx context.Context, route *Route) (*pgconn.PgConn, error) {
 // Transaction or statement pool modes silently swap backends between queries
 // and would defeat the policy; that constraint is enforced by deployment
 // configuration rather than by a runtime probe.
-func setUpstreamRole(ctx context.Context, conn *pgconn.PgConn, route *Route) error {
-	setSQL := "SET ROLE " + QuoteIdent(route.Role())
+func setUpstreamRole(ctx context.Context, conn *pgconn.PgConn, upstream *Upstream) error {
+	setSQL := "SET ROLE " + QuoteIdent(upstream.Role())
 	if _, err := conn.Exec(ctx, setSQL).ReadAll(); err != nil {
-		return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(route.Role()), err)
+		return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(upstream.Role()), err)
 	}
 	return nil
 }
@@ -210,8 +210,8 @@ type relay struct {
 	backend  *pgproto3.Backend
 	frontend *pgproto3.Frontend
 
-	route  *Route
-	logger *slog.Logger
+	upstream *Upstream
+	logger   *slog.Logger
 
 	clientWriteMu sync.Mutex
 
@@ -225,13 +225,13 @@ type relay struct {
 	skipExtended bool
 }
 
-func newRelay(clientConn, upstreamConn net.Conn, backend *pgproto3.Backend, frontend *pgproto3.Frontend, route *Route, logger *slog.Logger) *relay {
+func newRelay(clientConn, upstreamConn net.Conn, backend *pgproto3.Backend, frontend *pgproto3.Frontend, upstream *Upstream, logger *slog.Logger) *relay {
 	return &relay{
 		clientConn:   clientConn,
 		upstreamConn: upstreamConn,
 		backend:      backend,
 		frontend:     frontend,
-		route:        route,
+		upstream:     upstream,
 		logger:       logger,
 	}
 }

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -58,7 +58,7 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	if err := authenticateClient(backend, startup, upstream); err != nil {
+	if err := authenticateClient(backend, startup, listener); err != nil {
 		logger.Info("postgres: client auth failed",
 			slog.String("error", err.Error()),
 			slog.String("remote", clientConn.RemoteAddr().String()),

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -68,7 +68,14 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 
 	upstreamConn, err := dialUpstream(ctx, upstream)
 	if err != nil {
-		writeFatal(backend, "08006", "upstream connection failed")
+		var mismatch *databaseMismatchError
+		if errors.As(err, &mismatch) {
+			// Configuration error, but surface it clearly to the client rather
+			// than as a generic connection failure.
+			writeFatal(backend, "3D000", mismatch.Error())
+		} else {
+			writeFatal(backend, "08006", "upstream connection failed")
+		}
 		logger.Error("postgres: upstream connect failed", slog.String("error", err.Error()))
 		return
 	}
@@ -138,8 +145,26 @@ func receiveStartup(rawConn net.Conn, backend *pgproto3.Backend) (*pgproto3.Star
 	return nil, errors.New("startup message preceded by too many SSL/GSS requests")
 }
 
+// databaseMismatchError reports that an upstream's routing database does not
+// match the database its DSN connects to. The two must always be equal: the
+// routing database is the name the client connected with, so if the upstream
+// session lands on a different database the client's view (current_database(),
+// search_path resolution, etc.) silently diverges from what it asked for.
+type databaseMismatchError struct {
+	configured string // the upstream's routing database (what the client requested)
+	dsn        string // the database the DSN actually connects to
+}
+
+func (e *databaseMismatchError) Error() string {
+	return fmt.Sprintf("upstream database mismatch: client connected to database %q but its DSN connects to %q; the route database and DSN database must match",
+		e.configured, e.dsn)
+}
+
 // dialUpstream opens an authenticated PgConn to the upstream database using
-// the DSN resolved from the upstream's configured secret source.
+// the DSN resolved from the upstream's configured secret source. It refuses to
+// connect when the DSN's database does not match the upstream's routing
+// database, since that would land the client on a different database than the
+// one it named.
 func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, error) {
 	dsn, err := upstream.DSN(ctx)
 	if err != nil {
@@ -148,6 +173,9 @@ func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, erro
 	cfg, err := pgconn.ParseConfig(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream DSN: %w", err)
+	}
+	if cfg.Database != upstream.Database() {
+		return nil, &databaseMismatchError{configured: upstream.Database(), dsn: cfg.Database}
 	}
 	conn, err := pgconn.ConnectConfig(ctx, cfg)
 	if err != nil {

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -36,12 +36,16 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	// Select the route by the requested database. Postgres clients omit the
-	// database parameter when it equals the user, so fall back to the user name
-	// to match libpq's defaulting.
+	// Select the route by the requested database. The client must name a
+	// database explicitly; the proxy does not infer one from the user.
 	dbName := startup.Parameters["database"]
 	if dbName == "" {
-		dbName = startup.Parameters["user"]
+		writeFatal(backend, "3D000", "no database specified in startup message")
+		logger.Info("postgres: no database specified",
+			slog.String("listener", listener.Name()),
+			slog.String("remote", clientConn.RemoteAddr().String()),
+		)
+		return
 	}
 	route := listener.Route(dbName)
 	if route == nil {

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -15,10 +15,11 @@ import (
 )
 
 // runSession owns a single client connection from accept through close. It
-// performs the proxy-side handshake under a deadline, opens an upstream
-// connection through pgconn, issues SET ROLE on the upstream session,
-// hijacks the connection, then runs the bidirectional relay loop.
-func runSession(ctx context.Context, clientConn net.Conn, policy *Policy, logger *slog.Logger) {
+// performs the proxy-side handshake under a deadline, selects a route from the
+// startup database name, opens an upstream connection through pgconn, issues
+// SET ROLE on the upstream session, hijacks the connection, then runs the
+// bidirectional relay loop.
+func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, logger *slog.Logger) {
 	defer clientConn.Close()
 
 	_ = clientConn.SetDeadline(time.Now().Add(handshakeTimeout))
@@ -35,7 +36,25 @@ func runSession(ctx context.Context, clientConn net.Conn, policy *Policy, logger
 		return
 	}
 
-	if err := authenticateClient(backend, startup, policy); err != nil {
+	// Select the route by the requested database. Postgres clients omit the
+	// database parameter when it equals the user, so fall back to the user name
+	// to match libpq's defaulting.
+	dbName := startup.Parameters["database"]
+	if dbName == "" {
+		dbName = startup.Parameters["user"]
+	}
+	route := listener.Route(dbName)
+	if route == nil {
+		writeFatal(backend, "3D000", fmt.Sprintf("no route for database %q", dbName))
+		logger.Info("postgres: no route for database",
+			slog.String("database", dbName),
+			slog.String("listener", listener.Name()),
+			slog.String("remote", clientConn.RemoteAddr().String()),
+		)
+		return
+	}
+
+	if err := authenticateClient(backend, startup, route); err != nil {
 		logger.Info("postgres: client auth failed",
 			slog.String("error", err.Error()),
 			slog.String("remote", clientConn.RemoteAddr().String()),
@@ -43,15 +62,15 @@ func runSession(ctx context.Context, clientConn net.Conn, policy *Policy, logger
 		return
 	}
 
-	upstream, err := dialUpstream(ctx, policy)
+	upstream, err := dialUpstream(ctx, route)
 	if err != nil {
 		writeFatal(backend, "08006", "upstream connection failed")
 		logger.Error("postgres: upstream connect failed", slog.String("error", err.Error()))
 		return
 	}
 
-	if policy.Role() != "" {
-		if err := setUpstreamRole(ctx, upstream, policy); err != nil {
+	if route.Role() != "" {
+		if err := setUpstreamRole(ctx, upstream, route); err != nil {
 			writeFatal(backend, "08006", err.Error())
 			logger.Error("postgres: set role failed",
 				slog.String("error", err.Error()),
@@ -79,7 +98,7 @@ func runSession(ctx context.Context, clientConn net.Conn, policy *Policy, logger
 	// truncated by it. The relay loop drives I/O end-to-end from here.
 	_ = clientConn.SetDeadline(time.Time{})
 
-	relay := newRelay(clientConn, hijacked.Conn, backend, hijacked.Frontend, policy, logger)
+	relay := newRelay(clientConn, hijacked.Conn, backend, hijacked.Frontend, route, logger)
 	relay.run()
 }
 
@@ -116,9 +135,9 @@ func receiveStartup(rawConn net.Conn, backend *pgproto3.Backend) (*pgproto3.Star
 }
 
 // dialUpstream opens an authenticated PgConn to the upstream database using
-// the DSN resolved from the policy's configured secret source.
-func dialUpstream(ctx context.Context, policy *Policy) (*pgconn.PgConn, error) {
-	dsn, err := policy.UpstreamDSN(ctx)
+// the DSN resolved from the route's configured secret source.
+func dialUpstream(ctx context.Context, route *Route) (*pgconn.PgConn, error) {
+	dsn, err := route.UpstreamDSN(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loading upstream DSN: %w", err)
 	}
@@ -140,10 +159,10 @@ func dialUpstream(ctx context.Context, policy *Policy) (*pgconn.PgConn, error) {
 // Transaction or statement pool modes silently swap backends between queries
 // and would defeat the policy; that constraint is enforced by deployment
 // configuration rather than by a runtime probe.
-func setUpstreamRole(ctx context.Context, conn *pgconn.PgConn, policy *Policy) error {
-	setSQL := "SET ROLE " + QuoteIdent(policy.Role())
+func setUpstreamRole(ctx context.Context, conn *pgconn.PgConn, route *Route) error {
+	setSQL := "SET ROLE " + QuoteIdent(route.Role())
 	if _, err := conn.Exec(ctx, setSQL).ReadAll(); err != nil {
-		return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(policy.Role()), err)
+		return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(route.Role()), err)
 	}
 	return nil
 }
@@ -187,7 +206,7 @@ type relay struct {
 	backend  *pgproto3.Backend
 	frontend *pgproto3.Frontend
 
-	policy *Policy
+	route  *Route
 	logger *slog.Logger
 
 	clientWriteMu sync.Mutex
@@ -202,13 +221,13 @@ type relay struct {
 	skipExtended bool
 }
 
-func newRelay(clientConn, upstreamConn net.Conn, backend *pgproto3.Backend, frontend *pgproto3.Frontend, policy *Policy, logger *slog.Logger) *relay {
+func newRelay(clientConn, upstreamConn net.Conn, backend *pgproto3.Backend, frontend *pgproto3.Frontend, route *Route, logger *slog.Logger) *relay {
 	return &relay{
 		clientConn:   clientConn,
 		upstreamConn: upstreamConn,
 		backend:      backend,
 		frontend:     frontend,
-		policy:       policy,
+		route:        route,
 		logger:       logger,
 	}
 }

--- a/internal/postgres/session_test.go
+++ b/internal/postgres/session_test.go
@@ -26,6 +26,20 @@ func TestDialUpstreamDatabaseMismatch(t *testing.T) {
 	require.Equal(t, "otherdb", mismatch.dsn)
 }
 
+// TestDialUpstreamMissingDatabase verifies dialUpstream refuses a DSN that does
+// not name a database. Caught before any network round-trip.
+func TestDialUpstreamMissingDatabase(t *testing.T) {
+	up, err := NewManagedUpstream("appdb",
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 user=app"}, "u", "p", "")
+	require.NoError(t, err)
+
+	_, err = dialUpstream(context.Background(), up)
+	require.Error(t, err)
+	var missing *missingDSNDatabaseError
+	require.True(t, errors.As(err, &missing), "want missingDSNDatabaseError, got %v", err)
+	require.Equal(t, "appdb", missing.configured)
+}
+
 // TestDialUpstreamDatabaseMatchPassesCheck verifies that a DSN whose database
 // matches the routing database clears the check. The dial still fails (nothing
 // is listening on port 1), but the failure must not be a databaseMismatchError.

--- a/internal/postgres/session_test.go
+++ b/internal/postgres/session_test.go
@@ -15,7 +15,7 @@ import (
 // server.
 func TestDialUpstreamDatabaseMismatch(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=otherdb"}, "u", "p", "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=otherdb"}, "")
 	require.NoError(t, err)
 
 	_, err = dialUpstream(context.Background(), up)
@@ -30,7 +30,7 @@ func TestDialUpstreamDatabaseMismatch(t *testing.T) {
 // not name a database. Caught before any network round-trip.
 func TestDialUpstreamMissingDatabase(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 user=app"}, "u", "p", "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 user=app"}, "")
 	require.NoError(t, err)
 
 	_, err = dialUpstream(context.Background(), up)
@@ -45,7 +45,7 @@ func TestDialUpstreamMissingDatabase(t *testing.T) {
 // is listening on port 1), but the failure must not be a databaseMismatchError.
 func TestDialUpstreamDatabaseMatchPassesCheck(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=appdb"}, "u", "p", "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=appdb"}, "")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/postgres/session_test.go
+++ b/internal/postgres/session_test.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDialUpstreamDatabaseMismatch verifies dialUpstream refuses a DSN whose
+// database differs from the upstream's routing database. The mismatch is caught
+// after parsing the DSN but before any network round-trip, so this needs no
+// server.
+func TestDialUpstreamDatabaseMismatch(t *testing.T) {
+	up, err := NewManagedUpstream("appdb",
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=otherdb"}, "u", "p", "")
+	require.NoError(t, err)
+
+	_, err = dialUpstream(context.Background(), up)
+	require.Error(t, err)
+	var mismatch *databaseMismatchError
+	require.True(t, errors.As(err, &mismatch), "want databaseMismatchError, got %v", err)
+	require.Equal(t, "appdb", mismatch.configured)
+	require.Equal(t, "otherdb", mismatch.dsn)
+}
+
+// TestDialUpstreamDatabaseMatchPassesCheck verifies that a DSN whose database
+// matches the routing database clears the check. The dial still fails (nothing
+// is listening on port 1), but the failure must not be a databaseMismatchError.
+func TestDialUpstreamDatabaseMatchPassesCheck(t *testing.T) {
+	up, err := NewManagedUpstream("appdb",
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=appdb"}, "u", "p", "")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = dialUpstream(ctx, up)
+	require.Error(t, err)
+	var mismatch *databaseMismatchError
+	require.False(t, errors.As(err, &mismatch), "database matched; should not be a mismatch error: %v", err)
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -662,6 +662,12 @@ transforms:
 # rejects the connection.
 # postgres:
 #   listen: ":5432"
+#   # The single credential clients present to the proxy, shared across every
+#   # upstream below. Routing is by database, so per-database credentials add
+#   # nothing.
+#   client:
+#     user: app_user
+#     password_env: PG_PROXY_PASSWORD
 #   upstreams:
 #     # Clients connect with dbname=appdb to reach this upstream.
 #     - database: appdb
@@ -670,10 +676,6 @@ transforms:
 #       dsn:
 #         type: env
 #         var: PG_APPDB_DSN
-#       client:
-#         # The user/password clients must present for this upstream.
-#         user: app_user
-#         password_env: PG_APPDB_PROXY_PASSWORD
 #       # The Postgres role the proxy SETs at session start. Every query the
 #       # client issues runs as this role on the upstream database.
 #       role: tenant_role
@@ -682,9 +684,6 @@ transforms:
 #       dsn:
 #         type: env
 #         var: PG_ANALYTICS_DSN
-#       client:
-#         user: analytics_user
-#         password_env: PG_ANALYTICS_PROXY_PASSWORD
 #       role: analytics_role
 
 # Optional management API. When `listen` is empty (default), the management

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -651,26 +651,25 @@ transforms:
 # (no per-user).
 #
 # The proxy runs a single postgres listener: the postgres key is one object
-# with a bind address and a list of routes. A single listen address serves many
-# upstream databases. The client selects a route by the database name it sends
-# in its startup message (psql's `dbname=`), and the proxy authenticates that
-# connection against the route's own credentials before dialing the route's
-# upstream. The client must name a database explicitly; a database with no
-# matching route is rejected. The database name is only a routing key: the
-# upstream database is whatever the route's DSN names.
+# with a bind address and a list of upstreams. A single listen address serves
+# many upstream databases. The client selects an upstream by the database name
+# it sends in its startup message (psql's `dbname=`), and the proxy
+# authenticates that connection against the upstream's own credentials before
+# dialing it. The client must name a database explicitly; a database with no
+# matching upstream is rejected. The database name is only a routing key: the
+# upstream database is whatever the upstream's DSN names.
 # postgres:
 #   listen: ":5432"
-#   routes:
+#   upstreams:
 #     # Clients connect with dbname=appdb to reach this upstream.
 #     - database: appdb
-#       upstream:
-#         # The DSN is loaded from any registered secret source and passed
-#         # verbatim to pgconn. URL or keyword/value form both work.
-#         dsn:
-#           type: env
-#           var: PG_APPDB_DSN
+#       # The DSN is loaded from any registered secret source and passed
+#       # verbatim to pgconn. URL or keyword/value form both work.
+#       dsn:
+#         type: env
+#         var: PG_APPDB_DSN
 #       client:
-#         # The user/password clients must present for this route.
+#         # The user/password clients must present for this upstream.
 #         user: app_user
 #         password_env: PG_APPDB_PROXY_PASSWORD
 #       # The Postgres role the proxy SETs at session start. Every query the
@@ -678,10 +677,9 @@ transforms:
 #       role: tenant_role
 #     # Clients connect with dbname=analyticsdb to reach this upstream.
 #     - database: analyticsdb
-#       upstream:
-#         dsn:
-#           type: env
-#           var: PG_ANALYTICS_DSN
+#       dsn:
+#         type: env
+#         var: PG_ANALYTICS_DSN
 #       client:
 #         user: analytics_user
 #         password_env: PG_ANALYTICS_PROXY_PASSWORD

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -650,44 +650,42 @@ transforms:
 # CancelRequest is not forwarded; one shared client credential per route
 # (no per-user).
 #
-# The postgres key is a list of listeners, and each listener fronts a list of
-# routes. A single listen address can serve many upstream databases: the
-# client selects a route by the database name it sends in its startup message
-# (psql's `dbname=`), and the proxy authenticates that connection against the
-# route's own credentials before dialing the route's upstream. A client that
-# requests a database with no matching route is rejected. The database name is
-# only a routing key — the upstream database is whatever the route's DSN names.
-# The top-level list still permits more than one listener (e.g. a separate
-# bind address per network segment); listener names must be unique.
+# The proxy runs a single postgres listener: the postgres key is one object
+# with a bind address and a list of routes. A single listen address serves many
+# upstream databases. The client selects a route by the database name it sends
+# in its startup message (psql's `dbname=`), and the proxy authenticates that
+# connection against the route's own credentials before dialing the route's
+# upstream. The client must name a database explicitly; a database with no
+# matching route is rejected. The database name is only a routing key: the
+# upstream database is whatever the route's DSN names.
 # postgres:
-#   - name: main
-#     listen: ":5432"
-#     routes:
-#       # Clients connect with dbname=appdb to reach this upstream.
-#       - database: appdb
-#         upstream:
-#           # The DSN is loaded from any registered secret source and passed
-#           # verbatim to pgconn. URL or keyword/value form both work.
-#           dsn:
-#             type: env
-#             var: PG_APPDB_DSN
-#         client:
-#           # The user/password clients must present for this route.
-#           user: app_user
-#           password_env: PG_APPDB_PROXY_PASSWORD
-#         # The Postgres role the proxy SETs at session start. Every query the
-#         # client issues runs as this role on the upstream database.
-#         role: tenant_role
-#       # Clients connect with dbname=analyticsdb to reach this upstream.
-#       - database: analyticsdb
-#         upstream:
-#           dsn:
-#             type: env
-#             var: PG_ANALYTICS_DSN
-#         client:
-#           user: analytics_user
-#           password_env: PG_ANALYTICS_PROXY_PASSWORD
-#         role: analytics_role
+#   listen: ":5432"
+#   routes:
+#     # Clients connect with dbname=appdb to reach this upstream.
+#     - database: appdb
+#       upstream:
+#         # The DSN is loaded from any registered secret source and passed
+#         # verbatim to pgconn. URL or keyword/value form both work.
+#         dsn:
+#           type: env
+#           var: PG_APPDB_DSN
+#       client:
+#         # The user/password clients must present for this route.
+#         user: app_user
+#         password_env: PG_APPDB_PROXY_PASSWORD
+#       # The Postgres role the proxy SETs at session start. Every query the
+#       # client issues runs as this role on the upstream database.
+#       role: tenant_role
+#     # Clients connect with dbname=analyticsdb to reach this upstream.
+#     - database: analyticsdb
+#       upstream:
+#         dsn:
+#           type: env
+#           var: PG_ANALYTICS_DSN
+#       client:
+#         user: analytics_user
+#         password_env: PG_ANALYTICS_PROXY_PASSWORD
+#       role: analytics_role
 
 # Optional management API. When `listen` is empty (default), the management
 # server is disabled. When set, the proxy serves an authenticated

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -647,42 +647,47 @@ transforms:
 #  - Functions that wrap set_config under a different name.
 #
 # Limitations: client→proxy TLS is not supported (SSLRequest is refused);
-# CancelRequest is not forwarded; one shared client credential (no per-user).
+# CancelRequest is not forwarded; one shared client credential per route
+# (no per-user).
 #
-# The postgres key is a list, so one proxy process can front multiple
-# databases — each entry is an independent server with its own listen
-# address, upstream, credentials, and injected role. Server names must be
-# unique and are surfaced in logs to disambiguate.
+# The postgres key is a list of listeners, and each listener fronts a list of
+# routes. A single listen address can serve many upstream databases: the
+# client selects a route by the database name it sends in its startup message
+# (psql's `dbname=`), and the proxy authenticates that connection against the
+# route's own credentials before dialing the route's upstream. A client that
+# requests a database with no matching route is rejected. The database name is
+# only a routing key — the upstream database is whatever the route's DSN names.
+# The top-level list still permits more than one listener (e.g. a separate
+# bind address per network segment); listener names must be unique.
 # postgres:
-#   - name: primary
+#   - name: main
 #     listen: ":5432"
-#     upstream:
-#       host: "db.internal"
-#       port: 5432
-#       sslmode: "require"     # disable | require
-#       user_env: "PG_UPSTREAM_USER"
-#       password_env: "PG_UPSTREAM_PASSWORD"
-#       database: "appdb"
-#     client:
-#       # The single user clients must authenticate as when reaching the proxy.
-#       user: "app_user"
-#       password_env: "PG_PROXY_PASSWORD"
-#     # The Postgres role the proxy SETs at session start. Every query the
-#     # client issues runs as this role on the upstream database.
-#     role: "tenant_role"
-#   - name: analytics
-#     listen: ":5433"
-#     upstream:
-#       host: "analytics.internal"
-#       port: 5432
-#       sslmode: "require"
-#       user_env: "PG_ANALYTICS_USER"
-#       password_env: "PG_ANALYTICS_PASSWORD"
-#       database: "analyticsdb"
-#     client:
-#       user: "analytics_user"
-#       password_env: "PG_ANALYTICS_PROXY_PASSWORD"
-#     role: "analytics_role"
+#     routes:
+#       # Clients connect with dbname=appdb to reach this upstream.
+#       - database: appdb
+#         upstream:
+#           # The DSN is loaded from any registered secret source and passed
+#           # verbatim to pgconn. URL or keyword/value form both work.
+#           dsn:
+#             type: env
+#             var: PG_APPDB_DSN
+#         client:
+#           # The user/password clients must present for this route.
+#           user: app_user
+#           password_env: PG_APPDB_PROXY_PASSWORD
+#         # The Postgres role the proxy SETs at session start. Every query the
+#         # client issues runs as this role on the upstream database.
+#         role: tenant_role
+#       # Clients connect with dbname=analyticsdb to reach this upstream.
+#       - database: analyticsdb
+#         upstream:
+#           dsn:
+#             type: env
+#             var: PG_ANALYTICS_DSN
+#         client:
+#           user: analytics_user
+#           password_env: PG_ANALYTICS_PROXY_PASSWORD
+#         role: analytics_role
 
 # Optional management API. When `listen` is empty (default), the management
 # server is disabled. When set, the proxy serves an authenticated

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -656,8 +656,10 @@ transforms:
 # it sends in its startup message (psql's `dbname=`), and the proxy
 # authenticates that connection against the upstream's own credentials before
 # dialing it. The client must name a database explicitly; a database with no
-# matching upstream is rejected. The database name is only a routing key: the
-# upstream database is whatever the upstream's DSN names.
+# matching upstream is rejected. Each upstream's `database` must equal the
+# database its DSN connects to (the dbname in the DSN) — otherwise the client
+# would land on a different database than the one it named, and the proxy
+# rejects the connection.
 # postgres:
 #   listen: ":5432"
 #   upstreams:


### PR DESCRIPTION
Reworks the Postgres proxy from one-listener-per-upstream to a single listener that fronts many database-routed upstreams. The top-level `postgres:` block is one object with a `listen` address, one shared `client` credential, and a list of `upstreams` (each a required `database`, a first-class `dsn`, and an optional injected `role`):

```yaml
postgres:
  listen: ":5432"
  client:
    user: app_user
    password_env: PG_PROXY_PASSWORD
  upstreams:
    - database: appdb
      dsn: {type: env, var: PG_APPDB_DSN}
      role: tenant_role
    - database: analyticsdb
      dsn: {type: env, var: PG_ANALYTICS_DSN}
      role: analytics_role
```

The client selects an upstream by the database name it sends in its startup message and authenticates with the listener's single shared credential. Routing is by `database` alone, so credentials are not per-database. The client must name a database explicitly (no fallback to the user name); an unspecified or unmatched database is rejected with a FATAL `3D000`.

Each upstream's `database` must equal the database its DSN connects to. The proxy validates this when dialing: it rejects a DSN that names no database, and rejects a database/DSN mismatch, both with `3D000`. So a client connecting with `dbname=X` always lands on database `X` upstream.

In managed mode the control-plane-synced upstreams are layered onto the single listener. Each sync entry carries `{foreign_id, database, dsn, role?}` (no client credentials). The listener knobs (bind address and shared client credential) come from the local YAML block when present, otherwise from `IRON_PROXY_PG_LISTEN` / `IRON_PROXY_PG_CLIENT_USER` / `IRON_PROXY_PG_CLIENT_PASSWORD`. A synced upstream whose database collides with a local one (or another synced one) is dropped.

This is a breaking config change; the example config and integration testdata are updated. Verified end-to-end against real Postgres (`-integration`): routing to distinct databases with per-upstream role enforcement and RLS scoping, database/DSN mismatch rejection, and unknown-database rejection all pass.