### PR TITLE
feat(secrets): add file source re-read on reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,9 +405,9 @@ transforms:
 
 The sandbox never holds real credentials. Instead:
 
-1. Configure iron-proxy with the real secret source: environment variables,
-   AWS Secrets Manager, AWS Systems Manager Parameter Store, 1Password (service
-   account), or 1Password Connect.
+1. Configure iron-proxy with the real secret source: environment variables, a
+   file on disk, AWS Secrets Manager, AWS Systems Manager Parameter Store,
+   1Password (service account), or 1Password Connect.
 2. Give the sandbox a proxy token (e.g., `proxy-openai-abc123`).
 3. Configure the `secrets` transform to map proxy tokens to those sources.
 
@@ -436,7 +436,14 @@ Query parameters are always scanned.
 
 Secret sources:
 
-- **`env`:** reads `var` from the proxy process environment.
+- **`env`:** reads `var` from the proxy process environment. Fixed at process
+  start — use `file` instead if you need to rotate the value on a running proxy.
+- **`file`:** reads the secret from `path` on disk. The file is re-read on every
+  config reload (boot and each `POST /v1/reload`) and, when `ttl` is set, on
+  cache expiry — so you can rotate a running proxy's secret by rewriting the
+  file (atomically: write-temp + rename) and reloading, without a restart. The
+  value is the exact file contents (no trimming), so the writer controls
+  trailing whitespace. Optional `ttl` and `failure_ttl` are supported.
 - **`aws_sm`:** reads `secret_id` from AWS Secrets Manager. Optional `region`,
   `ttl`, and `failure_ttl` are supported.
 - **`aws_ssm`:** reads `name` from AWS Systems Manager Parameter Store. Optional

--- a/internal/transform/secrets/resolver.go
+++ b/internal/transform/secrets/resolver.go
@@ -118,6 +118,54 @@ func (r *envBuilder) Build(raw yaml.Node) (secretSource, error) {
 	})
 }
 
+// --- file builder ---
+
+// fileBuilder reads secrets from a file on disk. The file is re-read on every
+// pipeline build (boot and each /v1/reload) and, when ttl is set, on cache
+// expiry — so an integrator can rotate a running proxy's secret value by
+// rewriting the file (atomically: write-temp + rename) and triggering a
+// reload, without restarting the process. Unlike env (fixed at exec), a file
+// is mutable for the process lifetime.
+type fileBuilder struct {
+	readFile func(string) ([]byte, error)
+	logger   *slog.Logger
+}
+
+type fileConfig struct {
+	Type       string `yaml:"type"`
+	Path       string `yaml:"path"`
+	TTL        string `yaml:"ttl,omitempty"`
+	FailureTTL string `yaml:"failure_ttl,omitempty"`
+}
+
+func newFileBuilder(logger *slog.Logger) *fileBuilder {
+	return &fileBuilder{readFile: os.ReadFile, logger: logger}
+}
+
+func (r *fileBuilder) Build(raw yaml.Node) (secretSource, error) {
+	var cfg fileConfig
+	if err := raw.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parsing file source config: %w", err)
+	}
+	if cfg.Path == "" {
+		return nil, fmt.Errorf("file source requires \"path\" field")
+	}
+	return buildLazySource(cfg.Path, cfg.TTL, cfg.FailureTTL, r.logger, func(context.Context) (string, error) {
+		// The value is the exact file contents — no trimming. The writer
+		// controls trailing whitespace, matching how Kubernetes and Docker
+		// expose file-mounted secrets. Read each call so a ttl refresh sees
+		// the current contents.
+		b, err := r.readFile(cfg.Path)
+		if err != nil {
+			return "", fmt.Errorf("reading secret file %q: %w", cfg.Path, err)
+		}
+		if len(b) == 0 {
+			return "", fmt.Errorf("secret file %q is empty", cfg.Path)
+		}
+		return string(b), nil
+	})
+}
+
 // --- shared AWS client cache ---
 
 // awsClientCache provides region-keyed caching for any AWS service client.

--- a/internal/transform/secrets/resolver_test.go
+++ b/internal/transform/secrets/resolver_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -93,6 +95,123 @@ func TestEnvBuilder_HappyPath(t *testing.T) {
 	val, err := result.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "real-value", val)
+}
+
+// --- fileBuilder tests ---
+
+func TestFileBuilder_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	require.NoError(t, os.WriteFile(path, []byte("real-file-value"), 0o400))
+
+	r := newFileBuilder(slog.Default())
+	node := yamlNode(t, map[string]string{"type": "file", "path": path})
+	result, err := r.Build(node)
+	require.NoError(t, err)
+	require.Equal(t, path, result.Name())
+
+	val, err := result.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "real-file-value", val)
+}
+
+func TestFileBuilder_PreservesExactBytes(t *testing.T) {
+	// The value is the exact file contents — no trimming — so the writer
+	// controls trailing whitespace (matching k8s/docker file-mounted secrets).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	require.NoError(t, os.WriteFile(path, []byte("token-with-newline\n"), 0o400))
+
+	r := newFileBuilder(slog.Default())
+	node := yamlNode(t, map[string]string{"type": "file", "path": path})
+	result, err := r.Build(node)
+	require.NoError(t, err)
+
+	val, err := result.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "token-with-newline\n", val)
+}
+
+func TestFileBuilder_TTLRefreshSeesNewContents(t *testing.T) {
+	// With a ttl set, a rotated file is picked up on cache expiry without a
+	// pipeline rebuild. Rotation mirrors the integrator's atomic write-temp +
+	// rename onto a read-only (0o400) secret file.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	writeAtomic := func(value string) {
+		tmp := filepath.Join(dir, "secret.tmp")
+		require.NoError(t, os.WriteFile(tmp, []byte(value), 0o400))
+		require.NoError(t, os.Rename(tmp, path))
+	}
+	writeAtomic("v1")
+
+	r := newFileBuilder(slog.Default())
+	node := yamlNode(t, map[string]string{"type": "file", "path": path, "ttl": "10ms"})
+	result, err := r.Build(node)
+	require.NoError(t, err)
+
+	val, err := result.Get(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "v1", val)
+
+	writeAtomic("v2")
+	require.Eventually(t, func() bool {
+		v, err := result.Get(context.Background())
+		return err == nil && v == "v2"
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestFileBuilder_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]string
+		errMsg string
+		errAt  string
+	}{
+		{
+			name:   "missing path field",
+			input:  map[string]string{"type": "file"},
+			errMsg: "\"path\" field",
+			errAt:  "build",
+		},
+		{
+			name:   "nonexistent file",
+			input:  map[string]string{"type": "file", "path": "/nonexistent/secret/path"},
+			errMsg: "reading secret file",
+			errAt:  "fetch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFileBuilder(slog.Default())
+			node := yamlNode(t, tt.input)
+			result, err := r.Build(node)
+			if tt.errAt == "build" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			_, err = result.Get(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestFileBuilder_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0o400))
+
+	r := newFileBuilder(slog.Default())
+	node := yamlNode(t, map[string]string{"type": "file", "path": path})
+	result, err := r.Build(node)
+	require.NoError(t, err)
+
+	_, err = result.Get(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is empty")
 }
 
 func TestEnvBuilder_Errors(t *testing.T) {

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -144,6 +144,7 @@ func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) 
 func defaultRegistry(logger *slog.Logger) sourceBuilderRegistry {
 	return sourceBuilderRegistry{
 		"env":               newEnvBuilder(logger),
+		"file":              newFileBuilder(logger),
 		"control_plane":     newControlPlaneBuilder(logger),
 		"aws_sm":            newAWSSMBuilder(logger),
 		"aws_ssm":           newAWSSSMBuilder(logger),


### PR DESCRIPTION
## What

Adds a `file` secret source that reads the secret from a path on disk:

```yaml
- name: secrets
  config:
    secrets:
      - source:
          type: file
          path: /etc/iron-proxy/secrets/OPENAI_API_KEY
        proxy_value: "proxy-token-123"
        match_headers: ["Authorization"]
        rules:
          - host: "api.openai.com"
```

The file is re-resolved on every pipeline build — boot and each `POST /v1/reload` — and, when `ttl` is set, on cache expiry. Optional `ttl` / `failure_ttl` and the shared `json_key` extraction apply exactly as for the existing sources.

## Why

`env` is fixed at process exec, so a pre-warmed/long-lived proxy can never observe a secret value minted after it started. The cloud sources (`aws_sm`, `aws_ssm`, `1password*`) solve rotation but require that managed infrastructure in the egress path. A file source closes the gap with the smallest surface — no new endpoint, no watcher; the existing reload just re-reads the file like it re-reads the config.

Our use case (per [chat with Matt]): one iron-proxy per sandbox, pre-warmed ahead of a customer claim. At claim we rewrite config + `POST /v1/reload` (works great, thanks for the pointer) — but the per-session budget-scoped key isn't known at boot. We're on bare metal, so the cloud sources aren't in play. The integrator writes the file atomically (write-temp + rename, e.g. on a tmpfs mount, `0400`) and reloads; the proxy re-reads it. We understand the 0.42 control-plane is the intended longer-term home for dynamic principals/secrets — happy to align there too; this is the minimal v0.41-compatible bridge.

## Behavior notes

- **Exact bytes, no trimming** — the value is the literal file contents, matching how Kubernetes and Docker expose file-mounted secrets. The writer controls trailing whitespace.
- **Empty file** is an error (parity with `env`'s empty-value error).
- **Build does no I/O** — only static validation (`path` required), consistent with the lazy-resolve contract; the read happens on first `Get`.
- A missing/unreadable file surfaces a clear `reading secret file %q` error through the existing failure-cache path.

## Tests

`go test ./internal/transform/secrets/` — 187 pass. New unit tests cover happy path, exact-bytes preservation, ttl refresh picking up an atomically-rotated file, missing `path` / nonexistent file / empty file errors. `gofmt` clean, `go vet` clean. No integration test added — the source needs no external backend, matching `env`'s unit-only coverage.