### PR TITLE
feat(proxy): route outbound through upstream SOCKS5/HTTP CONNECT proxy

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -219,6 +219,7 @@ func main() {
 		MCPPolicy:                     mcpHolder,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
+		UpstreamProxy:                 cfg.Proxy.UpstreamProxy.ProxyFunc(),
 	})
 
 	// Initialize metrics server.

--- a/cmd/iron-token-broker/main.go
+++ b/cmd/iron-token-broker/main.go
@@ -76,6 +76,7 @@ func main() {
 		Credentials: credentials,
 		Logger:      logger,
 		BearerToken: bearerToken,
+		ProxyFunc:   cfg.UpstreamProxy.ProxyFunc(),
 	})
 	if err != nil {
 		logger.Error("initializing broker", slog.String("error", err.Error()))
@@ -143,4 +144,3 @@ func newLogger(cfg *config.Config) (*slog.Logger, error) {
 	}
 	return slog.New(handler), nil
 }
-

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.81.1
@@ -121,7 +122,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -40,8 +41,12 @@ type Options struct {
 	Config      *config.Config
 	Credentials []config.BuiltCredential
 	Logger      *slog.Logger
-	BearerToken string // captured value of cfg.BearerAuthEnv; empty disables auth
+	BearerToken string       // captured value of cfg.BearerAuthEnv; empty disables auth
 	HTTPClient  *http.Client // shared across credentials; nil = default
+	// ProxyFunc routes credential-refresh requests through an upstream
+	// SOCKS5/HTTP CONNECT proxy (see http.Transport.Proxy). nil falls back to
+	// http.ProxyFromEnvironment so the standard env vars are still honored.
+	ProxyFunc func(*http.Request) (*url.URL, error)
 }
 
 // New wires a Broker but does not start any goroutines or open any
@@ -54,7 +59,7 @@ func New(opts Options) (*Broker, error) {
 	met := newMetrics()
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
-		httpClient = newSharedHTTPClient(time.Duration(opts.Config.Defaults.RefreshTimeout))
+		httpClient = newSharedHTTPClient(time.Duration(opts.Config.Defaults.RefreshTimeout), opts.ProxyFunc)
 	}
 
 	creds := make(map[string]*credentialState, len(opts.Credentials))
@@ -139,7 +144,10 @@ func (b *Broker) Shutdown(ctx context.Context) error {
 // refresh loop. A single client lets every refresh share the TLS session
 // cache and connection pool against the IdP, which matters for IdPs that
 // throttle TLS handshakes.
-func newSharedHTTPClient(refreshTimeout time.Duration) *http.Client {
+func newSharedHTTPClient(refreshTimeout time.Duration, proxyFunc func(*http.Request) (*url.URL, error)) *http.Client {
+	if proxyFunc == nil {
+		proxyFunc = http.ProxyFromEnvironment
+	}
 	transport := &http.Transport{
 		MaxIdleConns:          50,
 		MaxIdleConnsPerHost:   10,
@@ -147,10 +155,9 @@ func newSharedHTTPClient(refreshTimeout time.Duration) *http.Client {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ResponseHeaderTimeout: 30 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		// Don't follow redirects automatically — the token endpoint
-		// is a single canonical URL, and a redirect there is a sign
-		// of misconfiguration.
-		Proxy: http.ProxyFromEnvironment,
+		// Route through an upstream proxy when one is configured/exported;
+		// otherwise connect directly.
+		Proxy: proxyFunc,
 	}
 	if refreshTimeout > 0 && refreshTimeout < 30*time.Second {
 		transport.ResponseHeaderTimeout = refreshTimeout

--- a/internal/broker/config/config.go
+++ b/internal/broker/config/config.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/broker/store"
+	proxyconfig "github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -55,6 +56,10 @@ type Config struct {
 	Log           Log          `yaml:"log"`
 	Defaults      Defaults     `yaml:"defaults"`
 	Credentials   []Credential `yaml:"credentials"`
+	// UpstreamProxy routes credential-refresh requests through an upstream
+	// SOCKS5/HTTP CONNECT proxy. The standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+	// environment variables override these fields when set.
+	UpstreamProxy proxyconfig.UpstreamProxy `yaml:"upstream_proxy"`
 }
 
 // Log configures structured logging.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,10 @@ type Proxy struct {
 	// at connect time against the resolved address. When unset, a secure
 	// default (IMDS + loopback) is applied; set to an empty list to disable.
 	UpstreamDenyCIDRs CIDRList `yaml:"upstream_deny_cidrs"`
+	// UpstreamProxy routes iron-proxy's own outbound connections through an
+	// upstream SOCKS5/HTTP CONNECT proxy. The standard HTTP_PROXY/HTTPS_PROXY/
+	// NO_PROXY environment variables override these fields when set.
+	UpstreamProxy UpstreamProxy `yaml:"upstream_proxy"`
 }
 
 // CIDRList is a list of CIDR strings whose presence in YAML is distinguishable

--- a/internal/config/upstream_proxy.go
+++ b/internal/config/upstream_proxy.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// UpstreamProxy configures an upstream SOCKS5/HTTP CONNECT proxy that
+// iron-proxy routes its own outbound connections through. This is for
+// deployments (e.g. corporate networks) where all egress must traverse a
+// forward proxy.
+//
+// Each field mirrors a standard proxy environment variable. The matching
+// environment variable, when set, OVERRIDES the configured value — config
+// supplies a default, env has the final word. This keeps iron-proxy
+// well-behaved in environments that already export HTTP_PROXY/HTTPS_PROXY/
+// NO_PROXY without forcing those operators to also edit YAML.
+//
+// Proxy URLs accept http, https, socks5, and socks5h schemes, e.g.
+// "http://proxy.corp:3128" or "socks5://proxy.corp:1080".
+type UpstreamProxy struct {
+	// HTTPProxy is the proxy used for plain-HTTP upstream requests.
+	// Overridden by HTTP_PROXY / http_proxy.
+	HTTPProxy string `yaml:"http_proxy"`
+	// HTTPSProxy is the proxy used for HTTPS upstream requests.
+	// Overridden by HTTPS_PROXY / https_proxy.
+	HTTPSProxy string `yaml:"https_proxy"`
+	// NoProxy is a comma-separated list of hosts/domains/CIDRs that bypass
+	// the proxy. Overridden by NO_PROXY / no_proxy.
+	NoProxy string `yaml:"no_proxy"`
+}
+
+// proxyConfig builds an httpproxy.Config, letting environment variables
+// override the configured fields one-for-one. httpproxy.FromEnvironment reads
+// both the upper- and lower-case forms of each variable.
+func (u UpstreamProxy) proxyConfig() *httpproxy.Config {
+	env := httpproxy.FromEnvironment()
+	cfg := &httpproxy.Config{
+		HTTPProxy:  env.HTTPProxy,
+		HTTPSProxy: env.HTTPSProxy,
+		NoProxy:    env.NoProxy,
+	}
+	if cfg.HTTPProxy == "" {
+		cfg.HTTPProxy = u.HTTPProxy
+	}
+	if cfg.HTTPSProxy == "" {
+		cfg.HTTPSProxy = u.HTTPSProxy
+	}
+	if cfg.NoProxy == "" {
+		cfg.NoProxy = u.NoProxy
+	}
+	return cfg
+}
+
+// ProxyFunc returns a function suitable for http.Transport.Proxy. It resolves
+// the upstream proxy for each request from the merged config+env settings, or
+// returns nil (direct connection) when no proxy applies. The returned function
+// is safe to reuse across requests and goroutines.
+func (u UpstreamProxy) ProxyFunc() func(*http.Request) (*url.URL, error) {
+	pf := u.proxyConfig().ProxyFunc()
+	return func(req *http.Request) (*url.URL, error) {
+		return pf(req.URL)
+	}
+}

--- a/internal/config/upstream_proxy_test.go
+++ b/internal/config/upstream_proxy_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// proxyForURL builds the ProxyFunc and resolves the proxy for rawurl,
+// returning "" when the request should connect directly.
+func proxyForURL(t *testing.T, u UpstreamProxy, rawurl string) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, rawurl, nil)
+	require.NoError(t, err)
+	proxyURL, err := u.ProxyFunc()(req)
+	require.NoError(t, err)
+	if proxyURL == nil {
+		return ""
+	}
+	return proxyURL.String()
+}
+
+// clearProxyEnv removes every standard proxy variable so a test starts from a
+// known-empty environment regardless of the host's settings.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestUpstreamProxy_Direct(t *testing.T) {
+	clearProxyEnv(t)
+	var u UpstreamProxy
+	require.Empty(t, proxyForURL(t, u, "http://example.com"))
+	require.Empty(t, proxyForURL(t, u, "https://example.com"))
+}
+
+func TestUpstreamProxy_ConfigOnly(t *testing.T) {
+	clearProxyEnv(t)
+	u := UpstreamProxy{
+		HTTPProxy:  "http://proxy.corp:3128",
+		HTTPSProxy: "http://proxy.corp:3129",
+	}
+	require.Equal(t, "http://proxy.corp:3128", proxyForURL(t, u, "http://example.com"))
+	require.Equal(t, "http://proxy.corp:3129", proxyForURL(t, u, "https://example.com"))
+}
+
+func TestUpstreamProxy_EnvOverridesConfig(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://env-proxy:8080")
+	u := UpstreamProxy{
+		HTTPProxy:  "http://config-proxy:3128",
+		HTTPSProxy: "http://config-proxy:3129",
+	}
+	// HTTPS_PROXY env wins for https; http falls back to config (no env set).
+	require.Equal(t, "http://env-proxy:8080", proxyForURL(t, u, "https://example.com"))
+	require.Equal(t, "http://config-proxy:3128", proxyForURL(t, u, "http://example.com"))
+}
+
+func TestUpstreamProxy_NoProxyConfig(t *testing.T) {
+	clearProxyEnv(t)
+	u := UpstreamProxy{
+		HTTPSProxy: "http://proxy.corp:3129",
+		NoProxy:    "internal.example.com",
+	}
+	require.Empty(t, proxyForURL(t, u, "https://internal.example.com"))
+	require.Equal(t, "http://proxy.corp:3129", proxyForURL(t, u, "https://external.example.com"))
+}
+
+func TestUpstreamProxy_NoProxyEnvOverridesConfig(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("NO_PROXY", "env.example.com")
+	u := UpstreamProxy{
+		HTTPSProxy: "http://proxy.corp:3129",
+		NoProxy:    "config.example.com",
+	}
+	// Env NO_PROXY replaces the configured list entirely.
+	require.Empty(t, proxyForURL(t, u, "https://env.example.com"))
+	require.Equal(t, "http://proxy.corp:3129", proxyForURL(t, u, "https://config.example.com"))
+}
+
+func TestUpstreamProxy_SOCKS5Scheme(t *testing.T) {
+	clearProxyEnv(t)
+	u := UpstreamProxy{HTTPSProxy: "socks5://proxy.corp:1080"}
+	require.Equal(t, "socks5://proxy.corp:1080", proxyForURL(t, u, "https://example.com"))
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -67,13 +67,17 @@ type Options struct {
 	CertCache  *certcache.Cache // required when TLSMode == config.TLSModeMITM
 	Pipeline   *transform.PipelineHolder
 	Resolver   *net.Resolver
-	Guard      *dnsguard.Guard // nil is treated as an empty (no-op) guard
+	Guard      *dnsguard.Guard   // nil is treated as an empty (no-op) guard
 	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
 	// config.DefaultUpstreamResponseHeaderTimeout.
 	UpstreamResponseHeaderTimeout time.Duration
+	// UpstreamProxy, when non-nil, routes upstream HTTP/HTTPS requests through
+	// an upstream SOCKS5/HTTP CONNECT proxy (see http.Transport.Proxy). nil
+	// means connect directly. Use config.UpstreamProxy.ProxyFunc to build one.
+	UpstreamProxy func(*http.Request) (*url.URL, error)
 }
 
 // New creates a new Proxy. In TLSModeMITM, certCache must be non-nil. In
@@ -94,7 +98,7 @@ func New(opts Options) *Proxy {
 		tunnelDone:     make(chan struct{}),
 		certCache:      opts.CertCache,
 		pipeline:       opts.Pipeline,
-		transport:      buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout),
+		transport:      buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout, opts.UpstreamProxy),
 		resolver:       opts.Resolver,
 		guard:          guard,
 		mcpPolicy:      opts.MCPPolicy,
@@ -712,7 +716,10 @@ func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 // is rejected before the TCP connect.
 // responseHeaderTimeout overrides the default 30-second
 // ResponseHeaderTimeout when greater than zero; pass 0 to keep the default.
-func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeaderTimeout time.Duration) *http.Transport {
+// proxyFunc, when non-nil, routes upstream requests through an upstream
+// SOCKS5/HTTP CONNECT proxy; the dialer (and thus guard.DialControl) then
+// applies to the proxy connection rather than the final target.
+func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeaderTimeout time.Duration, proxyFunc func(*http.Request) (*url.URL, error)) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
@@ -726,6 +733,7 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
+		Proxy:                 proxyFunc,
 		DialContext:           dialer.DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,

--- a/internal/proxy/upstream_proxy_test.go
+++ b/internal/proxy/upstream_proxy_test.go
@@ -1,0 +1,78 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildTransport_RoutesThroughUpstreamProxy proves that a non-nil
+// proxyFunc causes the upstream transport to send plain-HTTP requests via the
+// upstream proxy rather than dialing the origin directly.
+func TestBuildTransport_RoutesThroughUpstreamProxy(t *testing.T) {
+	// Origin the proxy would dial directly if no upstream proxy were used.
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "origin")
+	}))
+	defer origin.Close()
+
+	// Fake upstream forward proxy: for plain HTTP it receives the full
+	// absolute-URL request. Record that it was hit and answer directly.
+	var proxied atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.True(t, r.URL.IsAbs(), "upstream proxy should receive absolute-URI request, got %q", r.URL.String())
+		proxied.Add(1)
+		_, _ = io.WriteString(w, "via-proxy")
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	proxyFunc := func(*http.Request) (*url.URL, error) { return upstreamURL, nil }
+
+	guard, err := dnsguard.New(nil)
+	require.NoError(t, err)
+	transport := buildTransport(nil, guard, 0, proxyFunc)
+	defer transport.CloseIdleConnections()
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	require.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "via-proxy", string(body))
+	require.Equal(t, int32(1), proxied.Load(), "request should have traversed the upstream proxy")
+}
+
+// TestBuildTransport_NilProxyFuncDialsDirect confirms the default (no proxy)
+// behavior is preserved: a nil proxyFunc dials the origin directly.
+func TestBuildTransport_NilProxyFuncDialsDirect(t *testing.T) {
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "origin")
+	}))
+	defer origin.Close()
+
+	guard, err := dnsguard.New(nil)
+	require.NoError(t, err)
+	transport := buildTransport(nil, guard, 0, nil)
+	defer transport.CloseIdleConnections()
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	require.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "origin", string(body))
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -51,6 +51,23 @@ proxy:
   # upstream_deny_cidrs:
   #   - "169.254.169.254/32"
   #   - "127.0.0.0/8"
+  #
+  # Route iron-proxy's own outbound connections through an upstream
+  # SOCKS5/HTTP CONNECT proxy. Useful in corporate networks where all egress
+  # must traverse a forward proxy. Proxy URLs accept http, https, socks5, and
+  # socks5h schemes. The standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment
+  # variables override the matching field below when set, so you can omit this
+  # block entirely if those are already exported.
+  #
+  # NOTE: when an upstream proxy is in use, upstream_deny_cidrs is enforced
+  # against the proxy's address, not the final target — the proxy resolves and
+  # connects to the target on iron-proxy's behalf. This currently applies to
+  # the HTTP/HTTPS forward path (incl. CONNECT in mitm mode); raw TCP tunnels
+  # (sni-only passthrough, WebSocket) still dial directly.
+  # upstream_proxy:
+  #   http_proxy: "http://proxy.corp:3128"
+  #   https_proxy: "http://proxy.corp:3128"
+  #   no_proxy: "localhost,127.0.0.1,.internal.example.com"
 
 # TLS / MITM configuration
 tls:

--- a/iron-token-broker.example.yaml
+++ b/iron-token-broker.example.yaml
@@ -21,6 +21,14 @@ defaults:
   max_refresh_interval: "24h"         # keep-alive ceiling so idle creds don't age out
   refresh_timeout: "30s"              # per-attempt HTTP timeout against the IdP
 
+# Route credential-refresh requests through an upstream SOCKS5/HTTP CONNECT
+# proxy. The standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables
+# override the matching field below when set, so this block can be omitted if
+# those are already exported.
+# upstream_proxy:
+#   https_proxy: "http://proxy.corp:3128"
+#   no_proxy: "localhost,127.0.0.1"
+
 credentials:
   # OpenAI Codex — public client, no client_secret. The shipped UUIDs
   # below are placeholders; copy yours from the 1Password UI with the


### PR DESCRIPTION
iron-proxy now routes its own outbound connections through an upstream SOCKS5/HTTP CONNECT proxy, honoring the standard `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars plus an optional `proxy.upstream_proxy` config block. Env vars override the matching config field per-field, so deployments that already export the standard vars work without editing YAML.

This covers the HTTP/HTTPS forward data path (including CONNECT in mitm mode) and the broker's credential-refresh client. Raw TCP tunnels (sni-only passthrough, WebSocket) still dial directly and are out of scope here.

Note: when an upstream proxy is in use, `upstream_deny_cidrs` is enforced against the proxy's address rather than the final target, since the proxy resolves and connects on iron-proxy's behalf. This tradeoff is documented in the example config.

Closes #166