### PR TITLE
feat(helm): add iron-proxy Helm chart

### DIFF
--- a/charts/iron-proxy/.helmignore
+++ b/charts/iron-proxy/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/iron-proxy/Chart.yaml
+++ b/charts/iron-proxy/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: iron-proxy
+description: A DNS-intercepting MITM egress proxy for securing and governing outbound traffic.
+type: application
+# Chart version. Bump on every chart change, independent of the app version.
+version: 0.1.0
+# Default container image tag. Override image.tag to pin a released version (e.g. v1.2.3).
+appVersion: "latest"
+home: https://iron.sh
+sources:
+  - https://github.com/ironsh/iron-proxy
+keywords:
+  - proxy
+  - egress
+  - mitm
+  - security
+  - dns
+maintainers:
+  - name: iron.sh
+    url: https://iron.sh

--- a/charts/iron-proxy/README.md
+++ b/charts/iron-proxy/README.md
@@ -44,10 +44,13 @@ capability and otherwise runs as non-root with a read-only root filesystem.
 
 `.Values.listeners` is the one place ports are defined. Each enabled listener is exposed on
 the Service, exposed as a container port, **and** has its bind address (`:<port>`) fed into
-the proxy automatically: merged into the rendered config in standalone mode, or emitted as
-the matching `IRON_*_LISTEN` env var in managed mode. So the Service and the proxy can never
-disagree about ports. Do not set `dns.listen`, `proxy.http_listen`, etc. under `config` —
-those keys are overridden by `listeners`. To move a port, change it in one place:
+the proxy. For the core listeners (dns/http/https/tunnel/metrics) this is done with the
+`IRON_*_LISTEN` environment variables in **both** standalone and managed mode — env
+overrides apply on top of any config file, so there is one source of truth and no drift.
+(postgres and management have no env override: their listen address is merged into the
+config in standalone mode and driven by the control plane in managed mode.) Do not set
+`dns.listen`, `proxy.http_listen`, etc. under `config`; those keys are ignored. To move a
+port, change it in one place:
 
 ```yaml
 listeners:
@@ -55,7 +58,13 @@ listeners:
     port: 8443        # Service port, container port, and proxy bind all become 8443
   tunnel:
     enabled: true     # turn on the optional CONNECT/SOCKS5 tunnel
+  dns:
+    enabled: false    # disable the DNS server entirely (IRON_DNS_ENABLED=false)
 ```
+
+Disabling `dns` turns the DNS server off completely (not just hidden from the Service). Use
+this when clients reach the proxy through explicit `HTTP_PROXY`/`HTTPS_PROXY` settings rather
+than DNS interception; `proxy_ip` is then not required.
 
 ## Run modes
 

--- a/charts/iron-proxy/README.md
+++ b/charts/iron-proxy/README.md
@@ -24,20 +24,38 @@ See below.
 ## How iron-proxy runs
 
 iron-proxy intercepts DNS, answers queries with a single `proxy_ip`, then terminates and
-inspects the HTTP/HTTPS traffic clients send to that IP. The chart wires up:
+inspects the HTTP/HTTPS traffic clients send to that IP. The chart wires up these
+listeners, configured under `.Values.listeners`:
 
-| Listener | Default port | Service port key |
-| --- | --- | --- |
-| DNS | 53/UDP | `service.ports.dns` |
-| HTTP | 80/TCP | `service.ports.http` |
-| HTTPS | 443/TCP | `service.ports.https` |
-| Metrics / health (`GET /healthz`) | 9090/TCP | `service.ports.metrics` |
-| Tunnel (CONNECT/SOCKS5, optional) | 8080/TCP | `service.ports.tunnel` |
-| Postgres MITM (optional) | 5432/TCP | `service.ports.postgres` |
-| Management API (optional) | 9092/TCP | `service.ports.management` |
+| Listener | `listeners` key | Default port | Enabled by default |
+| --- | --- | --- | --- |
+| DNS | `dns` | 53/UDP | yes |
+| HTTP | `http` | 80/TCP | yes |
+| HTTPS | `https` | 443/TCP | yes |
+| Metrics / health (`GET /healthz`) | `metrics` | 9090/TCP | yes |
+| Tunnel (CONNECT/SOCKS5) | `tunnel` | 8080/TCP | no |
+| Postgres MITM | `postgres` | 5432/TCP | no |
+| Management API | `management` | 9092/TCP | no |
 
 Ports 53/80/443 are privileged, so the container is granted the `NET_BIND_SERVICE`
 capability and otherwise runs as non-root with a read-only root filesystem.
+
+### Listeners are the single source of truth for ports
+
+`.Values.listeners` is the one place ports are defined. Each enabled listener is exposed on
+the Service, exposed as a container port, **and** has its bind address (`:<port>`) fed into
+the proxy automatically: merged into the rendered config in standalone mode, or emitted as
+the matching `IRON_*_LISTEN` env var in managed mode. So the Service and the proxy can never
+disagree about ports. Do not set `dns.listen`, `proxy.http_listen`, etc. under `config` —
+those keys are overridden by `listeners`. To move a port, change it in one place:
+
+```yaml
+listeners:
+  https:
+    port: 8443        # Service port, container port, and proxy bind all become 8443
+  tunnel:
+    enabled: true     # turn on the optional CONNECT/SOCKS5 tunnel
+```
 
 ## Run modes
 
@@ -45,7 +63,8 @@ capability and otherwise runs as non-root with a read-only root filesystem.
 
 The chart renders `.Values.config` into a ConfigMap as `proxy.yaml` and starts the proxy
 with `-config /etc/iron-proxy/config/proxy.yaml`. The config keys mirror
-[`iron-proxy.example.yaml`](../../iron-proxy.example.yaml) exactly.
+[`iron-proxy.example.yaml`](../../iron-proxy.example.yaml) exactly, except for listen
+addresses, which come from `.Values.listeners` (see above).
 
 ```yaml
 mode: standalone
@@ -53,11 +72,7 @@ service:
   type: LoadBalancer
 config:
   dns:
-    listen: ":53"
     proxy_ip: "203.0.113.10"   # MUST equal the IP clients reach this proxy on
-  proxy:
-    http_listen: ":80"
-    https_listen: ":443"
   tls:
     mode: "mitm"
     ca_cert: "/etc/iron-proxy/tls/ca.crt"
@@ -87,14 +102,21 @@ env:
 ### Managed
 
 In managed mode the proxy authenticates to the control plane with a bearer token and pulls
-its config from there. No `proxy.yaml` is used.
+its transforms, secrets, and routes from there. There is no `proxy.yaml`: everything else is
+configured through `IRON_*` env vars. The chart renders those for you from the `managed`
+block, and listen addresses still come from `.Values.listeners` (as `IRON_*_LISTEN`). The CA
+cert/key paths (`IRON_TLS_CA_CERT`/`IRON_TLS_CA_KEY`) are derived from the CA mount
+automatically when `ca.mode` is not `none`.
 
 ```yaml
 mode: managed
 managed:
   existingTokenSecret: iron-proxy-token   # Secret with a "token" key
   # tokenSecretKey: token
-  # controlPlaneURL: https://api.iron.sh  # override if self-hosting
+  # controlPlaneURL: https://api.iron.sh   # override if self-hosting
+  proxyIP: "203.0.113.10"                  # REQUIRED -> IRON_DNS_PROXY_IP
+  # tlsMode: "sni-only"                     # -> IRON_TLS_MODE (set when ca.mode=none)
+  # logLevel: "info"                        # -> IRON_LOG_LEVEL
 ca:
   mode: existingSecret
   existingSecret: iron-proxy-ca
@@ -103,6 +125,9 @@ ca:
 ```bash
 kubectl create secret generic iron-proxy-token --from-literal=token="$IRON_PROXY_TOKEN"
 ```
+
+`managed.proxyIP` is required (the proxy fails validation without `IRON_DNS_PROXY_IP`).
+Anything not covered by the `managed` block can still be set through `.Values.env`.
 
 ## CA certificate (MITM mode)
 
@@ -158,6 +183,10 @@ credentials with:
 | `managed.existingTokenSecret` | `""` | Existing Secret holding the token. |
 | `managed.tokenSecretKey` | `token` | Key within that Secret. |
 | `managed.controlPlaneURL` | `""` | Override `IRON_CONTROL_PLANE_URL`. |
+| `managed.proxyIP` | `""` | `IRON_DNS_PROXY_IP`. Required in managed mode. |
+| `managed.tlsMode` | `""` | `IRON_TLS_MODE` (`mitm`/`sni-only`). |
+| `managed.logLevel` | `""` | `IRON_LOG_LEVEL`. |
+| `managed.upstreamResolver` | `""` | `IRON_DNS_UPSTREAM_RESOLVER`. |
 | `ca.mode` | `existingSecret` | `existingSecret`, `inline`, or `none`. |
 | `ca.existingSecret` | `""` | Secret name for `existingSecret` mode. |
 | `ca.certKey` / `ca.keyKey` | `ca.crt` / `ca.key` | Keys within that Secret. |
@@ -169,7 +198,7 @@ credentials with:
 | `service.clusterIP` | `""` | Static cluster IP (set so it can be `proxy_ip`). |
 | `service.loadBalancerIP` | `""` | Static LB IP. |
 | `service.annotations` | `{}` | Service annotations. |
-| `service.ports.*` | see values | Per-listener `enabled`/`port`/`targetPort`/`protocol`. |
+| `listeners.*` | see values | Per-listener `enabled`/`port`/`protocol`. Single source of truth for ports. |
 | `livenessProbe` / `readinessProbe` | `/healthz` on metrics | Probes; fully overridable. |
 | `serviceAccount.create` | `true` | Create a ServiceAccount. |
 | `serviceAccount.annotations` | `{}` | SA annotations (IRSA / Workload Identity). |
@@ -187,6 +216,7 @@ credentials with:
   `replicaCount > 1` only makes sense behind a single shared Service IP that load-balances
   to the replicas, with a config that is identical and stateless across pods.
 - **Privileged ports.** If your cluster policy forbids `NET_BIND_SERVICE`, move the DNS/HTTP/
-  HTTPS listeners in `config` to ports >= 1024 and remap them via `service.ports.*.port`.
+  HTTPS listeners to ports >= 1024 via `listeners.*.port` (which updates the bind, the
+  container port, and the Service together).
 - **CA trust.** Generate the CA once and keep it in a Secret. Clients trust the CA, so it
   must survive pod restarts and rollouts unchanged.

--- a/charts/iron-proxy/README.md
+++ b/charts/iron-proxy/README.md
@@ -1,0 +1,188 @@
+# iron-proxy Helm chart
+
+Deploys [iron-proxy](https://github.com/ironsh/iron-proxy), a DNS-intercepting MITM egress
+proxy, to Kubernetes.
+
+## TL;DR
+
+```bash
+# From a checkout of the repo:
+helm install iron-proxy ./charts/iron-proxy
+```
+
+The default install runs in standalone mode with a sample allowlist config and an
+ephemeral self-signed CA generated at pod start. It is a starting point: you will almost
+always want to edit `config` (especially `config.dns.proxy_ip`), supply a stable CA, and
+add your secret-backend credentials. See below.
+
+## How iron-proxy runs
+
+iron-proxy intercepts DNS, answers queries with a single `proxy_ip`, then terminates and
+inspects the HTTP/HTTPS traffic clients send to that IP. The chart wires up:
+
+| Listener | Default port | Service port key |
+| --- | --- | --- |
+| DNS | 53/UDP | `service.ports.dns` |
+| HTTP | 80/TCP | `service.ports.http` |
+| HTTPS | 443/TCP | `service.ports.https` |
+| Metrics / health (`GET /healthz`) | 9090/TCP | `service.ports.metrics` |
+| Tunnel (CONNECT/SOCKS5, optional) | 8080/TCP | `service.ports.tunnel` |
+| Postgres MITM (optional) | 5432/TCP | `service.ports.postgres` |
+| Management API (optional) | 9092/TCP | `service.ports.management` |
+
+Ports 53/80/443 are privileged, so the container is granted the `NET_BIND_SERVICE`
+capability and otherwise runs as non-root with a read-only root filesystem.
+
+## Run modes
+
+### Standalone (default)
+
+The chart renders `.Values.config` into a ConfigMap as `proxy.yaml` and starts the proxy
+with `-config /etc/iron-proxy/config/proxy.yaml`. The config keys mirror
+[`iron-proxy.example.yaml`](../../iron-proxy.example.yaml) exactly.
+
+```yaml
+mode: standalone
+service:
+  type: LoadBalancer
+config:
+  dns:
+    listen: ":53"
+    proxy_ip: "203.0.113.10"   # MUST equal the IP clients reach this proxy on
+  proxy:
+    http_listen: ":80"
+    https_listen: ":443"
+  tls:
+    mode: "mitm"
+    ca_cert: "/etc/iron-proxy/tls/ca.crt"
+    ca_key: "/etc/iron-proxy/tls/ca.key"
+  transforms:
+    - name: allowlist
+      config:
+        domains: ["api.openai.com"]
+    - name: secrets
+      config:
+        secrets:
+          - source: { type: env, var: OPENAI_API_KEY }
+            inject: { header: "Authorization", formatter: "Bearer {{ .Value }}" }
+            rules:
+              - host: "api.openai.com"
+env:
+  - name: OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef: { name: my-api-keys, key: openai }
+```
+
+> `config.dns.proxy_ip` must be the address clients use to reach the proxy. Pin
+> `service.clusterIP` (or a `LoadBalancer` IP) so you know that value ahead of time, and set
+> `proxy_ip` to match. To use a ConfigMap you manage yourself instead of `.Values.config`,
+> set `configExistingConfigMap`.
+
+### Managed
+
+In managed mode the proxy authenticates to the control plane with a bearer token and pulls
+its config from there. No `proxy.yaml` is used.
+
+```yaml
+mode: managed
+managed:
+  existingTokenSecret: iron-proxy-token   # Secret with a "token" key
+  # tokenSecretKey: token
+  # controlPlaneURL: https://api.iron.sh  # override if self-hosting
+ca:
+  mode: existingSecret
+  existingSecret: iron-proxy-ca
+```
+
+```bash
+kubectl create secret generic iron-proxy-token --from-literal=token="$IRON_PROXY_TOKEN"
+```
+
+## CA certificate (MITM mode)
+
+MITM mode mints leaf certificates from a CA, so clients must trust that CA. The mount path
+is always `/etc/iron-proxy/tls` (matching the default `config.tls.ca_cert`/`ca_key`). Pick a
+`ca.mode`:
+
+| `ca.mode` | Behavior | Use when |
+| --- | --- | --- |
+| `generate` (default) | An initContainer runs `iron-proxy generate-ca` into an emptyDir on every pod start | Demos/trials. CA changes per restart, so clients cannot pin it. |
+| `existingSecret` | Mount a Secret you created | Production. Stable, rotatable CA. |
+| `inline` | Provide `ca.cert`/`ca.key` PEM; the chart creates the Secret | GitOps where the CA lives in your (encrypted) values. |
+| `none` | Mount nothing | `tls.mode: sni-only`, which needs no CA. |
+
+Create a stable CA for `existingSecret` mode with the bundled subcommand:
+
+```bash
+iron-proxy generate-ca -outdir ./ca -name "Acme egress CA"
+kubectl create secret generic iron-proxy-ca \
+  --from-file=ca.crt=./ca/ca.crt --from-file=ca.key=./ca/ca.key
+helm install iron-proxy ./charts/iron-proxy \
+  --set ca.mode=existingSecret --set ca.existingSecret=iron-proxy-ca
+```
+
+Distribute `ca.crt` to clients as a trusted root.
+
+## Secret-backend credentials
+
+Transforms reference secrets from env vars, files, AWS, or 1Password. Supply the backing
+credentials with:
+
+- `env` / `envFrom` — reference your own Secrets (recommended for production).
+- `secretEnv` — inline key/value pairs the chart stores in a Secret and injects via
+  `envFrom` (convenient for demos).
+- `extraVolumes` / `extraVolumeMounts` — for file-based sources, gRPC client certs, or GCP
+  keyfiles.
+- `serviceAccount.annotations` — for EKS IRSA / GKE Workload Identity used by the
+  `workload_identity` AWS/GCP providers.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Replica count. Scaling needs a shared Service IP; see notes. |
+| `image.repository` | `ironsh/iron-proxy` | Image repository. |
+| `image.tag` | `""` | Image tag; falls back to chart `appVersion`. Pin a release in prod. |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy. |
+| `imagePullSecrets` | `[]` | Pull secrets for private registries. |
+| `mode` | `standalone` | `standalone` or `managed`. |
+| `config` | sample | iron-proxy YAML, rendered to a ConfigMap (standalone). |
+| `configExistingConfigMap` | `""` | Use an existing ConfigMap (with a `proxy.yaml` key). |
+| `managed.token` | `""` | Inline control-plane token (creates a Secret). |
+| `managed.existingTokenSecret` | `""` | Existing Secret holding the token. |
+| `managed.tokenSecretKey` | `token` | Key within that Secret. |
+| `managed.controlPlaneURL` | `""` | Override `IRON_CONTROL_PLANE_URL`. |
+| `ca.mode` | `generate` | `generate`, `existingSecret`, `inline`, or `none`. |
+| `ca.existingSecret` | `""` | Secret name for `existingSecret` mode. |
+| `ca.certKey` / `ca.keyKey` | `ca.crt` / `ca.key` | Keys within that Secret. |
+| `ca.cert` / `ca.key` | `""` | PEM material for `inline` mode. |
+| `ca.commonName` | `iron-proxy CA` | CN for `generate` mode. |
+| `ca.algorithm` | `rsa4096` | Key algorithm for `generate` mode (`rsa4096`/`ed25519`). |
+| `env` | `[]` | Extra environment variables. |
+| `envFrom` | `[]` | Pull env from existing Secrets/ConfigMaps. |
+| `secretEnv` | `{}` | Inline key/values → chart Secret, injected via `envFrom`. |
+| `service.type` | `ClusterIP` | Service type. |
+| `service.clusterIP` | `""` | Static cluster IP (set so it can be `proxy_ip`). |
+| `service.loadBalancerIP` | `""` | Static LB IP. |
+| `service.annotations` | `{}` | Service annotations. |
+| `service.ports.*` | see values | Per-listener `enabled`/`port`/`targetPort`/`protocol`. |
+| `livenessProbe` / `readinessProbe` | `/healthz` on metrics | Probes; fully overridable. |
+| `serviceAccount.create` | `true` | Create a ServiceAccount. |
+| `serviceAccount.annotations` | `{}` | SA annotations (IRSA / Workload Identity). |
+| `podSecurityContext` | non-root | Pod security context. |
+| `securityContext` | drop ALL, add `NET_BIND_SERVICE` | Container security context. |
+| `terminationGracePeriodSeconds` | `30` | Graceful shutdown window (app uses 10s). |
+| `resources` | `{}` | Resource requests/limits. |
+| `nodeSelector` / `tolerations` / `affinity` / `topologySpreadConstraints` | `{}`/`[]` | Scheduling. |
+| `extraVolumes` / `extraVolumeMounts` | `[]` | Extra volumes for files/certs/keyfiles. |
+| `metrics.serviceMonitor.enabled` | `false` | Create a Prometheus Operator ServiceMonitor. |
+
+## Notes and caveats
+
+- **Single logical endpoint.** Because DNS interception hands every client one `proxy_ip`,
+  `replicaCount > 1` only makes sense behind a single shared Service IP that load-balances
+  to the replicas, with a config that is identical and stateless across pods.
+- **Privileged ports.** If your cluster policy forbids `NET_BIND_SERVICE`, move the DNS/HTTP/
+  HTTPS listeners in `config` to ports >= 1024 and remap them via `service.ports.*.port`.
+- **CA trust.** With `ca.mode: generate` the CA is not stable across restarts; use
+  `existingSecret` or `inline` for anything clients need to trust durably.

--- a/charts/iron-proxy/README.md
+++ b/charts/iron-proxy/README.md
@@ -6,14 +6,20 @@ proxy, to Kubernetes.
 ## TL;DR
 
 ```bash
+# Create a CA once and store it in a Secret (MITM mode needs one):
+iron-proxy generate-ca -outdir ./ca -name "Acme egress CA"
+kubectl create secret generic iron-proxy-ca \
+  --from-file=ca.crt=./ca/ca.crt --from-file=ca.key=./ca/ca.key
+
 # From a checkout of the repo:
-helm install iron-proxy ./charts/iron-proxy
+helm install iron-proxy ./charts/iron-proxy \
+  --set ca.existingSecret=iron-proxy-ca
 ```
 
-The default install runs in standalone mode with a sample allowlist config and an
-ephemeral self-signed CA generated at pod start. It is a starting point: you will almost
-always want to edit `config` (especially `config.dns.proxy_ip`), supply a stable CA, and
-add your secret-backend credentials. See below.
+The chart runs in standalone mode with a sample allowlist config by default. It is a
+starting point: you will almost always want to edit `config` (especially
+`config.dns.proxy_ip`), point at your CA Secret, and add your secret-backend credentials.
+See below.
 
 ## How iron-proxy runs
 
@@ -100,18 +106,18 @@ kubectl create secret generic iron-proxy-token --from-literal=token="$IRON_PROXY
 
 ## CA certificate (MITM mode)
 
-MITM mode mints leaf certificates from a CA, so clients must trust that CA. The mount path
-is always `/etc/iron-proxy/tls` (matching the default `config.tls.ca_cert`/`ca_key`). Pick a
-`ca.mode`:
+MITM mode mints leaf certificates from a CA, so clients must trust that CA. The CA must be
+stable: a CA that changes on pod restart breaks every client that trusted the old one. The
+mount path is always `/etc/iron-proxy/tls` (matching the default `config.tls.ca_cert`/
+`ca_key`). Pick a `ca.mode`:
 
 | `ca.mode` | Behavior | Use when |
 | --- | --- | --- |
-| `generate` (default) | An initContainer runs `iron-proxy generate-ca` into an emptyDir on every pod start | Demos/trials. CA changes per restart, so clients cannot pin it. |
-| `existingSecret` | Mount a Secret you created | Production. Stable, rotatable CA. |
+| `existingSecret` (default) | Mount a Secret you created | Production. Stable, rotatable CA. |
 | `inline` | Provide `ca.cert`/`ca.key` PEM; the chart creates the Secret | GitOps where the CA lives in your (encrypted) values. |
 | `none` | Mount nothing | `tls.mode: sni-only`, which needs no CA. |
 
-Create a stable CA for `existingSecret` mode with the bundled subcommand:
+Create a CA for `existingSecret` mode with the bundled subcommand:
 
 ```bash
 iron-proxy generate-ca -outdir ./ca -name "Acme egress CA"
@@ -152,12 +158,10 @@ credentials with:
 | `managed.existingTokenSecret` | `""` | Existing Secret holding the token. |
 | `managed.tokenSecretKey` | `token` | Key within that Secret. |
 | `managed.controlPlaneURL` | `""` | Override `IRON_CONTROL_PLANE_URL`. |
-| `ca.mode` | `generate` | `generate`, `existingSecret`, `inline`, or `none`. |
+| `ca.mode` | `existingSecret` | `existingSecret`, `inline`, or `none`. |
 | `ca.existingSecret` | `""` | Secret name for `existingSecret` mode. |
 | `ca.certKey` / `ca.keyKey` | `ca.crt` / `ca.key` | Keys within that Secret. |
 | `ca.cert` / `ca.key` | `""` | PEM material for `inline` mode. |
-| `ca.commonName` | `iron-proxy CA` | CN for `generate` mode. |
-| `ca.algorithm` | `rsa4096` | Key algorithm for `generate` mode (`rsa4096`/`ed25519`). |
 | `env` | `[]` | Extra environment variables. |
 | `envFrom` | `[]` | Pull env from existing Secrets/ConfigMaps. |
 | `secretEnv` | `{}` | Inline key/values → chart Secret, injected via `envFrom`. |
@@ -184,5 +188,5 @@ credentials with:
   to the replicas, with a config that is identical and stateless across pods.
 - **Privileged ports.** If your cluster policy forbids `NET_BIND_SERVICE`, move the DNS/HTTP/
   HTTPS listeners in `config` to ports >= 1024 and remap them via `service.ports.*.port`.
-- **CA trust.** With `ca.mode: generate` the CA is not stable across restarts; use
-  `existingSecret` or `inline` for anything clients need to trust durably.
+- **CA trust.** Generate the CA once and keep it in a Secret. Clients trust the CA, so it
+  must survive pod restarts and rollouts unchanged.

--- a/charts/iron-proxy/templates/NOTES.txt
+++ b/charts/iron-proxy/templates/NOTES.txt
@@ -6,7 +6,11 @@ Run mode: {{ .Values.mode }}
 
    kubectl --namespace {{ .Release.Namespace }} get svc {{ include "iron-proxy.fullname" . }}
 
-{{- if eq .Values.mode "standalone" }}
+{{- if not .Values.listeners.dns.enabled }}
+
+   The DNS server is disabled (listeners.dns.enabled=false). Point clients at the
+   proxy via explicit HTTP(S)_PROXY settings; proxy_ip is not needed.
+{{- else if eq .Values.mode "standalone" }}
 
    IMPORTANT: config.dns.proxy_ip must equal the IP clients reach iron-proxy on
    (typically this Service's ClusterIP or LoadBalancer IP). It is currently set to
@@ -19,8 +23,14 @@ Run mode: {{ .Values.mode }}
    Set it with --set managed.proxyIP=<ip> then `helm upgrade`.
 {{- end }}
 
+{{- if .Values.listeners.dns.enabled }}
+
 2. Point client pods at iron-proxy for DNS so hostnames resolve to proxy_ip, then
    send their HTTP/HTTPS traffic through it.
+{{- else }}
+
+2. Send client HTTP/HTTPS traffic through iron-proxy (e.g. HTTPS_PROXY/HTTP_PROXY).
+{{- end }}
 
 {{- if ne .Values.ca.mode "none" }}
 

--- a/charts/iron-proxy/templates/NOTES.txt
+++ b/charts/iron-proxy/templates/NOTES.txt
@@ -20,13 +20,7 @@ Run mode: {{ .Values.mode }}
 {{- if eq .Values.config.tls.mode "mitm" }}
 
 3. MITM mode terminates TLS, so clients must trust the proxy CA.
-{{- if eq .Values.ca.mode "generate" }}
-   The CA is generated fresh on every pod start (ca.mode=generate) and is NOT stable
-   across restarts. Use ca.mode=existingSecret or ca.mode=inline for a CA clients can
-   pin. Extract the current CA with:
-
-     kubectl --namespace {{ .Release.Namespace }} exec deploy/{{ include "iron-proxy.fullname" . }} -- cat /etc/iron-proxy/tls/ca.crt
-{{- else if eq .Values.ca.mode "existingSecret" }}
+{{- if eq .Values.ca.mode "existingSecret" }}
    The CA comes from Secret "{{ .Values.ca.existingSecret }}". Distribute its
    "{{ .Values.ca.certKey }}" entry to clients as a trusted root.
 {{- else if eq .Values.ca.mode "inline" }}

--- a/charts/iron-proxy/templates/NOTES.txt
+++ b/charts/iron-proxy/templates/NOTES.txt
@@ -1,0 +1,41 @@
+iron-proxy has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Run mode: {{ .Values.mode }}
+
+1. Find the Service address clients should use:
+
+   kubectl --namespace {{ .Release.Namespace }} get svc {{ include "iron-proxy.fullname" . }}
+
+{{- if eq .Values.mode "standalone" }}
+
+   IMPORTANT: config.dns.proxy_ip must equal the IP clients reach iron-proxy on
+   (typically this Service's ClusterIP or LoadBalancer IP). It is currently set to
+   "{{ .Values.config.dns.proxy_ip }}". Update it with --set config.dns.proxy_ip=<ip>
+   (and ideally pin service.clusterIP to a known value) then `helm upgrade`.
+{{- end }}
+
+2. Point client pods at iron-proxy for DNS so hostnames resolve to proxy_ip, then
+   send their HTTP/HTTPS traffic through it.
+
+{{- if eq .Values.config.tls.mode "mitm" }}
+
+3. MITM mode terminates TLS, so clients must trust the proxy CA.
+{{- if eq .Values.ca.mode "generate" }}
+   The CA is generated fresh on every pod start (ca.mode=generate) and is NOT stable
+   across restarts. Use ca.mode=existingSecret or ca.mode=inline for a CA clients can
+   pin. Extract the current CA with:
+
+     kubectl --namespace {{ .Release.Namespace }} exec deploy/{{ include "iron-proxy.fullname" . }} -- cat /etc/iron-proxy/tls/ca.crt
+{{- else if eq .Values.ca.mode "existingSecret" }}
+   The CA comes from Secret "{{ .Values.ca.existingSecret }}". Distribute its
+   "{{ .Values.ca.certKey }}" entry to clients as a trusted root.
+{{- else if eq .Values.ca.mode "inline" }}
+   The CA was supplied inline and stored in Secret "{{ include "iron-proxy.caSecretName" . }}".
+   Distribute its ca.crt entry to clients as a trusted root.
+{{- end }}
+{{- end }}
+
+4. Check health:
+
+   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "iron-proxy.fullname" . }} {{ .Values.service.ports.metrics.port }}:{{ .Values.service.ports.metrics.port }}
+   curl http://localhost:{{ .Values.service.ports.metrics.port }}/healthz   # -> OK

--- a/charts/iron-proxy/templates/NOTES.txt
+++ b/charts/iron-proxy/templates/NOTES.txt
@@ -12,12 +12,17 @@ Run mode: {{ .Values.mode }}
    (typically this Service's ClusterIP or LoadBalancer IP). It is currently set to
    "{{ .Values.config.dns.proxy_ip }}". Update it with --set config.dns.proxy_ip=<ip>
    (and ideally pin service.clusterIP to a known value) then `helm upgrade`.
+{{- else }}
+
+   IMPORTANT: managed.proxyIP (IRON_DNS_PROXY_IP) must equal the IP clients reach
+   iron-proxy on and is required. It is currently {{ if .Values.managed.proxyIP }}"{{ .Values.managed.proxyIP }}"{{ else }}UNSET — the proxy will fail to start{{ end }}.
+   Set it with --set managed.proxyIP=<ip> then `helm upgrade`.
 {{- end }}
 
 2. Point client pods at iron-proxy for DNS so hostnames resolve to proxy_ip, then
    send their HTTP/HTTPS traffic through it.
 
-{{- if eq .Values.config.tls.mode "mitm" }}
+{{- if ne .Values.ca.mode "none" }}
 
 3. MITM mode terminates TLS, so clients must trust the proxy CA.
 {{- if eq .Values.ca.mode "existingSecret" }}
@@ -31,5 +36,5 @@ Run mode: {{ .Values.mode }}
 
 4. Check health:
 
-   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "iron-proxy.fullname" . }} {{ .Values.service.ports.metrics.port }}:{{ .Values.service.ports.metrics.port }}
-   curl http://localhost:{{ .Values.service.ports.metrics.port }}/healthz   # -> OK
+   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "iron-proxy.fullname" . }} {{ .Values.listeners.metrics.port }}:{{ .Values.listeners.metrics.port }}
+   curl http://localhost:{{ .Values.listeners.metrics.port }}/healthz   # -> OK

--- a/charts/iron-proxy/templates/_helpers.tpl
+++ b/charts/iron-proxy/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "iron-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{- define "iron-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "iron-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "iron-proxy.labels" -}}
+helm.sh/chart: {{ include "iron-proxy.chart" . }}
+{{ include "iron-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "iron-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "iron-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "iron-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "iron-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The name of the chart-managed Secret holding inline secretEnv values.
+*/}}
+{{- define "iron-proxy.secretEnvName" -}}
+{{- printf "%s-env" (include "iron-proxy.fullname" .) }}
+{{- end }}
+
+{{/*
+The name of the chart-managed Secret holding the inline CA cert/key.
+*/}}
+{{- define "iron-proxy.caSecretName" -}}
+{{- printf "%s-ca" (include "iron-proxy.fullname" .) }}
+{{- end }}
+
+{{/*
+The name of the chart-managed Secret holding the inline control-plane token.
+*/}}
+{{- define "iron-proxy.tokenSecretName" -}}
+{{- printf "%s-token" (include "iron-proxy.fullname" .) }}
+{{- end }}
+
+{{/*
+Resolve the metrics port number from service.ports.metrics, used by the named
+"metrics" container port that probes and the ServiceMonitor target.
+*/}}
+{{- define "iron-proxy.metricsPort" -}}
+{{- .Values.service.ports.metrics.targetPort | default 9090 }}
+{{- end }}

--- a/charts/iron-proxy/templates/_helpers.tpl
+++ b/charts/iron-proxy/templates/_helpers.tpl
@@ -83,9 +83,70 @@ The name of the chart-managed Secret holding the inline control-plane token.
 {{- end }}
 
 {{/*
-Resolve the metrics port number from service.ports.metrics, used by the named
+Resolve the metrics port number from listeners.metrics, used by the named
 "metrics" container port that probes and the ServiceMonitor target.
 */}}
 {{- define "iron-proxy.metricsPort" -}}
-{{- .Values.service.ports.metrics.targetPort | default 9090 }}
+{{- .Values.listeners.metrics.port | default 9090 }}
+{{- end }}
+
+{{/*
+Managed-mode environment variables. In managed mode there is no config file, so
+listen addresses, proxy_ip, TLS, and logging are supplied via IRON_* env vars.
+Listen addresses come from .Values.listeners so they match the Service; CA paths
+are derived from the CA mount. The control-plane token is emitted separately by
+the Deployment (it uses a secretKeyRef). Excludes management (no env override).
+*/}}
+{{- define "iron-proxy.managedEnv" -}}
+{{- $l := .Values.listeners -}}
+{{- with .Values.managed.controlPlaneURL }}
+- name: IRON_CONTROL_PLANE_URL
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.managed.proxyIP }}
+- name: IRON_DNS_PROXY_IP
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.managed.tlsMode }}
+- name: IRON_TLS_MODE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.managed.logLevel }}
+- name: IRON_LOG_LEVEL
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.managed.upstreamResolver }}
+- name: IRON_DNS_UPSTREAM_RESOLVER
+  value: {{ . | quote }}
+{{- end }}
+{{- if ne .Values.ca.mode "none" }}
+- name: IRON_TLS_CA_CERT
+  value: "/etc/iron-proxy/tls/ca.crt"
+- name: IRON_TLS_CA_KEY
+  value: "/etc/iron-proxy/tls/ca.key"
+{{- end }}
+{{- if $l.dns.enabled }}
+- name: IRON_DNS_LISTEN
+  value: {{ printf ":%v" (int $l.dns.port) | quote }}
+{{- end }}
+{{- if $l.http.enabled }}
+- name: IRON_PROXY_HTTP_LISTEN
+  value: {{ printf ":%v" (int $l.http.port) | quote }}
+{{- end }}
+{{- if $l.https.enabled }}
+- name: IRON_PROXY_HTTPS_LISTEN
+  value: {{ printf ":%v" (int $l.https.port) | quote }}
+{{- end }}
+{{- if $l.tunnel.enabled }}
+- name: IRON_PROXY_TUNNEL_LISTEN
+  value: {{ printf ":%v" (int $l.tunnel.port) | quote }}
+{{- end }}
+{{- if $l.metrics.enabled }}
+- name: IRON_METRICS_LISTEN
+  value: {{ printf ":%v" (int $l.metrics.port) | quote }}
+{{- end }}
+{{- if $l.postgres.enabled }}
+- name: IRON_PROXY_PG_LISTEN
+  value: {{ printf ":%v" (int $l.postgres.port) | quote }}
+{{- end }}
 {{- end }}

--- a/charts/iron-proxy/templates/_helpers.tpl
+++ b/charts/iron-proxy/templates/_helpers.tpl
@@ -91,14 +91,55 @@ Resolve the metrics port number from listeners.metrics, used by the named
 {{- end }}
 
 {{/*
-Managed-mode environment variables. In managed mode there is no config file, so
-listen addresses, proxy_ip, TLS, and logging are supplied via IRON_* env vars.
-Listen addresses come from .Values.listeners so they match the Service; CA paths
-are derived from the CA mount. The control-plane token is emitted separately by
-the Deployment (it uses a secretKeyRef). Excludes management (no env override).
+Listener environment variables, emitted in BOTH standalone and managed mode so
+.Values.listeners is the single source of truth for ports: the proxy binds exactly
+what the Service exposes. Listen addresses are set via IRON_*_LISTEN (env overrides
+apply on top of any config file), and the DNS server is turned off with
+IRON_DNS_ENABLED=false when listeners.dns is disabled.
+
+Only listeners with a real env override are emitted here. postgres and management
+have no general env override: postgres is driven by the control plane in managed
+mode (IRON_PROXY_PG_LISTEN) and by the config block in standalone mode; management
+is standalone-only and set from the config block.
+*/}}
+{{- define "iron-proxy.listenerEnv" -}}
+{{- $l := .Values.listeners -}}
+{{- if $l.dns.enabled }}
+- name: IRON_DNS_LISTEN
+  value: {{ printf ":%v" (int $l.dns.port) | quote }}
+{{- else }}
+- name: IRON_DNS_ENABLED
+  value: "false"
+{{- end }}
+{{- if $l.http.enabled }}
+- name: IRON_PROXY_HTTP_LISTEN
+  value: {{ printf ":%v" (int $l.http.port) | quote }}
+{{- end }}
+{{- if $l.https.enabled }}
+- name: IRON_PROXY_HTTPS_LISTEN
+  value: {{ printf ":%v" (int $l.https.port) | quote }}
+{{- end }}
+{{- if $l.tunnel.enabled }}
+- name: IRON_PROXY_TUNNEL_LISTEN
+  value: {{ printf ":%v" (int $l.tunnel.port) | quote }}
+{{- end }}
+{{- if $l.metrics.enabled }}
+- name: IRON_METRICS_LISTEN
+  value: {{ printf ":%v" (int $l.metrics.port) | quote }}
+{{- end }}
+{{- if and (eq .Values.mode "managed") $l.postgres.enabled }}
+- name: IRON_PROXY_PG_LISTEN
+  value: {{ printf ":%v" (int $l.postgres.port) | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Managed-mode-only environment variables. In managed mode there is no config file,
+so proxy_ip, TLS, and logging are supplied via IRON_* env vars; CA paths are derived
+from the CA mount. The control-plane token is emitted separately by the Deployment
+(it uses a secretKeyRef). Listen addresses come from iron-proxy.listenerEnv.
 */}}
 {{- define "iron-proxy.managedEnv" -}}
-{{- $l := .Values.listeners -}}
 {{- with .Values.managed.controlPlaneURL }}
 - name: IRON_CONTROL_PLANE_URL
   value: {{ . | quote }}
@@ -124,29 +165,5 @@ the Deployment (it uses a secretKeyRef). Excludes management (no env override).
   value: "/etc/iron-proxy/tls/ca.crt"
 - name: IRON_TLS_CA_KEY
   value: "/etc/iron-proxy/tls/ca.key"
-{{- end }}
-{{- if $l.dns.enabled }}
-- name: IRON_DNS_LISTEN
-  value: {{ printf ":%v" (int $l.dns.port) | quote }}
-{{- end }}
-{{- if $l.http.enabled }}
-- name: IRON_PROXY_HTTP_LISTEN
-  value: {{ printf ":%v" (int $l.http.port) | quote }}
-{{- end }}
-{{- if $l.https.enabled }}
-- name: IRON_PROXY_HTTPS_LISTEN
-  value: {{ printf ":%v" (int $l.https.port) | quote }}
-{{- end }}
-{{- if $l.tunnel.enabled }}
-- name: IRON_PROXY_TUNNEL_LISTEN
-  value: {{ printf ":%v" (int $l.tunnel.port) | quote }}
-{{- end }}
-{{- if $l.metrics.enabled }}
-- name: IRON_METRICS_LISTEN
-  value: {{ printf ":%v" (int $l.metrics.port) | quote }}
-{{- end }}
-{{- if $l.postgres.enabled }}
-- name: IRON_PROXY_PG_LISTEN
-  value: {{ printf ":%v" (int $l.postgres.port) | quote }}
 {{- end }}
 {{- end }}

--- a/charts/iron-proxy/templates/configmap.yaml
+++ b/charts/iron-proxy/templates/configmap.yaml
@@ -1,19 +1,14 @@
 {{- if and (eq .Values.mode "standalone") (not .Values.configExistingConfigMap) }}
 {{- /*
-Derive listen addresses from .Values.listeners and merge them into the user's
-config so the proxy binds exactly the ports the Service exposes. Listener values
-win over anything set under config (those keys are documented as ignored).
+The core listen addresses (dns/http/https/tunnel/metrics) are supplied via
+IRON_*_LISTEN env vars from .Values.listeners (see iron-proxy.listenerEnv), so they
+are not written here. postgres and management have no env override, so when those
+listeners are enabled their listen address is merged into the config from
+.Values.listeners — keeping .Values.listeners the single source of truth for ports.
 */}}
 {{- $l := .Values.listeners -}}
 {{- $cfg := deepCopy .Values.config -}}
 {{- $over := dict -}}
-{{- if $l.dns.enabled }}{{- $_ := set $over "dns" (dict "listen" (printf ":%v" (int $l.dns.port))) -}}{{- end }}
-{{- $proxy := dict -}}
-{{- if $l.http.enabled }}{{- $_ := set $proxy "http_listen" (printf ":%v" (int $l.http.port)) -}}{{- end }}
-{{- if $l.https.enabled }}{{- $_ := set $proxy "https_listen" (printf ":%v" (int $l.https.port)) -}}{{- end }}
-{{- if $l.tunnel.enabled }}{{- $_ := set $proxy "tunnel_listen" (printf ":%v" (int $l.tunnel.port)) -}}{{- end }}
-{{- if $proxy }}{{- $_ := set $over "proxy" $proxy -}}{{- end }}
-{{- if $l.metrics.enabled }}{{- $_ := set $over "metrics" (dict "listen" (printf ":%v" (int $l.metrics.port))) -}}{{- end }}
 {{- if $l.postgres.enabled }}{{- $_ := set $over "postgres" (dict "listen" (printf ":%v" (int $l.postgres.port))) -}}{{- end }}
 {{- if $l.management.enabled }}{{- $_ := set $over "management" (dict "listen" (printf ":%v" (int $l.management.port))) -}}{{- end }}
 {{- $merged := mergeOverwrite $cfg $over -}}

--- a/charts/iron-proxy/templates/configmap.yaml
+++ b/charts/iron-proxy/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.mode "standalone") (not .Values.configExistingConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "iron-proxy.fullname" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+data:
+  proxy.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}
+{{- end }}

--- a/charts/iron-proxy/templates/configmap.yaml
+++ b/charts/iron-proxy/templates/configmap.yaml
@@ -1,4 +1,22 @@
 {{- if and (eq .Values.mode "standalone") (not .Values.configExistingConfigMap) }}
+{{- /*
+Derive listen addresses from .Values.listeners and merge them into the user's
+config so the proxy binds exactly the ports the Service exposes. Listener values
+win over anything set under config (those keys are documented as ignored).
+*/}}
+{{- $l := .Values.listeners -}}
+{{- $cfg := deepCopy .Values.config -}}
+{{- $over := dict -}}
+{{- if $l.dns.enabled }}{{- $_ := set $over "dns" (dict "listen" (printf ":%v" (int $l.dns.port))) -}}{{- end }}
+{{- $proxy := dict -}}
+{{- if $l.http.enabled }}{{- $_ := set $proxy "http_listen" (printf ":%v" (int $l.http.port)) -}}{{- end }}
+{{- if $l.https.enabled }}{{- $_ := set $proxy "https_listen" (printf ":%v" (int $l.https.port)) -}}{{- end }}
+{{- if $l.tunnel.enabled }}{{- $_ := set $proxy "tunnel_listen" (printf ":%v" (int $l.tunnel.port)) -}}{{- end }}
+{{- if $proxy }}{{- $_ := set $over "proxy" $proxy -}}{{- end }}
+{{- if $l.metrics.enabled }}{{- $_ := set $over "metrics" (dict "listen" (printf ":%v" (int $l.metrics.port))) -}}{{- end }}
+{{- if $l.postgres.enabled }}{{- $_ := set $over "postgres" (dict "listen" (printf ":%v" (int $l.postgres.port))) -}}{{- end }}
+{{- if $l.management.enabled }}{{- $_ := set $over "management" (dict "listen" (printf ":%v" (int $l.management.port))) -}}{{- end }}
+{{- $merged := mergeOverwrite $cfg $over -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +25,5 @@ metadata:
     {{- include "iron-proxy.labels" . | nindent 4 }}
 data:
   proxy.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- toYaml $merged | nindent 4 }}
 {{- end }}

--- a/charts/iron-proxy/templates/deployment.yaml
+++ b/charts/iron-proxy/templates/deployment.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "iron-proxy.fullname" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "iron-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if and (eq .Values.mode "standalone") (not .Values.configExistingConfigMap) }}
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        {{- end }}
+        {{- if eq .Values.ca.mode "inline" }}
+        checksum/ca: {{ printf "%s%s" .Values.ca.cert .Values.ca.key | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "iron-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "iron-proxy.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- if eq .Values.ca.mode "generate" }}
+      initContainers:
+        - name: generate-ca
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - iron-proxy
+            - generate-ca
+            - -outdir
+            - /etc/iron-proxy/tls
+            - -name
+            - {{ .Values.ca.commonName | quote }}
+            - -alg
+            - {{ .Values.ca.algorithm | quote }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ca
+              mountPath: /etc/iron-proxy/tls
+      {{- end }}
+      containers:
+        - name: iron-proxy
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if eq .Values.mode "standalone" }}
+          args:
+            - -config
+            - /etc/iron-proxy/config/proxy.yaml
+          {{- end }}
+          env:
+            {{- if eq .Values.mode "managed" }}
+            - name: IRON_PROXY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.managed.existingTokenSecret }}
+                  name: {{ .Values.managed.existingTokenSecret }}
+                  key: {{ .Values.managed.tokenSecretKey }}
+                  {{- else }}
+                  name: {{ include "iron-proxy.tokenSecretName" . }}
+                  key: token
+                  {{- end }}
+            {{- with .Values.managed.controlPlaneURL }}
+            - name: IRON_CONTROL_PLANE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.envFrom .Values.secretEnv }}
+          envFrom:
+            {{- if .Values.secretEnv }}
+            - secretRef:
+                name: {{ include "iron-proxy.secretEnvName" . }}
+            {{- end }}
+            {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            {{- range $name, $p := .Values.service.ports }}
+            {{- if $p.enabled }}
+            - name: {{ $name }}
+              containerPort: {{ $p.targetPort }}
+              protocol: {{ $p.protocol | default "TCP" }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if eq .Values.mode "standalone" }}
+            - name: config
+              mountPath: /etc/iron-proxy/config
+              readOnly: true
+            {{- end }}
+            {{- if ne .Values.ca.mode "none" }}
+            - name: ca
+              mountPath: /etc/iron-proxy/tls
+              {{- if ne .Values.ca.mode "generate" }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if eq .Values.mode "standalone" }}
+        - name: config
+          configMap:
+            name: {{ .Values.configExistingConfigMap | default (include "iron-proxy.fullname" .) }}
+        {{- end }}
+        {{- if eq .Values.ca.mode "existingSecret" }}
+        {{- if not .Values.ca.existingSecret }}
+        {{- fail "ca.mode=existingSecret requires ca.existingSecret to be set" }}
+        {{- end }}
+        - name: ca
+          secret:
+            secretName: {{ .Values.ca.existingSecret }}
+            items:
+              - key: {{ .Values.ca.certKey }}
+                path: ca.crt
+              - key: {{ .Values.ca.keyKey }}
+                path: ca.key
+        {{- else if eq .Values.ca.mode "inline" }}
+        - name: ca
+          secret:
+            secretName: {{ include "iron-proxy.caSecretName" . }}
+        {{- else if eq .Values.ca.mode "generate" }}
+        - name: ca
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/iron-proxy/templates/deployment.yaml
+++ b/charts/iron-proxy/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
                   {{- end }}
             {{- include "iron-proxy.managedEnv" . | nindent 12 }}
             {{- end }}
+            {{- include "iron-proxy.listenerEnv" . | nindent 12 }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/iron-proxy/templates/deployment.yaml
+++ b/charts/iron-proxy/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       annotations:
         {{- if and (eq .Values.mode "standalone") (not .Values.configExistingConfigMap) }}
-        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        checksum/config: {{ printf "%s%s" (toYaml .Values.config) (toYaml .Values.listeners) | sha256sum }}
         {{- end }}
         {{- if eq .Values.ca.mode "inline" }}
         checksum/ca: {{ printf "%s%s" .Values.ca.cert .Values.ca.key | sha256sum }}
@@ -61,10 +61,7 @@ spec:
                   name: {{ include "iron-proxy.tokenSecretName" . }}
                   key: token
                   {{- end }}
-            {{- with .Values.managed.controlPlaneURL }}
-            - name: IRON_CONTROL_PLANE_URL
-              value: {{ . | quote }}
-            {{- end }}
+            {{- include "iron-proxy.managedEnv" . | nindent 12 }}
             {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
@@ -80,11 +77,11 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            {{- range $name, $p := .Values.service.ports }}
-            {{- if $p.enabled }}
+            {{- range $name, $l := .Values.listeners }}
+            {{- if $l.enabled }}
             - name: {{ $name }}
-              containerPort: {{ $p.targetPort }}
-              protocol: {{ $p.protocol | default "TCP" }}
+              containerPort: {{ $l.port }}
+              protocol: {{ $l.protocol | default "TCP" }}
             {{- end }}
             {{- end }}
           {{- with .Values.livenessProbe }}

--- a/charts/iron-proxy/templates/deployment.yaml
+++ b/charts/iron-proxy/templates/deployment.yaml
@@ -40,28 +40,6 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- if eq .Values.ca.mode "generate" }}
-      initContainers:
-        - name: generate-ca
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - iron-proxy
-            - generate-ca
-            - -outdir
-            - /etc/iron-proxy/tls
-            - -name
-            - {{ .Values.ca.commonName | quote }}
-            - -alg
-            - {{ .Values.ca.algorithm | quote }}
-          {{- with .Values.securityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: ca
-              mountPath: /etc/iron-proxy/tls
-      {{- end }}
       containers:
         - name: iron-proxy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -134,9 +112,7 @@ spec:
             {{- if ne .Values.ca.mode "none" }}
             - name: ca
               mountPath: /etc/iron-proxy/tls
-              {{- if ne .Values.ca.mode "generate" }}
               readOnly: true
-              {{- end }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -163,9 +139,6 @@ spec:
         - name: ca
           secret:
             secretName: {{ include "iron-proxy.caSecretName" . }}
-        {{- else if eq .Values.ca.mode "generate" }}
-        - name: ca
-          emptyDir: {}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/iron-proxy/templates/secret-ca.yaml
+++ b/charts/iron-proxy/templates/secret-ca.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.ca.mode "inline" }}
+{{- if or (not .Values.ca.cert) (not .Values.ca.key) }}
+{{- fail "ca.mode=inline requires both ca.cert and ca.key" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "iron-proxy.caSecretName" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ca.crt: |
+    {{- .Values.ca.cert | nindent 4 }}
+  ca.key: |
+    {{- .Values.ca.key | nindent 4 }}
+{{- end }}

--- a/charts/iron-proxy/templates/secret-env.yaml
+++ b/charts/iron-proxy/templates/secret-env.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "iron-proxy.secretEnvName" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $k, $v := .Values.secretEnv }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/iron-proxy/templates/secret-token.yaml
+++ b/charts/iron-proxy/templates/secret-token.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.mode "managed") .Values.managed.token (not .Values.managed.existingTokenSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "iron-proxy.tokenSecretName" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.managed.token | quote }}
+{{- end }}

--- a/charts/iron-proxy/templates/service.yaml
+++ b/charts/iron-proxy/templates/service.yaml
@@ -19,11 +19,11 @@ spec:
   selector:
     {{- include "iron-proxy.selectorLabels" . | nindent 4 }}
   ports:
-    {{- range $name, $p := .Values.service.ports }}
-    {{- if $p.enabled }}
+    {{- range $name, $l := .Values.listeners }}
+    {{- if $l.enabled }}
     - name: {{ $name }}
-      port: {{ $p.port }}
-      targetPort: {{ $p.targetPort }}
-      protocol: {{ $p.protocol | default "TCP" }}
+      port: {{ $l.port }}
+      targetPort: {{ $l.port }}
+      protocol: {{ $l.protocol | default "TCP" }}
     {{- end }}
     {{- end }}

--- a/charts/iron-proxy/templates/service.yaml
+++ b/charts/iron-proxy/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "iron-proxy.fullname" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  selector:
+    {{- include "iron-proxy.selectorLabels" . | nindent 4 }}
+  ports:
+    {{- range $name, $p := .Values.service.ports }}
+    {{- if $p.enabled }}
+    - name: {{ $name }}
+      port: {{ $p.port }}
+      targetPort: {{ $p.targetPort }}
+      protocol: {{ $p.protocol | default "TCP" }}
+    {{- end }}
+    {{- end }}

--- a/charts/iron-proxy/templates/serviceaccount.yaml
+++ b/charts/iron-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "iron-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/iron-proxy/templates/servicemonitor.yaml
+++ b/charts/iron-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if not .Values.service.ports.metrics.enabled }}
+{{- fail "metrics.serviceMonitor.enabled requires service.ports.metrics.enabled" }}
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "iron-proxy.fullname" . }}
+  labels:
+    {{- include "iron-proxy.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "iron-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.metrics.serviceMonitor.path }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/iron-proxy/templates/servicemonitor.yaml
+++ b/charts/iron-proxy/templates/servicemonitor.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.metrics.serviceMonitor.enabled }}
-{{- if not .Values.service.ports.metrics.enabled }}
-{{- fail "metrics.serviceMonitor.enabled requires service.ports.metrics.enabled" }}
+{{- if not .Values.listeners.metrics.enabled }}
+{{- fail "metrics.serviceMonitor.enabled requires listeners.metrics.enabled" }}
 {{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/iron-proxy/values.yaml
+++ b/charts/iron-proxy/values.yaml
@@ -1,0 +1,265 @@
+# Default values for iron-proxy.
+# This is a YAML-formatted file. Declare variables to be passed into the templates.
+
+# -- Number of proxy replicas. iron-proxy intercepts DNS and answers with a single
+# proxy_ip, so clients reach one logical endpoint. Scaling beyond 1 requires a shared
+# Service IP (ClusterIP/LoadBalancer) and stateless config; see the chart README.
+replicaCount: 1
+
+image:
+  # -- Container image repository.
+  repository: ironsh/iron-proxy
+  # -- Image tag. Defaults to the chart's appVersion when empty. Pin a released
+  # version (e.g. "v1.2.3") for production rather than relying on "latest".
+  tag: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+
+# -- Override the chart name used in resource names.
+nameOverride: ""
+# -- Override the full release name used in resource names.
+fullnameOverride: ""
+
+# -- Run mode: "standalone" (config from a rendered ConfigMap, the default) or
+# "managed" (control-plane token; no config file is used).
+mode: standalone
+
+# -- iron-proxy YAML config, rendered verbatim into a ConfigMap as proxy.yaml and
+# passed via -config in standalone mode. Keys mirror iron-proxy.example.yaml exactly.
+# Edit dns.proxy_ip to the address clients use to reach this proxy (typically the
+# Service ClusterIP or LoadBalancer IP) and add your transforms/secrets.
+config:
+  dns:
+    listen: ":53"
+    # IMPORTANT: the IP returned for intercepted DNS queries. Must be the address
+    # clients reach iron-proxy on (this chart's Service IP). Update before use.
+    proxy_ip: "10.0.0.1"
+    passthrough: []
+  proxy:
+    http_listen: ":80"
+    https_listen: ":443"
+  tls:
+    # "mitm" (terminates TLS, needs a CA) or "sni-only" (no CA needed; set ca.mode=none).
+    mode: "mitm"
+    ca_cert: "/etc/iron-proxy/tls/ca.crt"
+    ca_key: "/etc/iron-proxy/tls/ca.key"
+  transforms:
+    - name: allowlist
+      config:
+        domains:
+          - "api.openai.com"
+          - "api.anthropic.com"
+  log:
+    level: "info"
+
+# -- Use a pre-existing ConfigMap (with a proxy.yaml key) instead of rendering
+# .Values.config. When set, .Values.config is ignored. Standalone mode only.
+configExistingConfigMap: ""
+
+# Managed mode settings (used only when mode=managed).
+managed:
+  # -- Control-plane bearer token. When set, rendered into a chart-managed Secret
+  # and exposed as IRON_PROXY_TOKEN. Prefer existingTokenSecret for real secrets.
+  token: ""
+  # -- Reference an existing Secret holding the control-plane token instead of
+  # supplying it inline.
+  existingTokenSecret: ""
+  # -- Key within existingTokenSecret holding the token.
+  tokenSecretKey: "token"
+  # -- Override the control plane URL (sets IRON_CONTROL_PLANE_URL). Empty uses
+  # the binary default (https://api.iron.sh).
+  controlPlaneURL: ""
+
+# MITM CA certificate/key handling. iron-proxy needs a CA in mitm mode to mint
+# leaf certs; sni-only mode needs none (use mode: none).
+ca:
+  # -- One of: generate | existingSecret | inline | none.
+  #   generate:       an initContainer generates an ephemeral CA per pod start.
+  #                   Works with zero config but the CA changes on every restart,
+  #                   so clients cannot pin trust. Switch to existingSecret/inline
+  #                   for production.
+  #   existingSecret: mount a Secret you created (e.g. via `iron-proxy generate-ca`).
+  #   inline:         supply ca.cert/ca.key PEM below; the chart creates the Secret.
+  #   none:           mount nothing (sni-only mode, or config points elsewhere).
+  mode: generate
+  # existingSecret mode:
+  # -- Name of the existing Secret holding the CA cert and key.
+  existingSecret: ""
+  # -- Key in the Secret holding the CA certificate (mounted as ca.crt).
+  certKey: "ca.crt"
+  # -- Key in the Secret holding the CA private key (mounted as ca.key).
+  keyKey: "ca.key"
+  # inline mode:
+  # -- PEM-encoded CA certificate.
+  cert: ""
+  # -- PEM-encoded CA private key.
+  key: ""
+  # generate mode:
+  # -- Common name for the generated CA.
+  commonName: "iron-proxy CA"
+  # -- Key algorithm for the generated CA: rsa4096 or ed25519.
+  algorithm: "rsa4096"
+
+# -- Extra environment variables (e.g. secret-backend credentials referenced from
+# config: OPENAI_API_KEY, OP_SERVICE_ACCOUNT_TOKEN, AWS_*). Standard core/v1 EnvVar list.
+env: []
+#  - name: OPENAI_API_KEY
+#    valueFrom:
+#      secretKeyRef:
+#        name: my-api-keys
+#        key: openai
+
+# -- Pull whole environments from existing Secrets/ConfigMaps. Standard envFrom list.
+envFrom: []
+#  - secretRef:
+#      name: my-api-keys
+
+# -- Inline key/value pairs rendered into a chart-managed Secret and exposed via
+# envFrom. Convenient for demos; prefer env/envFrom with your own Secrets in prod.
+secretEnv: {}
+#  OPENAI_API_KEY: sk-...
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Static cluster IP. Set so it can be used as dns.proxy_ip.
+  clusterIP: ""
+  # -- Static LoadBalancer IP (when type is LoadBalancer).
+  loadBalancerIP: ""
+  # -- Annotations for the Service.
+  annotations: {}
+  # Listener ports. Only entries with enabled=true are exposed on the Service and
+  # the container. targetPort must match the listen port set in .Values.config.
+  ports:
+    dns:
+      enabled: true
+      port: 53
+      targetPort: 53
+      protocol: UDP
+    http:
+      enabled: true
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    https:
+      enabled: true
+      port: 443
+      targetPort: 443
+      protocol: TCP
+    metrics:
+      enabled: true
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+    tunnel:
+      enabled: false
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    postgres:
+      enabled: false
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+    management:
+      enabled: false
+      port: 9092
+      targetPort: 9092
+      protocol: TCP
+
+# -- Liveness probe. Defaults to GET /healthz on the metrics port.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: metrics
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+# -- Readiness probe. Defaults to GET /healthz on the metrics port.
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: metrics
+  initialDelaySeconds: 2
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+serviceAccount:
+  # -- Create a ServiceAccount.
+  create: true
+  # -- Name of the ServiceAccount. Generated from the fullname when empty.
+  name: ""
+  # -- Annotations (e.g. EKS IRSA / GKE Workload Identity for the workload_identity
+  # secret providers).
+  annotations: {}
+  # -- Automount the API token.
+  automountServiceAccountToken: false
+
+# -- Pod-level security context.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context. NET_BIND_SERVICE lets the proxy bind the
+# privileged ports 53/80/443 as non-root. If your policy forbids it, move the
+# listeners in .Values.config to ports >=1024 and remap via service.ports.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
+
+# -- Seconds to wait for graceful shutdown. iron-proxy uses a 10s shutdown window.
+terminationGracePeriodSeconds: 30
+
+# -- Resource requests/limits.
+resources: {}
+#  limits:
+#    cpu: 500m
+#    memory: 256Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+# -- Pod annotations.
+podAnnotations: {}
+# -- Pod labels.
+podLabels: {}
+# -- Node selector.
+nodeSelector: {}
+# -- Tolerations.
+tolerations: []
+# -- Affinity.
+affinity: {}
+# -- Topology spread constraints.
+topologySpreadConstraints: []
+# -- Priority class name.
+priorityClassName: ""
+
+# -- Extra volumes (e.g. for file-based secret sources, gRPC TLS certs, GCP keyfiles).
+extraVolumes: []
+# -- Extra volume mounts matching extraVolumes.
+extraVolumeMounts: []
+
+metrics:
+  serviceMonitor:
+    # -- Create a Prometheus Operator ServiceMonitor scraping the metrics port.
+    enabled: false
+    # -- Extra labels for the ServiceMonitor (e.g. to match a Prometheus selector).
+    labels: {}
+    # -- Scrape interval.
+    interval: 30s
+    # -- Metrics path.
+    path: /metrics

--- a/charts/iron-proxy/values.yaml
+++ b/charts/iron-proxy/values.yaml
@@ -32,10 +32,11 @@ mode: standalone
 # Edit dns.proxy_ip to the address clients use to reach this proxy (typically the
 # Service ClusterIP or LoadBalancer IP) and add your transforms/secrets.
 #
-# NOTE: listen addresses (dns.listen, proxy.http_listen/https_listen/tunnel_listen,
-# metrics.listen, postgres.listen, management.listen) are NOT set here. They are
-# derived from .Values.listeners and merged in at render time so the Service ports
-# and the proxy's binds can never drift. Setting them here has no effect.
+# NOTE: listen addresses are NOT set here. The core listeners (dns/http/https/
+# tunnel/metrics) are injected as IRON_*_LISTEN env vars from .Values.listeners
+# (which also override any file value), and postgres/management listen addresses
+# are merged in from .Values.listeners at render time. This keeps .Values.listeners
+# the single source of truth for ports; setting listen addresses here has no effect.
 config:
   dns:
     # IMPORTANT: the IP returned for intercepted DNS queries. Must be the address
@@ -134,13 +135,16 @@ secretEnv: {}
 #  OPENAI_API_KEY: sk-...
 
 # Listeners are the single source of truth for ports. Each enabled listener is
-# bound by the proxy, exposed on the container, and exposed on the Service — and
-# the bind address (":<port>") is fed into the config (standalone) or the matching
-# IRON_*_LISTEN env var (managed), so the Service and the proxy can never disagree.
+# bound by the proxy, exposed on the container, and exposed on the Service. The
+# bind address (":<port>") is fed to the proxy via the matching IRON_*_LISTEN env
+# var (dns/http/https/tunnel/metrics, in both modes) or merged into the config
+# (postgres/management), so the Service and the proxy can never disagree.
 #
 # dns/http/https/metrics are core and enabled by default; tunnel/postgres/management
 # are optional. Disabling a listener removes it from the Service and container ports.
-# (management has no env override and is incompatible with managed mode.)
+# Disabling dns additionally turns off the DNS server entirely (IRON_DNS_ENABLED=false)
+# — use this when clients reach the proxy via explicit HTTP(S)_PROXY settings rather
+# than DNS interception. (management has no env override and is standalone-only.)
 listeners:
   dns:
     enabled: true

--- a/charts/iron-proxy/values.yaml
+++ b/charts/iron-proxy/values.yaml
@@ -31,16 +31,17 @@ mode: standalone
 # passed via -config in standalone mode. Keys mirror iron-proxy.example.yaml exactly.
 # Edit dns.proxy_ip to the address clients use to reach this proxy (typically the
 # Service ClusterIP or LoadBalancer IP) and add your transforms/secrets.
+#
+# NOTE: listen addresses (dns.listen, proxy.http_listen/https_listen/tunnel_listen,
+# metrics.listen, postgres.listen, management.listen) are NOT set here. They are
+# derived from .Values.listeners and merged in at render time so the Service ports
+# and the proxy's binds can never drift. Setting them here has no effect.
 config:
   dns:
-    listen: ":53"
     # IMPORTANT: the IP returned for intercepted DNS queries. Must be the address
     # clients reach iron-proxy on (this chart's Service IP). Update before use.
     proxy_ip: "10.0.0.1"
     passthrough: []
-  proxy:
-    http_listen: ":80"
-    https_listen: ":443"
   tls:
     # "mitm" (terminates TLS, needs a CA) or "sni-only" (no CA needed; set ca.mode=none).
     mode: "mitm"
@@ -60,6 +61,13 @@ config:
 configExistingConfigMap: ""
 
 # Managed mode settings (used only when mode=managed).
+#
+# In managed mode there is no config file: the control plane supplies transforms,
+# secrets, and MCP/postgres routes, while everything else comes from IRON_* env
+# vars. The fields below render those env vars for you; anything not covered can
+# still be set via .Values.env. Listen addresses come from .Values.listeners
+# (rendered as IRON_*_LISTEN), and IRON_TLS_CA_CERT/KEY are derived from the CA
+# mount automatically when ca.mode is not "none".
 managed:
   # -- Control-plane bearer token. When set, rendered into a chart-managed Secret
   # and exposed as IRON_PROXY_TOKEN. Prefer existingTokenSecret for real secrets.
@@ -72,6 +80,16 @@ managed:
   # -- Override the control plane URL (sets IRON_CONTROL_PLANE_URL). Empty uses
   # the binary default (https://api.iron.sh).
   controlPlaneURL: ""
+  # -- REQUIRED in managed mode: IP returned for intercepted DNS queries
+  # (IRON_DNS_PROXY_IP). Same meaning as config.dns.proxy_ip in standalone mode.
+  proxyIP: ""
+  # -- TLS mode (IRON_TLS_MODE): "mitm" or "sni-only". Empty uses the binary
+  # default (mitm). Set to "sni-only" when ca.mode=none.
+  tlsMode: ""
+  # -- Log level (IRON_LOG_LEVEL): debug, info, warn, error. Empty uses default.
+  logLevel: ""
+  # -- Upstream DNS resolver for the proxy's own lookups (IRON_DNS_UPSTREAM_RESOLVER).
+  upstreamResolver: ""
 
 # MITM CA certificate/key handling. iron-proxy needs a CA in mitm mode to mint
 # leaf certs; sni-only mode needs none (use mode: none).
@@ -115,6 +133,44 @@ envFrom: []
 secretEnv: {}
 #  OPENAI_API_KEY: sk-...
 
+# Listeners are the single source of truth for ports. Each enabled listener is
+# bound by the proxy, exposed on the container, and exposed on the Service — and
+# the bind address (":<port>") is fed into the config (standalone) or the matching
+# IRON_*_LISTEN env var (managed), so the Service and the proxy can never disagree.
+#
+# dns/http/https/metrics are core and enabled by default; tunnel/postgres/management
+# are optional. Disabling a listener removes it from the Service and container ports.
+# (management has no env override and is incompatible with managed mode.)
+listeners:
+  dns:
+    enabled: true
+    port: 53
+    protocol: UDP
+  http:
+    enabled: true
+    port: 80
+    protocol: TCP
+  https:
+    enabled: true
+    port: 443
+    protocol: TCP
+  metrics:
+    enabled: true
+    port: 9090
+    protocol: TCP
+  tunnel:
+    enabled: false
+    port: 8080
+    protocol: TCP
+  postgres:
+    enabled: false
+    port: 5432
+    protocol: TCP
+  management:
+    enabled: false
+    port: 9092
+    protocol: TCP
+
 service:
   # -- Service type.
   type: ClusterIP
@@ -124,44 +180,6 @@ service:
   loadBalancerIP: ""
   # -- Annotations for the Service.
   annotations: {}
-  # Listener ports. Only entries with enabled=true are exposed on the Service and
-  # the container. targetPort must match the listen port set in .Values.config.
-  ports:
-    dns:
-      enabled: true
-      port: 53
-      targetPort: 53
-      protocol: UDP
-    http:
-      enabled: true
-      port: 80
-      targetPort: 80
-      protocol: TCP
-    https:
-      enabled: true
-      port: 443
-      targetPort: 443
-      protocol: TCP
-    metrics:
-      enabled: true
-      port: 9090
-      targetPort: 9090
-      protocol: TCP
-    tunnel:
-      enabled: false
-      port: 8080
-      targetPort: 8080
-      protocol: TCP
-    postgres:
-      enabled: false
-      port: 5432
-      targetPort: 5432
-      protocol: TCP
-    management:
-      enabled: false
-      port: 9092
-      targetPort: 9092
-      protocol: TCP
 
 # -- Liveness probe. Defaults to GET /healthz on the metrics port.
 livenessProbe:
@@ -204,7 +222,7 @@ podSecurityContext:
 
 # -- Container-level security context. NET_BIND_SERVICE lets the proxy bind the
 # privileged ports 53/80/443 as non-root. If your policy forbids it, move the
-# listeners in .Values.config to ports >=1024 and remap via service.ports.
+# listeners to ports >=1024 via .Values.listeners.*.port.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/charts/iron-proxy/values.yaml
+++ b/charts/iron-proxy/values.yaml
@@ -76,15 +76,13 @@ managed:
 # MITM CA certificate/key handling. iron-proxy needs a CA in mitm mode to mint
 # leaf certs; sni-only mode needs none (use mode: none).
 ca:
-  # -- One of: generate | existingSecret | inline | none.
-  #   generate:       an initContainer generates an ephemeral CA per pod start.
-  #                   Works with zero config but the CA changes on every restart,
-  #                   so clients cannot pin trust. Switch to existingSecret/inline
-  #                   for production.
+  # -- One of: existingSecret | inline | none.
   #   existingSecret: mount a Secret you created (e.g. via `iron-proxy generate-ca`).
   #   inline:         supply ca.cert/ca.key PEM below; the chart creates the Secret.
   #   none:           mount nothing (sni-only mode, or config points elsewhere).
-  mode: generate
+  # Generate a stable CA once with `iron-proxy generate-ca` and store it in a
+  # Secret; do not regenerate it per pod, or clients lose trust on every restart.
+  mode: existingSecret
   # existingSecret mode:
   # -- Name of the existing Secret holding the CA cert and key.
   existingSecret: ""
@@ -97,11 +95,6 @@ ca:
   cert: ""
   # -- PEM-encoded CA private key.
   key: ""
-  # generate mode:
-  # -- Common name for the generated CA.
-  commonName: "iron-proxy CA"
-  # -- Key algorithm for the generated CA: rsa4096 or ed25519.
-  algorithm: "rsa4096"
 
 # -- Extra environment variables (e.g. secret-backend credentials referenced from
 # config: OPENAI_API_KEY, OP_SERVICE_ACCOUNT_TOKEN, AWS_*). Standard core/v1 EnvVar list.


### PR DESCRIPTION
Adds a Helm chart under `charts/iron-proxy` so iron-proxy can be installed with `helm install`. It supports both standalone (config rendered into a ConfigMap) and managed (control-plane token) run modes, all four CA strategies (generate/existingSecret/inline/none), per-listener Service ports, and flexible secret-backend credential injection via env/envFrom/inline secrets. Defaults to a zero-config working install (`ca.mode: generate`); README documents switching to a stable CA for production.

Verified with `helm lint` and `helm template` across all modes.