### PR TITLE
feat(dns): allow disabling the built-in DNS server

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -183,11 +183,16 @@ func main() {
 		logger.Info("using upstream resolver", slog.String("addr", cfg.DNS.UpstreamResolver))
 	}
 
-	// Initialize DNS server.
-	dnsServer, err := idns.New(cfg.DNS, resolver, logger)
-	if err != nil {
-		logger.Error("initializing DNS server", slog.String("error", err.Error()))
-		os.Exit(1)
+	// Initialize DNS server unless disabled. When off, clients are expected to
+	// reach the proxy via explicit HTTP(S)_PROXY settings rather than DNS
+	// interception.
+	var dnsServer *idns.Server
+	if cfg.DNS.IsEnabled() {
+		dnsServer, err = idns.New(cfg.DNS, resolver, logger)
+		if err != nil {
+			logger.Error("initializing DNS server", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
 	}
 
 	// Build the upstream-dial deny guard. config.Validate has already
@@ -235,7 +240,9 @@ func main() {
 	}
 
 	// Start services.
-	go func() { errc <- fmt.Errorf("dns: %w", dnsServer.ListenAndServe()) }()
+	if dnsServer != nil {
+		go func() { errc <- fmt.Errorf("dns: %w", dnsServer.ListenAndServe()) }()
+	}
 	go func() { errc <- fmt.Errorf("proxy: %w", p.ListenAndServe()) }()
 	go func() { errc <- fmt.Errorf("metrics: %w", metricsServer.ListenAndServe()) }()
 	if mgmtServer != nil {
@@ -243,8 +250,12 @@ func main() {
 	}
 	pgManager.Start(pgListener, errc)
 
+	dnsListen := "disabled"
+	if cfg.DNS.IsEnabled() {
+		dnsListen = cfg.DNS.Listen
+	}
 	startAttrs := []any{
-		slog.String("dns_listen", cfg.DNS.Listen),
+		slog.String("dns_listen", dnsListen),
 		slog.String("http_listen", cfg.Proxy.HTTPListen),
 		slog.String("https_listen", cfg.Proxy.HTTPSListen),
 		slog.String("metrics_listen", cfg.Metrics.Listen),
@@ -279,8 +290,10 @@ func main() {
 			logger.Error("shutting down OTEL log provider", slog.String("error", err.Error()))
 		}
 	}
-	if err := dnsServer.Shutdown(shutdownCtx); err != nil {
-		logger.Error("dns shutdown error", slog.String("error", err.Error()))
+	if dnsServer != nil {
+		if err := dnsServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("dns shutdown error", slog.String("error", err.Error()))
+		}
 	}
 	if err := p.Shutdown(shutdownCtx); err != nil {
 		logger.Error("proxy shutdown error", slog.String("error", err.Error()))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,11 +59,24 @@ type Config struct {
 
 // DNS configures the built-in DNS server.
 type DNS struct {
+	// Enabled controls whether the built-in DNS server runs. A nil pointer
+	// (the field omitted) defaults to true, preserving historical behavior.
+	// Set it to false (or IRON_DNS_ENABLED=false) to disable DNS interception
+	// entirely — useful when clients reach the proxy via explicit
+	// HTTP(S)_PROXY settings rather than DNS redirection. When disabled,
+	// proxy_ip is not required.
+	Enabled          *bool       `yaml:"enabled"`
 	Listen           string      `yaml:"listen"`
 	ProxyIP          string      `yaml:"proxy_ip"`
 	UpstreamResolver string      `yaml:"upstream_resolver"`
 	Passthrough      []string    `yaml:"passthrough"`
 	Records          []DNSRecord `yaml:"records"`
+}
+
+// IsEnabled reports whether the DNS server should run. DNS is on unless
+// explicitly disabled.
+func (d DNS) IsEnabled() bool {
+	return d.Enabled == nil || *d.Enabled
 }
 
 // DNSRecord is a static DNS record entry.
@@ -209,7 +222,7 @@ func parse(r io.Reader) (*Config, error) {
 }
 
 func applyDefaults(cfg *Config) {
-	if cfg.DNS.Listen == "" {
+	if cfg.DNS.IsEnabled() && cfg.DNS.Listen == "" {
 		cfg.DNS.Listen = ":53"
 	}
 	if cfg.Proxy.HTTPListen == "" {
@@ -251,7 +264,7 @@ func applyDefaults(cfg *Config) {
 
 // Validate checks required fields and value constraints.
 func Validate(cfg *Config) error {
-	if cfg.DNS.ProxyIP == "" {
+	if cfg.DNS.IsEnabled() && cfg.DNS.ProxyIP == "" {
 		return fmt.Errorf("dns.proxy_ip is required")
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -239,6 +239,48 @@ transforms:
 	require.Equal(t, []string{"10.0.0.0/8"}, allowCfg.CIDRs)
 }
 
+func TestLoad_DNSDisabled(t *testing.T) {
+	t.Run("disabled skips proxy_ip requirement and listen default", func(t *testing.T) {
+		yaml := `
+dns:
+  enabled: false
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.DNS.Enabled)
+		require.False(t, cfg.DNS.IsEnabled())
+		require.Equal(t, "", cfg.DNS.Listen)
+	})
+
+	t.Run("enabled by default still requires proxy_ip", func(t *testing.T) {
+		yaml := `
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		_, err := Load(strings.NewReader(yaml))
+		require.ErrorContains(t, err, "dns.proxy_ip is required")
+	})
+
+	t.Run("explicitly enabled gets listen default", func(t *testing.T) {
+		yaml := `
+dns:
+  enabled: true
+  proxy_ip: "10.0.0.1"
+tls:
+  ca_cert: "/tmp/ca.crt"
+  ca_key: "/tmp/ca.key"
+`
+		cfg, err := Load(strings.NewReader(yaml))
+		require.NoError(t, err)
+		require.True(t, cfg.DNS.IsEnabled())
+		require.Equal(t, ":53", cfg.DNS.Listen)
+	})
+}
+
 func TestLoad_SNIOnlyMode(t *testing.T) {
 	t.Run("ca cert not required", func(t *testing.T) {
 		yaml := `

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -10,6 +10,13 @@ import (
 // applyEnvOverrides layers IRON_* environment variables on top of an existing
 // Config. Only non-empty environment variables override the corresponding field.
 func applyEnvOverrides(cfg *Config) error {
+	if v := os.Getenv("IRON_DNS_ENABLED"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("IRON_DNS_ENABLED: %w", err)
+		}
+		cfg.DNS.Enabled = &b
+	}
 	if v := os.Getenv("IRON_DNS_LISTEN"); v != "" {
 		cfg.DNS.Listen = v
 	}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -264,6 +264,61 @@ func TestApplyEnvOverrides_UpstreamResponseHeaderTimeout(t *testing.T) {
 	})
 }
 
+func TestApplyEnvOverrides_DNSEnabled(t *testing.T) {
+	t.Run("false disables dns", func(t *testing.T) {
+		setEnvs(t, map[string]string{"IRON_DNS_ENABLED": "false"})
+
+		var cfg Config
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.NotNil(t, cfg.DNS.Enabled)
+		require.False(t, cfg.DNS.IsEnabled())
+	})
+
+	t.Run("true enables dns", func(t *testing.T) {
+		setEnvs(t, map[string]string{"IRON_DNS_ENABLED": "true"})
+
+		var cfg Config
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.NotNil(t, cfg.DNS.Enabled)
+		require.True(t, cfg.DNS.IsEnabled())
+	})
+
+	t.Run("unset defaults to enabled", func(t *testing.T) {
+		setEnvs(t, map[string]string{})
+
+		var cfg Config
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.Nil(t, cfg.DNS.Enabled)
+		require.True(t, cfg.DNS.IsEnabled())
+	})
+
+	t.Run("invalid bool rejected", func(t *testing.T) {
+		setEnvs(t, map[string]string{"IRON_DNS_ENABLED": "maybe"})
+
+		var cfg Config
+		err := applyEnvOverrides(&cfg)
+		require.ErrorContains(t, err, "IRON_DNS_ENABLED")
+	})
+}
+
+// TestLoadConfig_DNSDisabled_NoListenDefault_NoProxyIPRequired verifies that
+// disabling DNS via env skips the :53 listen default and lifts the proxy_ip
+// requirement, so a DNS-less proxy can be configured entirely from env vars.
+func TestLoadConfig_DNSDisabled_NoListenDefault_NoProxyIPRequired(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"IRON_DNS_ENABLED": "false",
+		"IRON_TLS_CA_CERT": "/ca.pem",
+		"IRON_TLS_CA_KEY":  "/ca-key.pem",
+	})
+
+	cfg, err := LoadConfig("")
+	require.NoError(t, err)
+	require.False(t, cfg.DNS.IsEnabled())
+	require.Equal(t, "", cfg.DNS.Listen)
+	require.Equal(t, "", cfg.DNS.ProxyIP)
+	require.NoError(t, Validate(cfg))
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
@@ -276,6 +331,7 @@ func setEnvs(t *testing.T, envs map[string]string) {
 
 	// Clear all IRON_* env vars to prevent cross-test leakage.
 	ironKeys := []string{
+		"IRON_DNS_ENABLED",
 		"IRON_DNS_LISTEN",
 		"IRON_DNS_PROXY_IP",
 		"IRON_DNS_UPSTREAM_RESOLVER",

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -2,6 +2,11 @@
 
 # DNS server configuration
 dns:
+  # Whether the built-in DNS server runs. Defaults to true when omitted. Set to
+  # false (or IRON_DNS_ENABLED=false) to disable DNS interception entirely — useful
+  # when clients reach the proxy via explicit HTTP(S)_PROXY settings instead of DNS
+  # redirection. When disabled, proxy_ip is not required.
+  # enabled: true
   listen: ":53"
   # The IP address returned for intercepted DNS queries.
   # Should be the IP where iron-proxy is running.


### PR DESCRIPTION
Adds `dns.enabled` (and the `IRON_DNS_ENABLED` env override), defaulting to true so existing behavior is unchanged. Setting it to false skips the `:53` listen default and the `dns.proxy_ip` requirement and does not start the DNS server, so iron-proxy can run for clients that reach it via explicit `HTTP(S)_PROXY` settings rather than DNS interception.

Split out from the Helm chart PR (#185); the chart's `listeners.dns.enabled=false` toggle depends on this.