### PR TITLE
feat(postgres): inject and pin per-upstream session settings

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -513,7 +513,7 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 	synced := make([]*postgres.Upstream, 0, len(entries))
 	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.Role)
+		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.Role, e.Settings)
 		if err != nil {
 			logger.Error("skipping synced postgres upstream: invalid upstream",
 				slog.String("foreign_id", e.ForeignID),

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -36,7 +36,7 @@ func discardLogger() *slog.Logger {
 // client credential) for conflict/passthrough tests.
 func localListener(t *testing.T, database string) *postgres.Listener {
 	t.Helper()
-	u, err := postgres.NewManagedUpstream(database, staticSource{name: "local", value: "host=local"}, "")
+	u, err := postgres.NewManagedUpstream(database, staticSource{name: "local", value: "host=local"}, "", nil)
 	require.NoError(t, err)
 	l, err := postgres.NewListener("127.0.0.1:0", "u", "p", []*postgres.Upstream{u})
 	require.NoError(t, err)

--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -316,6 +316,45 @@ func TestPostgresPolicy(t *testing.T) {
 		require.Len(t, results, 1)
 	})
 
+	t.Run("session setting is injected at session start", func(t *testing.T) {
+		// The proxy applied SET via set_config for app.tenant_label during the
+		// handshake, so the client's first query already sees the value.
+		conn := dial(t, pgClientPassword)
+		results, err := conn.Exec(context.Background(), "SELECT current_setting('app.tenant_label')").ReadAll()
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Len(t, results[0].Rows, 1)
+		require.Equal(t, "centaur", string(results[0].Rows[0][0]))
+	})
+
+	t.Run("client cannot override a pinned setting", func(t *testing.T) {
+		conn := dial(t, pgClientPassword)
+		currentLabel := func() string {
+			results, err := conn.Exec(context.Background(), "SELECT current_setting('app.tenant_label')").ReadAll()
+			require.NoError(t, err)
+			return string(results[0].Rows[0][0])
+		}
+
+		// Direct SET, the set_config bypass, RESET, and RESET ALL are all
+		// blocked, and none of them perturbs the injected value.
+		for _, sql := range []string{
+			"SET app.tenant_label = 'evil'",
+			"SELECT set_config('app.tenant_label', 'evil', false)",
+			"RESET app.tenant_label",
+			"RESET ALL",
+			"DISCARD ALL",
+		} {
+			err := exec(t, conn, sql)
+			require.Errorf(t, err, "expected %q to be rejected", sql)
+			var pgErr *pgconn.PgError
+			require.Truef(t, errors.As(err, &pgErr), "want PgError for %q, got %T: %v", sql, err, err)
+			require.Equalf(t, "42501", pgErr.Code, "reject code for %q", sql)
+			require.Equal(t, "centaur", currentLabel(), "injected setting must survive %q", sql)
+		}
+		// Role is also still intact after the blocked statements.
+		require.Equal(t, pgRole, currentRole(t, conn))
+	})
+
 	t.Run("do block is rejected", func(t *testing.T) {
 		conn := dial(t, pgClientPassword)
 		err := exec(t, conn, "DO $$ BEGIN PERFORM 1; END $$")

--- a/integration_test/testdata/postgres_pipeline.yaml
+++ b/integration_test/testdata/postgres_pipeline.yaml
@@ -22,6 +22,9 @@ postgres:
         type: env
         var: PG_UPSTREAM_DSN
       role: tenant_role
+      settings:
+        - name: app.tenant_label
+          value: centaur
 
 metrics:
   listen: "127.0.0.1:0"

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -7,6 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -132,6 +133,9 @@ type PostgresSyncEntry struct {
 	Database string
 	DSN      secrets.Source
 	Role     string
+	// Settings are the pinned session variables the proxy SETs at session start
+	// for this upstream. Optional; nil when the control plane sends none.
+	Settings []postgres.Setting
 }
 
 // PostgresFromSync parses the top-level postgres: array from the control
@@ -160,6 +164,10 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 			Database  string          `json:"database"`
 			DSN       json.RawMessage `json:"dsn"`
 			Role      string          `json:"role"`
+			Settings  []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"settings"`
 		}
 		if err := json.Unmarshal(re, &e); err != nil {
 			return nil, fmt.Errorf("parsing postgres[%d]: %w", i, err)
@@ -181,11 +189,19 @@ func PostgresFromSync(raw json.RawMessage, logger *slog.Logger) ([]PostgresSyncE
 		if err != nil {
 			return nil, fmt.Errorf("postgres[%q]: building dsn source: %w", e.ForeignID, err)
 		}
+		var settings []postgres.Setting
+		if len(e.Settings) > 0 {
+			settings = make([]postgres.Setting, len(e.Settings))
+			for j, s := range e.Settings {
+				settings[j] = postgres.Setting{Name: s.Name, Value: s.Value}
+			}
+		}
 		entries = append(entries, PostgresSyncEntry{
 			ForeignID: e.ForeignID,
 			Database:  e.Database,
 			DSN:       src,
 			Role:      e.Role,
+			Settings:  settings,
 		})
 	}
 	return entries, nil

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -29,7 +29,7 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	t.Setenv("PG_MAIN_DSN", "host=main")
 
 	raw := json.RawMessage(`[
-		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly"},
+		{"id":"pgs_1","foreign_id":"pg-analytics","database":"analytics","dsn":{"type":"env","var":"PG_ANALYTICS_DSN"},"role":"readonly","settings":[{"name":"app.tenant","value":"centaur"},{"name":"app.region","value":"us"}]},
 		{"id":"pgs_2","foreign_id":"pg-main","database":"maindb","dsn":{"type":"env","var":"PG_MAIN_DSN"}}
 	]`)
 
@@ -44,10 +44,15 @@ func TestPostgresFromSync_ParsesEntries(t *testing.T) {
 	got, err := entries[0].DSN.Get(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "host=analytics", got)
+	require.Len(t, entries[0].Settings, 2)
+	require.Equal(t, "app.tenant", entries[0].Settings[0].Name)
+	require.Equal(t, "centaur", entries[0].Settings[0].Value)
+	require.Equal(t, "app.region", entries[0].Settings[1].Name)
 
 	require.Equal(t, "pg-main", entries[1].ForeignID)
 	require.Equal(t, "maindb", entries[1].Database)
 	require.Empty(t, entries[1].Role)
+	require.Empty(t, entries[1].Settings)
 }
 
 func TestPostgresFromSync_DatabaseDistinctFromForeignID(t *testing.T) {

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -4,9 +4,9 @@
 //
 // The listener accepts client connections, authenticates them against
 // proxy-managed credentials, opens its own authenticated connection upstream
-// (handling SCRAM/MD5 termination via pgconn), optionally issues a single
-// `SET ROLE "<role>"` on the upstream session, then relays the PostgreSQL
-// wire protocol bidirectionally.
+// (handling SCRAM/MD5 termination via pgconn), applies the upstream's pinned
+// session settings and optionally issues a single `SET ROLE "<role>"` on the
+// upstream session, then relays the PostgreSQL wire protocol bidirectionally.
 //
 // Deployment assumption: if PgBouncer (or any pooler) sits between the proxy
 // and PostgreSQL, it must be configured in session-pool mode. Transaction or
@@ -14,12 +14,14 @@
 // nullify the role injection. This is not probed at runtime — the constraint
 // is enforced by deployment configuration.
 //
-// While the relay is running the proxy is mostly transparent: it rejects only
+// While the relay is running the proxy is mostly transparent. It rejects
 // client-issued role-changing statements (`SET ROLE`, `RESET ROLE`,
-// `SET SESSION AUTHORIZATION`, `RESET SESSION AUTHORIZATION`), the function-
-// call equivalents (`set_config('role', ...)`), and DO blocks. Multi-statement
-// Simple Queries are allowed as long as every statement passes the role policy;
-// a batch is rejected if any statement mutates the role or is a DO block.
+// `SET SESSION AUTHORIZATION`, `RESET SESSION AUTHORIZATION`) and their
+// function-call equivalents (`set_config('role', ...)`); any `SET`, `RESET`, or
+// `set_config` of a setting the upstream pins; the reset-everything statements
+// `RESET ALL` and `DISCARD ALL` (which would clear the managed role and pinned
+// settings); and DO blocks. Multi-statement Simple Queries are allowed as long
+// as every statement passes; a batch is rejected if any statement is rejected.
 // Extended Query, COPY, and prepared statements pass through unchanged.
 //
 // The proxy runs a single postgres listener fronting multiple upstream
@@ -35,6 +37,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -91,6 +95,24 @@ type UpstreamConfig struct {
 	// this role on the upstream database. Optional: when empty, the proxy issues
 	// no SET ROLE and the upstream session runs as the connecting user.
 	Role string `yaml:"role,omitempty"`
+
+	// Settings are session variables (GUCs) the proxy SETs at session start for
+	// this upstream, in order, before the SET ROLE. Each is applied via
+	// set_config(name, value, false) so the value is a session-level parameter.
+	// The proxy also pins these names: a client may not SET, RESET, or
+	// set_config them afterwards (nor RESET ALL / DISCARD ALL), so a setting
+	// used as a security boundary (e.g. an RLS key) can't be overridden. The
+	// name must be a bare or dotted GUC identifier; role and
+	// session_authorization are reserved (use Role). Optional.
+	Settings []Setting `yaml:"settings,omitempty"`
+}
+
+// Setting is one session variable the proxy injects at session start: a GUC
+// name and the value it is set to. Values are applied verbatim through
+// set_config, so no SQL quoting is required of the configuration.
+type Setting struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 // ClientConfig describes the credentials the proxy demands from clients.
@@ -166,10 +188,17 @@ func (l *Listener) WithUpstreams(extra []*Upstream) (listener *Listener, dropped
 }
 
 // Upstream is the compiled, runtime form of a single UpstreamConfig: one
-// upstream database with its DSN and optional injected role.
+// upstream database with its DSN, optional injected role, and optional pinned
+// session settings.
 type Upstream struct {
 	database string
 	role     string
+	settings []Setting
+
+	// pinnedGUCs is the lowercased set of setting names the relay forbids the
+	// client from mutating. Derived from settings; never includes role or
+	// session_authorization (those are always blocked by the role policy).
+	pinnedGUCs map[string]struct{}
 
 	dsn secrets.Source
 }
@@ -181,6 +210,14 @@ func (u *Upstream) Database() string { return u.database }
 // Role returns the role the proxy SETs upstream at session start. Empty
 // means no role is set (the upstream session runs as the connecting user).
 func (u *Upstream) Role() string { return u.role }
+
+// Settings returns the session variables the proxy SETs at session start, in
+// configuration order.
+func (u *Upstream) Settings() []Setting { return u.settings }
+
+// PinnedGUCs returns the lowercased set of setting names the client is forbidden
+// from mutating for this upstream. The returned map must not be modified.
+func (u *Upstream) PinnedGUCs() map[string]struct{} { return u.pinnedGUCs }
 
 // DSN returns the upstream connection string, fetched from the configured
 // secret source. The result is cached by the source; repeated calls do not
@@ -252,10 +289,17 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 			return nil, fmt.Errorf("%s: building dsn source: %w", uctx, err)
 		}
 
+		settings, pinned, err := compileSettings(uctx, uc.Settings)
+		if err != nil {
+			return nil, err
+		}
+
 		upstreams[uc.Database] = &Upstream{
-			database: uc.Database,
-			role:     uc.Role,
-			dsn:      dsnSource,
+			database:   uc.Database,
+			role:       uc.Role,
+			settings:   settings,
+			pinnedGUCs: pinned,
+			dsn:        dsnSource,
 		}
 	}
 
@@ -304,20 +348,65 @@ func NewListener(listen, clientUser, clientPassword string, upstreams []*Upstrea
 }
 
 // NewManagedUpstream builds an Upstream for a control-plane-synced listener. The
-// DSN source and optional role come from the control plane. Database is the
-// routing key and is required; role is optional.
-func NewManagedUpstream(database string, dsn secrets.Source, role string) (*Upstream, error) {
+// DSN source, optional role, and optional pinned session settings come from the
+// control plane. Database is the routing key and is required; role and settings
+// are optional. Settings are validated identically to the YAML path.
+func NewManagedUpstream(database string, dsn secrets.Source, role string, settings []Setting) (*Upstream, error) {
 	if database == "" {
 		return nil, fmt.Errorf("postgres: managed upstream database is required")
 	}
 	if dsn == nil {
 		return nil, fmt.Errorf("postgres upstream[%q]: dsn source is required", database)
 	}
+	compiled, pinned, err := compileSettings(fmt.Sprintf("postgres upstream[%q]", database), settings)
+	if err != nil {
+		return nil, err
+	}
 	return &Upstream{
-		database: database,
-		role:     role,
-		dsn:      dsn,
+		database:   database,
+		role:       role,
+		settings:   compiled,
+		pinnedGUCs: pinned,
+		dsn:        dsn,
 	}, nil
+}
+
+// gucNameRe matches a Postgres GUC name: a bare identifier, or a dotted
+// class.name custom variable. The strict charset lets the proxy treat validated
+// names as trusted, and matches the form custom settings (e.g. centaur.foo)
+// must take.
+var gucNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$`)
+
+// compileSettings validates a slice of session settings and returns the cleaned
+// slice alongside the lowercased set of names to pin. ctx is a config-location
+// prefix for error messages (e.g. `postgres.upstreams["centaur"]`). Names must
+// be valid GUC identifiers, unique within the upstream, and may not be role or
+// session_authorization (those are managed via the role field and always
+// blocked by the role policy).
+func compileSettings(ctx string, settings []Setting) ([]Setting, map[string]struct{}, error) {
+	if len(settings) == 0 {
+		return nil, nil, nil
+	}
+	out := make([]Setting, 0, len(settings))
+	pinned := make(map[string]struct{}, len(settings))
+	for i, s := range settings {
+		if s.Name == "" {
+			return nil, nil, fmt.Errorf("%s: settings[%d]: name is required", ctx, i)
+		}
+		if !gucNameRe.MatchString(s.Name) {
+			return nil, nil, fmt.Errorf("%s: settings[%d]: invalid setting name %q", ctx, i, s.Name)
+		}
+		lower := strings.ToLower(s.Name)
+		if lower == "role" || lower == "session_authorization" {
+			return nil, nil, fmt.Errorf("%s: settings[%d]: %q is managed by the proxy; use the role field", ctx, i, s.Name)
+		}
+		if _, dup := pinned[lower]; dup {
+			return nil, nil, fmt.Errorf("%s: duplicate setting %q", ctx, s.Name)
+		}
+		pinned[lower] = struct{}{}
+		out = append(out, s)
+	}
+	return out, pinned, nil
 }
 
 // QuoteIdent returns s formatted as a Postgres double-quoted identifier,

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -106,4 +106,49 @@ func TestCompile(t *testing.T) {
 		_, err := Compile(cfg(u), logger, stubSource)
 		require.ErrorContains(t, err, "dsn is required")
 	})
+
+	t.Run("settings compiled and pinned", func(t *testing.T) {
+		u := upstream("centaur")
+		u.Settings = []Setting{
+			{Name: "centaur.slack_channel_id", Value: "C123"},
+			{Name: "centaur.tenant", Value: ""},
+		}
+		l, err := Compile(cfg(u), logger, stubSource)
+		require.NoError(t, err)
+		up := l.Upstream("centaur")
+		require.Equal(t, u.Settings, up.Settings())
+		require.Contains(t, up.PinnedGUCs(), "centaur.slack_channel_id")
+		require.Contains(t, up.PinnedGUCs(), "centaur.tenant")
+	})
+
+	t.Run("setting name is required", func(t *testing.T) {
+		u := upstream("a")
+		u.Settings = []Setting{{Name: "", Value: "x"}}
+		_, err := Compile(cfg(u), logger, stubSource)
+		require.ErrorContains(t, err, "name is required")
+	})
+
+	t.Run("invalid setting name rejected", func(t *testing.T) {
+		u := upstream("a")
+		u.Settings = []Setting{{Name: "bad name!", Value: "x"}}
+		_, err := Compile(cfg(u), logger, stubSource)
+		require.ErrorContains(t, err, "invalid setting name")
+	})
+
+	t.Run("reserved setting name rejected", func(t *testing.T) {
+		u := upstream("a")
+		u.Settings = []Setting{{Name: "Role", Value: "x"}}
+		_, err := Compile(cfg(u), logger, stubSource)
+		require.ErrorContains(t, err, "managed by the proxy")
+	})
+
+	t.Run("duplicate setting name rejected", func(t *testing.T) {
+		u := upstream("a")
+		u.Settings = []Setting{
+			{Name: "app.x", Value: "1"},
+			{Name: "APP.X", Value: "2"},
+		}
+		_, err := Compile(cfg(u), logger, stubSource)
+		require.ErrorContains(t, err, "duplicate setting")
+	})
 }

--- a/internal/postgres/policy.go
+++ b/internal/postgres/policy.go
@@ -14,18 +14,35 @@ const (
 	// The plpgsql body is opaque to our SQL-level AST walker; rejecting
 	// avoids the risk of an embedded role change.
 	RejectDoBlock
+	// RejectPinnedSetting — the client tried to SET / RESET / set_config a
+	// session variable the upstream pins. The proxy sets these at session start
+	// and forbids overrides so a setting used as a security boundary can't be
+	// changed.
+	RejectPinnedSetting
+	// RejectResetAll — the client tried RESET ALL, which would reset the
+	// proxy-managed role and every pinned setting.
+	RejectResetAll
+	// RejectDiscardAll — the client tried DISCARD ALL, which (like RESET ALL)
+	// resets the proxy-managed role and every pinned setting.
+	RejectDiscardAll
 )
 
 // ClassifyClientStatement inspects sql and returns whether the relay should
-// reject it before forwarding upstream. (reason == 0) means "allow".
+// reject it before forwarding upstream. (reason == 0) means "allow". pinned is
+// the lowercased set of setting names this upstream forbids the client from
+// mutating; pass nil when the upstream pins nothing.
 //
-// Multi-statement Simple Queries are allowed when every statement passes the
-// role policy; Classify rejects the batch if any statement mutates the role or
-// is a DO block.
+// Beyond the role policy, the proxy rejects any SET / RESET / set_config of a
+// pinned setting, and any RESET ALL / DISCARD ALL (which would reset the
+// managed role and every pinned setting at once).
+//
+// Multi-statement Simple Queries are allowed when every statement passes;
+// Classify aggregates the batch, so a single offending statement anywhere
+// rejects the whole batch.
 //
 // Used for both Simple Query bodies and the SQL string carried by Extended
 // Query Parse messages.
-func ClassifyClientStatement(sql string) (allowed bool, reason RejectReason) {
+func ClassifyClientStatement(sql string, pinned map[string]struct{}) (allowed bool, reason RejectReason) {
 	op := Classify(sql)
 	switch op.Kind {
 	case OpSetRole, OpSetSessionAuthorization, OpResetRole, OpResetSessionAuthorization:
@@ -35,7 +52,19 @@ func ClassifyClientStatement(sql string) (allowed bool, reason RejectReason) {
 		// AST. Rather than risk an embedded role change slipping through,
 		// we reject them outright.
 		return false, RejectDoBlock
-	default:
-		return true, 0
 	}
+	// RESET ALL / DISCARD ALL reset the proxy-managed role regardless of which
+	// settings the upstream pins, so they are always rejected.
+	if op.ResetAll {
+		return false, RejectResetAll
+	}
+	if op.Discard {
+		return false, RejectDiscardAll
+	}
+	for _, name := range op.SetGUCs {
+		if _, ok := pinned[name]; ok {
+			return false, RejectPinnedSetting
+		}
+	}
+	return true, 0
 }

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -7,9 +7,14 @@ import (
 )
 
 func TestClassifyClientStatement(t *testing.T) {
+	// pinned models an upstream that pins one custom setting; nil means an
+	// upstream that pins nothing beyond the always-on role policy.
+	pinned := map[string]struct{}{"centaur.slack_channel_id": {}}
+
 	tests := []struct {
 		name    string
 		sql     string
+		pinned  map[string]struct{}
 		allowed bool
 		reason  RejectReason
 	}{
@@ -27,6 +32,13 @@ func TestClassifyClientStatement(t *testing.T) {
 		{name: "set session authorization rejected", sql: "SET SESSION AUTHORIZATION admin", reason: RejectClientRoleChange},
 		{name: "reset session authorization rejected", sql: "RESET SESSION AUTHORIZATION", reason: RejectClientRoleChange},
 
+		// RESET ALL / DISCARD ALL reset the managed role, so they are blocked
+		// even when the upstream pins no custom settings.
+		{name: "reset all rejected", sql: "RESET ALL", reason: RejectResetAll},
+		{name: "discard all rejected", sql: "DISCARD ALL", reason: RejectDiscardAll},
+		{name: "discard plans allowed", sql: "DISCARD PLANS", allowed: true},
+		{name: "discard temp allowed", sql: "DISCARD TEMP", allowed: true},
+
 		// Multi-statement batches are allowed when every statement passes the
 		// role policy, and rejected per-statement otherwise.
 		{name: "clean multi statement allowed", sql: "SELECT 1; SELECT 2", allowed: true},
@@ -37,6 +49,20 @@ func TestClassifyClientStatement(t *testing.T) {
 		// SET of other GUCs is fine — only role-changing statements are rejected.
 		{name: "set search_path allowed", sql: "SET search_path = public", allowed: true},
 		{name: "set local search_path allowed", sql: "SET LOCAL search_path = public", allowed: true},
+
+		// A pinned setting may not be mutated by the client through any form.
+		{name: "set pinned rejected", sql: "SET centaur.slack_channel_id = 'C999'", pinned: pinned, reason: RejectPinnedSetting},
+		{name: "set local pinned rejected", sql: "SET LOCAL centaur.slack_channel_id = 'C999'", pinned: pinned, reason: RejectPinnedSetting},
+		{name: "reset pinned rejected", sql: "RESET centaur.slack_channel_id", pinned: pinned, reason: RejectPinnedSetting},
+		{name: "set_config pinned rejected", sql: "SELECT set_config('centaur.slack_channel_id', 'C999', false)", pinned: pinned, reason: RejectPinnedSetting},
+		{name: "set pinned buried in batch rejected", sql: "SELECT 1; SET centaur.slack_channel_id = 'C999'", pinned: pinned, reason: RejectPinnedSetting},
+		{name: "reset all rejected even with pin", sql: "RESET ALL", pinned: pinned, reason: RejectResetAll},
+		// Reading a pinned setting is fine; only writes are blocked.
+		{name: "current_setting pinned allowed", sql: "SELECT current_setting('centaur.slack_channel_id')", pinned: pinned, allowed: true},
+		// A setting that isn't pinned passes through.
+		{name: "set unpinned allowed", sql: "SET centaur.other = 'x'", pinned: pinned, allowed: true},
+		// Without a pin, the same SET is allowed.
+		{name: "set formerly-pinned allowed without pin", sql: "SET centaur.slack_channel_id = 'C999'", allowed: true},
 
 		// Function-call bypass attempts — caught by AST walker.
 		{name: "set_config role rejected", sql: "SELECT set_config('role', 'admin', false)", reason: RejectClientRoleChange},
@@ -52,7 +78,7 @@ func TestClassifyClientStatement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			allowed, reason := ClassifyClientStatement(tt.sql)
+			allowed, reason := ClassifyClientStatement(tt.sql, tt.pinned)
 			if tt.allowed {
 				require.Truef(t, allowed, "ClassifyClientStatement(%q) returned (false, %v); want allowed", tt.sql, reason)
 				return
@@ -66,27 +92,37 @@ func TestClassifyClientStatement(t *testing.T) {
 func TestNewManagedUpstream(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 
-	u, err := NewManagedUpstream("analytics", dsn, "readonly")
+	u, err := NewManagedUpstream("analytics", dsn, "readonly", nil)
 	require.NoError(t, err)
 	require.Equal(t, "analytics", u.Database())
 	require.Equal(t, "readonly", u.Role())
 
 	// Absent role is allowed (no SET ROLE issued).
-	u, err = NewManagedUpstream("main", dsn, "")
+	u, err = NewManagedUpstream("main", dsn, "", nil)
 	require.NoError(t, err)
 	require.Empty(t, u.Role())
 
+	// Settings are carried through and pinned.
+	u, err = NewManagedUpstream("centaur", dsn, "reader", []Setting{{Name: "centaur.slack_channel_id", Value: "C123"}})
+	require.NoError(t, err)
+	require.Equal(t, []Setting{{Name: "centaur.slack_channel_id", Value: "C123"}}, u.Settings())
+	require.Contains(t, u.PinnedGUCs(), "centaur.slack_channel_id")
+
+	// Settings are validated identically to the YAML path.
+	_, err = NewManagedUpstream("centaur", dsn, "", []Setting{{Name: "role", Value: "x"}})
+	require.ErrorContains(t, err, "managed by the proxy")
+
 	// Required fields.
-	_, err = NewManagedUpstream("", dsn, "")
+	_, err = NewManagedUpstream("", dsn, "", nil)
 	require.ErrorContains(t, err, "database is required")
-	_, err = NewManagedUpstream("d", nil, "")
+	_, err = NewManagedUpstream("d", nil, "", nil)
 	require.ErrorContains(t, err, "dsn source is required")
 }
 
 func TestNewListener(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 	mustUpstream := func(database string) *Upstream {
-		u, err := NewManagedUpstream(database, dsn, "")
+		u, err := NewManagedUpstream(database, dsn, "", nil)
 		require.NoError(t, err)
 		return u
 	}
@@ -117,7 +153,7 @@ func TestNewListener(t *testing.T) {
 func TestListenerWithUpstreams(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 	mustUpstream := func(database string) *Upstream {
-		u, err := NewManagedUpstream(database, dsn, "")
+		u, err := NewManagedUpstream(database, dsn, "", nil)
 		require.NoError(t, err)
 		return u
 	}

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -80,16 +80,14 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		return
 	}
 
-	if upstream.Role() != "" {
-		if err := setUpstreamRole(ctx, upstreamConn, upstream); err != nil {
-			writeFatal(backend, "08006", err.Error())
-			logger.Error("postgres: set role failed",
-				slog.String("error", err.Error()),
-				slog.String("remote", clientConn.RemoteAddr().String()),
-			)
-			_ = upstreamConn.Close(ctx)
-			return
-		}
+	if err := applySessionSetup(ctx, upstreamConn, upstream); err != nil {
+		writeFatal(backend, "08006", err.Error())
+		logger.Error("postgres: session setup failed",
+			slog.String("error", err.Error()),
+			slog.String("remote", clientConn.RemoteAddr().String()),
+		)
+		_ = upstreamConn.Close(ctx)
+		return
 	}
 
 	hijacked, err := upstreamConn.Hijack()
@@ -213,17 +211,33 @@ func dialUpstream(ctx context.Context, upstream *Upstream) (*pgconn.PgConn, erro
 	return conn, nil
 }
 
-// setUpstreamRole issues `SET ROLE "<role>"` on the upstream session.
+// applySessionSetup prepares the upstream session before the relay starts: it
+// applies the upstream's pinned settings, then issues `SET ROLE "<role>"`.
 //
-// The proxy assumes the role persists for the lifetime of the connection,
-// which requires PgBouncer (if present) to be running in session-pool mode.
-// Transaction or statement pool modes silently swap backends between queries
-// and would defeat the policy; that constraint is enforced by deployment
-// configuration rather than by a runtime probe.
-func setUpstreamRole(ctx context.Context, conn *pgconn.PgConn, upstream *Upstream) error {
-	setSQL := "SET ROLE " + QuoteIdent(upstream.Role())
-	if _, err := conn.Exec(ctx, setSQL).ReadAll(); err != nil {
-		return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(upstream.Role()), err)
+// Settings are applied first, while the session still runs as the connecting
+// (login) user, so a setting that requires elevated privilege isn't blocked by
+// an already-downgraded role. Each is applied through set_config(name, value,
+// false) via the extended protocol so the value is a bound parameter — no SQL
+// quoting of the configured value is needed.
+//
+// The proxy assumes the role and settings persist for the lifetime of the
+// connection, which requires PgBouncer (if present) to be running in
+// session-pool mode. Transaction or statement pool modes silently swap backends
+// between queries and would defeat the policy; that constraint is enforced by
+// deployment configuration rather than by a runtime probe.
+func applySessionSetup(ctx context.Context, conn *pgconn.PgConn, upstream *Upstream) error {
+	for _, s := range upstream.Settings() {
+		rr := conn.ExecParams(ctx, "SELECT set_config($1, $2, false)",
+			[][]byte{[]byte(s.Name), []byte(s.Value)}, nil, nil, nil)
+		if _, err := rr.Close(); err != nil {
+			return fmt.Errorf("upstream rejected setting %q: %w", s.Name, err)
+		}
+	}
+	if upstream.Role() != "" {
+		setSQL := "SET ROLE " + QuoteIdent(upstream.Role())
+		if _, err := conn.Exec(ctx, setSQL).ReadAll(); err != nil {
+			return fmt.Errorf("upstream rejected SET ROLE %s: %w", QuoteIdent(upstream.Role()), err)
+		}
 	}
 	return nil
 }
@@ -336,7 +350,7 @@ func (r *relay) clientToServer() {
 				// Unexpected mid-batch; treat the Simple Query as a fresh statement.
 				r.skipExtended = false
 			}
-			if allowed, reason := ClassifyClientStatement(m.String); !allowed {
+			if allowed, reason := ClassifyClientStatement(m.String, r.upstream.PinnedGUCs()); !allowed {
 				r.writeReject(reason, true)
 				continue
 			}
@@ -346,7 +360,7 @@ func (r *relay) clientToServer() {
 			}
 
 		case *pgproto3.Parse:
-			if allowed, reason := ClassifyClientStatement(m.Query); !allowed {
+			if allowed, reason := ClassifyClientStatement(m.Query, r.upstream.PinnedGUCs()); !allowed {
 				r.writeReject(reason, false)
 				r.skipExtended = true
 				continue
@@ -416,6 +430,24 @@ func rejectError(reason RejectReason) *pgproto3.ErrorResponse {
 			Severity: "ERROR",
 			Code:     "0A000",
 			Message:  "blocked by iron-proxy policy: DO blocks are not supported (their plpgsql body cannot be inspected for embedded role changes)",
+		}
+	case RejectPinnedSetting:
+		return &pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Code:     "42501",
+			Message:  "blocked by iron-proxy policy: this session setting is managed by the proxy; clients may not SET / RESET / set_config it",
+		}
+	case RejectResetAll:
+		return &pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Code:     "42501",
+			Message:  "blocked by iron-proxy policy: RESET ALL would reset the proxy-managed role and session settings",
+		}
+	case RejectDiscardAll:
+		return &pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Code:     "42501",
+			Message:  "blocked by iron-proxy policy: DISCARD ALL would reset the proxy-managed role and session settings",
 		}
 	case RejectClientRoleChange:
 		fallthrough

--- a/internal/postgres/session_test.go
+++ b/internal/postgres/session_test.go
@@ -15,7 +15,7 @@ import (
 // server.
 func TestDialUpstreamDatabaseMismatch(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=otherdb"}, "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=otherdb"}, "", nil)
 	require.NoError(t, err)
 
 	_, err = dialUpstream(context.Background(), up)
@@ -30,7 +30,7 @@ func TestDialUpstreamDatabaseMismatch(t *testing.T) {
 // not name a database. Caught before any network round-trip.
 func TestDialUpstreamMissingDatabase(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 user=app"}, "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 user=app"}, "", nil)
 	require.NoError(t, err)
 
 	_, err = dialUpstream(context.Background(), up)
@@ -45,7 +45,7 @@ func TestDialUpstreamMissingDatabase(t *testing.T) {
 // is listening on port 1), but the failure must not be a databaseMismatchError.
 func TestDialUpstreamDatabaseMatchPassesCheck(t *testing.T) {
 	up, err := NewManagedUpstream("appdb",
-		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=appdb"}, "")
+		staticDSN{name: "dsn", value: "host=127.0.0.1 port=1 dbname=appdb"}, "", nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/postgres/sql.go
+++ b/internal/postgres/sql.go
@@ -21,8 +21,25 @@ import (
 // `WITH x AS (SELECT pg_catalog.set_config('role', ...)) SELECT * FROM x`,
 // or `PREPARE p AS SET ROLE admin`.
 type Op struct {
-	// Kind is the classified statement kind.
+	// Kind is the classified statement kind. It captures the role-policy verdict
+	// (OpSetRole and friends), DO blocks, parse errors, and empties — the cases
+	// that don't depend on which custom GUCs a given upstream pins.
 	Kind OpKind
+
+	// SetGUCs is the lowercased set of GUC names the statement writes through
+	// SET / RESET <name> / set_config(<name>, ...). Role and
+	// session_authorization are reported here too, but those are already
+	// covered by Kind; the per-upstream policy uses this for custom pinned
+	// names. Nil when the statement writes no GUC.
+	SetGUCs []string
+
+	// ResetAll is true when the statement contains RESET ALL, which resets every
+	// session variable — including the proxy-managed role and any pinned GUC.
+	ResetAll bool
+
+	// Discard is true when the statement contains DISCARD ALL, which (among
+	// other things) resets every session variable like RESET ALL.
+	Discard bool
 }
 
 // OpKind enumerates the statement classes the policy reasons about.
@@ -107,91 +124,123 @@ func classifyUncached(sql string) Op {
 		return Op{Kind: OpEmpty}
 	}
 
-	// Multi-statement Simple Queries are permitted as long as every statement
-	// passes the role policy. We classify each statement and reject the whole
-	// batch on the first one that mutates the role or is an (opaque) DO block.
-	// The relay forwards the batch unchanged when all statements are allowed;
-	// the upstream runs it as one implicit transaction.
+	// Multi-statement Simple Queries are classified per statement and the batch
+	// carries the union of what its statements do. Kind takes the first
+	// role-changing or DO-block statement (so the relay can reject it as before);
+	// the GUC-mutation facts accumulate across the batch so the per-upstream
+	// policy can reject a batch touching any pinned setting wherever it appears.
+	op := Op{Kind: OpOther}
 	for _, s := range stmts {
 		root := s.GetStmt()
 		if root == nil {
 			continue
 		}
-		if kind := classifyStmt(root); kind != OpOther {
-			return Op{Kind: kind}
+		m := classifyStmt(root)
+		if op.Kind == OpOther {
+			op.Kind = m.kind
 		}
+		op.SetGUCs = append(op.SetGUCs, m.setGUCs...)
+		op.ResetAll = op.ResetAll || m.resetAll
+		op.Discard = op.Discard || m.discard
 	}
-	return Op{Kind: OpOther}
+	return op
 }
 
-// classifyStmt classifies a single statement's root node, returning the OpKind
-// of any role-mutating or otherwise-rejectable construct it finds, or OpOther
-// when the statement is allowed.
-func classifyStmt(root *pg_query.Node) OpKind {
+// mutations is what a single statement does that the policy cares about: its
+// role-policy kind (OpSetRole and friends, or OpDoBlock), the GUC names it
+// writes, and whether it resets every variable via RESET ALL / DISCARD ALL.
+type mutations struct {
+	kind     OpKind
+	setGUCs  []string
+	resetAll bool
+	discard  bool
+}
+
+// classifyStmt classifies a single statement's root node.
+func classifyStmt(root *pg_query.Node) mutations {
 	// Top-level shape gives us a fast path for the common DDL/DML cases.
 	switch root.Node.(type) {
 	case *pg_query.Node_TransactionStmt:
-		// BEGIN / COMMIT / ROLLBACK / SAVEPOINT etc. — no role mutation.
-		return OpOther
+		// BEGIN / COMMIT / ROLLBACK / SAVEPOINT etc. — no GUC mutation.
+		return mutations{kind: OpOther}
 	case *pg_query.Node_DoStmt:
-		return OpDoBlock
+		// The plpgsql body is opaque to the SQL AST walker; we can't see GUC
+		// writes inside it, so the statement is rejected wholesale via Kind.
+		return mutations{kind: OpDoBlock}
 	}
-
-	// Generic scan: any role-affecting node anywhere in the tree triggers a
-	// rejection. Covers SELECT set_config(...), PREPARE ... AS SET ROLE,
-	// CTEs, subqueries, INSERT...SELECT, function arguments, etc.
-	if kind := scanForRoleChange(root); kind != 0 {
-		return kind
-	}
-	return OpOther
+	return scanMutations(root)
 }
 
-// scanForRoleChange walks the AST rooted at node and returns the OpKind of
-// any role-affecting construct it finds. Returns 0 if none.
+// scanMutations walks the AST rooted at node and reports every GUC-affecting
+// construct it finds: SET / RESET / RESET ALL, DISCARD ALL, and set_config(...)
+// calls, wherever they're nested (CTEs, subqueries, PREPARE bodies, function
+// arguments, ...).
 //
-// The walk uses protoreflect for generic descent so we don't have to maintain
-// a hand-rolled case statement for every Node subtype as Postgres adds
-// syntax. Any nested *VariableSetStmt or *FuncCall to set_config is caught
-// regardless of how it's wrapped.
-func scanForRoleChange(node *pg_query.Node) OpKind {
-	var found OpKind
-	walkProto(node.ProtoReflect(), func(m protoreflect.Message) bool {
-		msg := m.Interface()
-		switch n := msg.(type) {
+// The walk uses protoreflect for generic descent so we don't have to maintain a
+// hand-rolled case statement for every Node subtype as Postgres adds syntax.
+func scanMutations(node *pg_query.Node) mutations {
+	var m mutations
+	walkProto(node.ProtoReflect(), func(msg protoreflect.Message) bool {
+		switch n := msg.Interface().(type) {
 		case *pg_query.VariableSetStmt:
-			if kind, ok := roleGUCs[strings.ToLower(n.GetName())]; ok {
-				switch n.GetKind() {
-				case pg_query.VariableSetKind_VAR_RESET, pg_query.VariableSetKind_VAR_RESET_ALL:
-					if kind == OpSetRole {
-						found = OpResetRole
-					} else {
-						found = OpResetSessionAuthorization
-					}
-				default:
-					found = kind
-				}
-				return false
+			if n.GetKind() == pg_query.VariableSetKind_VAR_RESET_ALL {
+				m.resetAll = true
+				break
+			}
+			// SET, SET LOCAL, and RESET <name> all name a single GUC.
+			name := strings.ToLower(n.GetName())
+			if name != "" {
+				m.setGUCs = append(m.setGUCs, name)
+			}
+			if rk := roleKindFor(name, n.GetKind()); rk != 0 && m.kind == 0 {
+				m.kind = rk
+			}
+		case *pg_query.DiscardStmt:
+			// Only DISCARD ALL resets session variables; the PLANS / SEQUENCES /
+			// TEMP variants leave GUCs (and the role) intact.
+			if n.GetTarget() == pg_query.DiscardMode_DISCARD_ALL {
+				m.discard = true
 			}
 		case *pg_query.VariableShowStmt:
-			// SHOW is read-only; allow.
+			// SHOW is read-only; ignore.
 		case *pg_query.FuncCall:
-			if kind := classifyFuncCall(n); kind != 0 {
-				found = kind
-				return false
+			if name, kind := setConfigTarget(n); name != "" {
+				m.setGUCs = append(m.setGUCs, name)
+				if kind != 0 && m.kind == 0 {
+					m.kind = kind
+				}
 			}
 		}
 		return true
 	})
-	return found
+	return m
 }
 
-// classifyFuncCall returns a role-change OpKind if fc is a call to
-// set_config (or pg_catalog.set_config) whose first argument is a string
-// literal naming a role-mutating GUC. Returns 0 otherwise.
-func classifyFuncCall(fc *pg_query.FuncCall) OpKind {
+// roleKindFor returns the role-policy OpKind for a SET/RESET of the named GUC,
+// or 0 when the GUC is not role-affecting. kind distinguishes a write
+// (OpSetRole) from a reset (OpResetRole).
+func roleKindFor(name string, kind pg_query.VariableSetKind) OpKind {
+	base, ok := roleGUCs[name]
+	if !ok {
+		return 0
+	}
+	if kind == pg_query.VariableSetKind_VAR_RESET {
+		if base == OpSetRole {
+			return OpResetRole
+		}
+		return OpResetSessionAuthorization
+	}
+	return base
+}
+
+// setConfigTarget inspects fc and, when it is a call to set_config (or
+// pg_catalog.set_config) whose first argument is a string-literal GUC name,
+// returns that lowercased name and the role-policy OpKind for it (0 when the
+// target is not role-affecting). Returns ("", 0) when fc is not such a call.
+func setConfigTarget(fc *pg_query.FuncCall) (name string, kind OpKind) {
 	names := fc.GetFuncname()
 	if len(names) == 0 {
-		return 0
+		return "", 0
 	}
 	// Funcname is a list of String nodes: ["set_config"] for unqualified
 	// or ["pg_catalog", "set_config"] for schema-qualified. We accept any
@@ -200,24 +249,23 @@ func classifyFuncCall(fc *pg_query.FuncCall) OpKind {
 	last := names[len(names)-1]
 	lastStr, ok := last.Node.(*pg_query.Node_String_)
 	if !ok {
-		return 0
+		return "", 0
 	}
 	if !strings.EqualFold(lastStr.String_.GetSval(), "set_config") {
-		return 0
+		return "", 0
 	}
 	args := fc.GetArgs()
 	if len(args) < 1 {
-		return 0
+		return "", 0
 	}
 	param, ok := stringConst(args[0])
 	if !ok {
-		return 0
+		return "", 0
 	}
-	kind, ok := roleGUCsForSetConfig[strings.ToLower(param)]
-	if !ok {
-		return 0
-	}
-	return kind
+	lower := strings.ToLower(param)
+	// roleGUCsForSetConfig returns the zero OpKind (0) for non-role names, which
+	// is exactly the "not role-affecting" signal callers expect.
+	return lower, roleGUCsForSetConfig[lower]
 }
 
 // stringConst returns the string value of node if it's an A_Const with a

--- a/internal/postgres/sql_test.go
+++ b/internal/postgres/sql_test.go
@@ -92,3 +92,38 @@ func TestClassify(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyMutationFacts covers the generic GUC-mutation facts Classify
+// reports (independent of the role-specific Kind): the names written, and the
+// reset-everything statements RESET ALL / DISCARD ALL.
+func TestClassifyMutationFacts(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		setGUCs  []string
+		resetAll bool
+		discard  bool
+	}{
+		{name: "set custom guc", sql: "SET centaur.slack_channel_id = 'C123'", setGUCs: []string{"centaur.slack_channel_id"}},
+		{name: "set local custom guc", sql: "SET LOCAL centaur.slack_channel_id = 'C123'", setGUCs: []string{"centaur.slack_channel_id"}},
+		{name: "reset custom guc", sql: "RESET centaur.slack_channel_id", setGUCs: []string{"centaur.slack_channel_id"}},
+		{name: "set_config custom guc", sql: "SELECT set_config('centaur.slack_channel_id', 'C123', false)", setGUCs: []string{"centaur.slack_channel_id"}},
+		{name: "name lowercased", sql: "SET Centaur.Slack_Channel_ID = 'C123'", setGUCs: []string{"centaur.slack_channel_id"}},
+		{name: "search_path collected", sql: "SET search_path = public", setGUCs: []string{"search_path"}},
+		{name: "multi statement collects all", sql: "SET a.x = '1'; SET a.y = '2'", setGUCs: []string{"a.x", "a.y"}},
+		{name: "reset all flagged", sql: "RESET ALL", resetAll: true},
+		{name: "discard all flagged", sql: "DISCARD ALL", discard: true},
+		{name: "discard plans not flagged", sql: "DISCARD PLANS"},
+		{name: "select writes nothing", sql: "SELECT 1"},
+		{name: "current_setting writes nothing", sql: "SELECT current_setting('centaur.slack_channel_id')"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := Classify(tt.sql)
+			require.ElementsMatchf(t, tt.setGUCs, op.SetGUCs, "Classify(%q).SetGUCs", tt.sql)
+			require.Equalf(t, tt.resetAll, op.ResetAll, "Classify(%q).ResetAll", tt.sql)
+			require.Equalf(t, tt.discard, op.Discard, "Classify(%q).Discard", tt.sql)
+		})
+	}
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -679,6 +679,15 @@ transforms:
 #       # The Postgres role the proxy SETs at session start. Every query the
 #       # client issues runs as this role on the upstream database.
 #       role: tenant_role
+#       # Optional session variables (GUCs) the proxy SETs at session start,
+#       # before the SET ROLE. The proxy also pins these: a client may not SET,
+#       # RESET, or set_config them afterwards (nor RESET ALL / DISCARD ALL), so
+#       # a setting used as a security boundary (e.g. an RLS key) can't be
+#       # overridden. Names must be bare or dotted GUC identifiers; role and
+#       # session_authorization are reserved (use role above).
+#       settings:
+#         - name: app.tenant_id
+#           value: centaur
 #     # Clients connect with dbname=analyticsdb to reach this upstream.
 #     - database: analyticsdb
 #       dsn:


### PR DESCRIPTION
Generalizes the existing single `SET ROLE` injection into a list of session variables (GUCs) the proxy SETs at session start, so an upstream can carry context like `centaur.slack_channel_id = 'C123'` for RLS policies to key off.

Settings are applied via `set_config` (bound params, no value quoting) before the `SET ROLE` downgrade, and the proxy pins them: clients may not `SET` / `RESET` / `set_config` a pinned name afterwards. The SQL classifier now reports every GUC a statement writes (not just role), and the relay rejects writes to pinned names. This also closes a latent gap in the role pin: `RESET ALL` / `DISCARD ALL` reset the managed role and were not previously blocked; they are now rejected whenever the proxy manages a role or settings.

Settings flow through both the YAML config and the control-plane sync path, with name validation (dotted GUC identifiers; `role` and `session_authorization` reserved). Values are static per-upstream.