### PR TITLE
feat: managed-mode management API (status, sync-now) and fail-closed startup

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -83,15 +83,14 @@ func main() {
 	// Managed mode is determined by the presence of a control plane token.
 	managed := proxyToken != ""
 
-	if cfg.Management.Listen != "" {
-		if managed {
-			fmt.Fprintln(os.Stderr, "error: management.listen cannot be used with managed mode; the control plane is the source of truth")
-			os.Exit(1)
-		}
-		if *configPath == "" {
-			fmt.Fprintln(os.Stderr, "error: management.listen requires --config; /v1/reload has no file to re-read")
-			os.Exit(1)
-		}
+	// Standalone mode serves /v1/reload, which re-reads the config file.
+	// Managed mode serves /v1/status and /v1/sync instead: the control plane
+	// stays the source of truth for config, while the sandbox control plane
+	// can verify which principal's config the proxy has actually applied
+	// before routing traffic through it.
+	if cfg.Management.Listen != "" && !managed && *configPath == "" {
+		fmt.Fprintln(os.Stderr, "error: management.listen requires --config in standalone mode; /v1/reload has no file to re-read")
+		os.Exit(1)
 	}
 
 	// Both modes produce a pipeline holder. Managed mode populates the
@@ -121,10 +120,11 @@ func main() {
 	var holder *transform.PipelineHolder
 	var mcpHolder *mcp.PolicyHolder
 	var otelCfg iotel.ExportConfig
+	var poller *controlplane.Poller
 
 	if managed {
 		var ingestToken string
-		holder, mcpHolder, ingestToken, pgListener = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListener, logger)
+		holder, mcpHolder, ingestToken, pgListener, poller = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListener, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -222,21 +222,32 @@ func main() {
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 		UpstreamProxy:                 cfg.Proxy.UpstreamProxy.ProxyFunc(),
+		// Managed proxies fail closed until the first control-plane config
+		// has been applied; an un-synced pipeline would otherwise pass
+		// requests through with placeholder credentials intact.
+		Ready: managedReady(poller),
 	})
 
 	// Initialize metrics server.
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)
 
-	// Initialize management server (standalone mode only; guarded above).
+	// Initialize management server: /v1/reload in standalone mode,
+	// /v1/status and /v1/sync in managed mode.
 	var mgmtServer *management.Server
 	if cfg.Management.Listen != "" {
-		mgmtServer = management.New(management.Options{
+		mgmtOpts := management.Options{
 			Addr:   cfg.Management.Listen,
 			APIKey: os.Getenv(cfg.Management.APIKeyEnv),
-			Reload: newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger),
 			Logger: logger,
 			Ctx:    ctx,
-		})
+		}
+		if managed {
+			mgmtOpts.Status = func() any { return poller.Status() }
+			mgmtOpts.SyncNow = poller.Poke
+		} else {
+			mgmtOpts.Reload = newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger)
+		}
+		mgmtServer = management.New(mgmtOpts)
 	}
 
 	// Start services.
@@ -321,7 +332,7 @@ func main() {
 //
 // Initial MCP policy preference: control-plane-supplied mcp block first, then
 // fall back to cfg.MCP from the YAML if the sync did not include one.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListener *postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, *postgres.Listener) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListener *postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, *postgres.Listener, *controlplane.Poller) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -402,11 +413,24 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		return nil
 	}, logger)
 
+	// Seed the poller's status from the startup sync so /v1/status (and the
+	// fail-closed gate) reflect it before the polling loop's first pass.
+	poller.SeedStatus(syncResp)
+
 	go func() {
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, mcpHolder, ingestToken, pgListener
+	return holder, mcpHolder, ingestToken, pgListener, poller
+}
+
+// managedReady gates the proxy on the first applied control-plane config.
+// A nil poller (standalone mode) means always ready.
+func managedReady(poller *controlplane.Poller) func() bool {
+	if poller == nil {
+		return nil
+	}
+	return func() bool { return poller.Status().SyncedOnce }
 }
 
 // buildInitialMCPHolder picks the initial MCP policy source: a control-plane

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -47,6 +47,9 @@ func applyEnvOverrides(cfg *Config) error {
 	if v := os.Getenv("IRON_METRICS_LISTEN"); v != "" {
 		cfg.Metrics.Listen = v
 	}
+	if v := os.Getenv("IRON_MANAGEMENT_LISTEN"); v != "" {
+		cfg.Management.Listen = v
+	}
 	if v := os.Getenv("IRON_LOG_LEVEL"); v != "" {
 		cfg.Log.Level = v
 	}

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -23,6 +23,11 @@ type SyncResponse struct {
 	MCP         json.RawMessage `json:"mcp"`
 	Postgres    json.RawMessage `json:"postgres"`
 	IngestToken string          `json:"ingest_token"`
+	// Status and PrincipalID describe the proxy's control-plane assignment as
+	// of this sync. The control plane includes them only on responses that
+	// carry a config payload; hash-match responses leave them empty.
+	Status      string `json:"status"`
+	PrincipalID string `json:"principal_id"`
 }
 
 // Client talks to the iron.sh control plane REST API. Requests are

--- a/internal/controlplane/poller.go
+++ b/internal/controlplane/poller.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"math/rand/v2"
+	"sync"
 	"time"
 )
 
@@ -23,12 +24,28 @@ type SyncUpdate struct {
 	Postgres   json.RawMessage
 }
 
+// Status is a snapshot of the poller's applied control-plane state. The
+// management API serves it so an operator (or the sandbox control plane)
+// can verify which principal's config this proxy is actually enforcing
+// before routing traffic through it.
+type Status struct {
+	ConfigHash      string    `json:"config_hash"`
+	PrincipalID     string    `json:"principal_id"`
+	PrincipalStatus string    `json:"principal_status"`
+	SyncedOnce      bool      `json:"synced_once"`
+	LastSyncAt      time.Time `json:"last_sync_at"`
+}
+
 // Poller periodically calls Sync and applies config updates.
 type Poller struct {
 	client     *Client
 	configHash string
 	onUpdate   func(SyncUpdate) error
 	logger     *slog.Logger
+
+	mu     sync.RWMutex
+	status Status
+	poke   chan struct{}
 }
 
 // NewPoller creates a new sync poller.
@@ -38,12 +55,56 @@ func NewPoller(client *Client, initialConfigHash string, onUpdate func(SyncUpdat
 		configHash: initialConfigHash,
 		onUpdate:   onUpdate,
 		logger:     logger,
+		poke:       make(chan struct{}, 1),
+	}
+}
+
+// Poke requests an immediate out-of-band sync. It never blocks: at most one
+// poke is queued, and a poke arriving while a sync is in flight coalesces
+// into the next loop iteration.
+func (p *Poller) Poke() {
+	select {
+	case p.poke <- struct{}{}:
+	default:
+	}
+}
+
+// Status returns a snapshot of the applied control-plane state.
+func (p *Poller) Status() Status {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.status
+}
+
+// SeedStatus records the result of a sync performed outside the poller (the
+// startup sync in managed mode) so Status reflects it before Run's first
+// iteration.
+func (p *Poller) SeedStatus(resp *SyncResponse) {
+	if resp == nil {
+		return
+	}
+	p.recordSync(resp)
+}
+
+func (p *Poller) recordSync(resp *SyncResponse) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.status.ConfigHash = resp.ConfigHash
+	p.status.SyncedOnce = true
+	p.status.LastSyncAt = time.Now().UTC()
+	// Hash-match responses omit the assignment fields; keep the last known
+	// values so Status stays meaningful between config changes.
+	if resp.Status != "" {
+		p.status.PrincipalStatus = resp.Status
+	}
+	if resp.PrincipalID != "" {
+		p.status.PrincipalID = resp.PrincipalID
 	}
 }
 
 // Run starts the polling loop. It performs an initial sync immediately, then
-// polls on PollInterval with ±10% jitter. Returns when ctx is canceled or
-// a revocation error is received.
+// polls on PollInterval with ±10% jitter; a Poke wakes it early. Returns when
+// ctx is canceled or a revocation error is received.
 func (p *Poller) Run(ctx context.Context) error {
 	if err := p.sync(ctx); err != nil {
 		if isRevocationError(err) {
@@ -61,6 +122,8 @@ func (p *Poller) Run(ctx context.Context) error {
 			timer.Stop()
 			return nil
 		case <-timer.C:
+		case <-p.poke:
+			timer.Stop()
 		}
 
 		if err := p.sync(ctx); err != nil {
@@ -108,6 +171,7 @@ func (p *Poller) sync(ctx context.Context) error {
 	}
 
 	p.configHash = resp.ConfigHash
+	p.recordSync(resp)
 	return nil
 }
 

--- a/internal/controlplane/poller_test.go
+++ b/internal/controlplane/poller_test.go
@@ -207,3 +207,109 @@ func TestPollerGracefulShutdown(t *testing.T) {
 		t.Fatal("poller did not shut down in time")
 	}
 }
+
+func TestPollerPokeTriggersImmediateSync(t *testing.T) {
+	var syncCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := syncCalls.Add(1)
+		resp := SyncResponse{ConfigHash: "sha256:one"}
+		if n > 1 {
+			resp = SyncResponse{
+				ConfigHash:  "sha256:two",
+				Status:      "assigned",
+				PrincipalID: "prn_session",
+				Secrets:     json.RawMessage(`[]`),
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "irpt_test", testLogger())
+	poller := NewPoller(client, "", nil, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- poller.Run(ctx) }()
+
+	// The initial sync runs immediately; wait for it.
+	require.Eventually(t, func() bool {
+		return poller.Status().SyncedOnce
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Equal(t, "sha256:one", poller.Status().ConfigHash)
+
+	// A poke must trigger the second sync long before the 5s poll interval.
+	poller.Poke()
+	require.Eventually(t, func() bool {
+		return poller.Status().ConfigHash == "sha256:two"
+	}, 2*time.Second, 10*time.Millisecond)
+
+	status := poller.Status()
+	require.Equal(t, "prn_session", status.PrincipalID)
+	require.Equal(t, "assigned", status.PrincipalStatus)
+	require.True(t, status.SyncedOnce)
+	require.False(t, status.LastSyncAt.IsZero())
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestPollerStatusRetainsPrincipalOnHashMatch(t *testing.T) {
+	var syncCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := syncCalls.Add(1)
+		resp := SyncResponse{ConfigHash: "sha256:same"}
+		if n == 1 {
+			resp.Status = "assigned"
+			resp.PrincipalID = "prn_keep"
+			resp.Secrets = json.RawMessage(`[]`)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "irpt_test", testLogger())
+	poller := NewPoller(client, "", nil, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- poller.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return poller.Status().PrincipalID == "prn_keep"
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Hash-match responses omit the assignment fields; they must be retained.
+	poller.Poke()
+	require.Eventually(t, func() bool {
+		return syncCalls.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Equal(t, "prn_keep", poller.Status().PrincipalID)
+	require.Equal(t, "assigned", poller.Status().PrincipalStatus)
+
+	cancel()
+	require.NoError(t, <-done)
+}
+
+func TestPollerSeedStatus(t *testing.T) {
+	client := NewClient("http://127.0.0.1:0", "irpt_test", testLogger())
+	poller := NewPoller(client, "", nil, testLogger())
+	require.False(t, poller.Status().SyncedOnce)
+
+	poller.SeedStatus(nil)
+	require.False(t, poller.Status().SyncedOnce)
+
+	poller.SeedStatus(&SyncResponse{
+		ConfigHash:  "sha256:seed",
+		Status:      "assigned",
+		PrincipalID: "prn_boot",
+	})
+	status := poller.Status()
+	require.True(t, status.SyncedOnce)
+	require.Equal(t, "sha256:seed", status.ConfigHash)
+	require.Equal(t, "prn_boot", status.PrincipalID)
+}

--- a/internal/management/server.go
+++ b/internal/management/server.go
@@ -45,8 +45,16 @@ type statusResponse struct {
 type Options struct {
 	Addr   string
 	APIKey string
+	// Reload rebuilds the pipeline from the on-disk config. Standalone mode
+	// only; nil disables /v1/reload (managed proxies have no file to re-read).
 	Reload ReloadFunc
-	Logger *slog.Logger
+	// Status returns a JSON-encodable snapshot of the applied control-plane
+	// state. Managed mode only; nil disables /v1/status.
+	Status func() any
+	// SyncNow requests an immediate control-plane sync. Managed mode only;
+	// nil disables /v1/sync.
+	SyncNow func()
+	Logger  *slog.Logger
 
 	// Ctx is the process-scoped context passed to Reload. It must outlive
 	// individual HTTP requests so a client disconnect cannot abort a reload
@@ -57,11 +65,13 @@ type Options struct {
 
 // Server serves the management API.
 type Server struct {
-	server *http.Server
-	apiKey string
-	reload ReloadFunc
-	logger *slog.Logger
-	ctx    context.Context
+	server  *http.Server
+	apiKey  string
+	reload  ReloadFunc
+	status  func() any
+	syncNow func()
+	logger  *slog.Logger
+	ctx     context.Context
 }
 
 // New creates a Server bound to opts.Addr. The caller starts it with
@@ -73,12 +83,16 @@ func New(opts Options) *Server {
 		ctx = context.Background()
 	}
 	s := &Server{
-		apiKey: opts.APIKey,
-		reload: opts.Reload,
-		logger: opts.Logger,
-		ctx:    ctx,
+		apiKey:  opts.APIKey,
+		reload:  opts.Reload,
+		status:  opts.Status,
+		syncNow: opts.SyncNow,
+		logger:  opts.Logger,
+		ctx:     ctx,
 	}
 	mux.HandleFunc("/v1/reload", s.handleReload)
+	mux.HandleFunc("/v1/status", s.handleStatus)
+	mux.HandleFunc("/v1/sync", s.handleSync)
 	s.server = &http.Server{
 		Addr:    opts.Addr,
 		Handler: mux,
@@ -111,6 +125,10 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
 		return
 	}
+	if s.reload == nil {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "reload is unavailable in managed mode"})
+		return
+	}
 
 	// Use the server-scoped context, not r.Context(): reload mutates
 	// process-wide state and must not be cut short by a client disconnect.
@@ -130,6 +148,45 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Error("management reload failed", slog.String("error", err.Error()))
 	writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal error"})
+}
+
+// handleStatus serves the applied control-plane state (managed mode).
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(r) {
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	if s.status == nil {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "status is unavailable in standalone mode"})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.status())
+}
+
+// handleSync requests an immediate control-plane sync (managed mode). The
+// sync itself is asynchronous: callers poll /v1/status to observe the
+// applied result.
+func (s *Server) handleSync(w http.ResponseWriter, r *http.Request) {
+	if !s.authorize(r) {
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	if s.syncNow == nil {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "sync is unavailable in standalone mode"})
+		return
+	}
+	s.syncNow()
+	writeJSON(w, http.StatusAccepted, statusResponse{Status: "sync requested"})
 }
 
 func (s *Server) authorize(r *http.Request) bool {

--- a/internal/management/server_test.go
+++ b/internal/management/server_test.go
@@ -121,3 +121,76 @@ func TestUnknownPath(t *testing.T) {
 	rec := do(t, s, http.MethodPost, "/anything-else", "Bearer secret")
 	require.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+func newManagedTestServer(t *testing.T, key string, status func() any, syncNow func()) *Server {
+	t.Helper()
+	return New(Options{
+		Addr:    "127.0.0.1:0",
+		APIKey:  key,
+		Status:  status,
+		SyncNow: syncNow,
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+}
+
+func TestStatus_Success(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any {
+		return map[string]any{"principal_id": "prn_1", "synced_once": true}
+	}, func() {})
+	rec := do(t, s, http.MethodGet, "/v1/status", "Bearer secret")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	require.Equal(t, "prn_1", body["principal_id"])
+	require.Equal(t, true, body["synced_once"])
+}
+
+func TestStatus_MissingAuth(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() {})
+	rec := do(t, s, http.MethodGet, "/v1/status", "")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestStatus_WrongMethod(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() {})
+	rec := do(t, s, http.MethodPost, "/v1/status", "Bearer secret")
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestStatus_StandaloneUnavailable(t *testing.T) {
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
+	rec := do(t, s, http.MethodGet, "/v1/status", "Bearer secret")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestSync_Success(t *testing.T) {
+	var poked bool
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() { poked = true })
+	rec := do(t, s, http.MethodPost, "/v1/sync", "Bearer secret")
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.True(t, poked)
+}
+
+func TestSync_MissingAuth(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() {})
+	rec := do(t, s, http.MethodPost, "/v1/sync", "")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestSync_WrongMethod(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() {})
+	rec := do(t, s, http.MethodGet, "/v1/sync", "Bearer secret")
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestSync_StandaloneUnavailable(t *testing.T) {
+	s := newTestServer(t, "secret", func(context.Context) error { return nil })
+	rec := do(t, s, http.MethodPost, "/v1/sync", "Bearer secret")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestReload_ManagedUnavailable(t *testing.T) {
+	s := newManagedTestServer(t, "secret", func() any { return nil }, func() {})
+	rec := do(t, s, http.MethodPost, "/v1/reload", "Bearer secret")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -56,6 +56,7 @@ type Proxy struct {
 	// 443 in production so a client-supplied CONNECT port cannot pivot an
 	// allowlisted hostname onto a different port. Overridable in tests.
 	sniUpstreamPort string
+	ready           func() bool
 }
 
 // Options configures Proxy construction.
@@ -78,6 +79,12 @@ type Options struct {
 	// an upstream SOCKS5/HTTP CONNECT proxy (see http.Transport.Proxy). nil
 	// means connect directly. Use config.UpstreamProxy.ProxyFunc to build one.
 	UpstreamProxy func(*http.Request) (*url.URL, error)
+	// Ready, when non-nil, gates request handling: while it returns false
+	// every proxied request is rejected with 503. Managed proxies use it to
+	// fail closed until the first control-plane config has been applied, so
+	// requests can never pass through un-transformed (leaking placeholder
+	// credentials upstream) during startup.
+	Ready func() bool
 }
 
 // New creates a new Proxy. In TLSModeMITM, certCache must be non-nil. In
@@ -92,6 +99,7 @@ func New(opts Options) *Proxy {
 		guard, _ = dnsguard.New(nil)
 	}
 	p := &Proxy{
+		ready:          opts.Ready,
 		httpsAddr:      opts.HTTPSAddr,
 		tlsMode:        opts.TLSMode,
 		tunnelAddr:     opts.TunnelAddr,
@@ -254,6 +262,12 @@ func (p *Proxy) handleDirectHTTP(w http.ResponseWriter, r *http.Request) {
 // handleHTTP is the core HTTP request handler. tunnelInfo is non-nil only
 // when r originated inside a CONNECT/SOCKS5 tunnel.
 func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *transform.TunnelInfo) {
+	if p.ready != nil && !p.ready() {
+		// Fail closed: without a control-plane config the pipeline would pass
+		// requests through un-transformed.
+		http.Error(w, "proxy is not ready: awaiting control-plane config", http.StatusServiceUnavailable)
+		return
+	}
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -831,4 +832,50 @@ func TestContainsDotSegments(t *testing.T) {
 			require.Equal(t, tc.want, containsDotSegments(tc.path))
 		})
 	}
+}
+
+func TestHTTPProxy_FailsClosedUntilReady(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	caCert, caKey := generateTestCA(t)
+	cache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
+	holder := transform.NewPipelineHolder(pipeline)
+
+	var ready atomic.Bool
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		CertCache: cache,
+		Pipeline:  holder,
+		Logger:    testLogger(),
+		Ready:     ready.Load,
+	})
+
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = p.httpServer.Serve(httpLn) }()
+	t.Cleanup(func() { _ = p.httpServer.Close() })
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/test", httpLn.Addr()), nil)
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	// Not ready: the proxy must reject rather than pass the request through
+	// an un-synced pipeline.
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+	// Ready: the same request flows.
+	ready.Store(true)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
## Problem

Two related gaps for managed (control-plane-synced) proxies:

1. **No way to observe or accelerate config application.** A control plane that reassigns a proxy's principal (e.g. binding a warm sandbox to a session at claim time) has no way to know when the proxy has actually applied the new config — the only option is sleeping longer than the 5s poll interval and hoping. We hit exactly this in production: the first LLM call after a principal reassignment beat the proxy's next sync poll by ~350ms and went upstream with the placeholder credential still in the header (401 from the upstream API).
2. **Fail-open startup.** A freshly started managed proxy serves requests with whatever pipeline it has — including the empty pre-first-sync pipeline — so requests during startup pass through un-transformed, leaking placeholder credentials upstream.

## Changes

- **Managed-mode management server**: `management.listen` is now allowed in managed mode, serving:
  - `GET /v1/status` → `{config_hash, principal_id, principal_status, synced_once, last_sync_at}` — the applied control-plane state, so an operator/control plane can verify which principal's config the proxy is enforcing before routing traffic through it
  - `POST /v1/sync` → non-blocking immediate sync request (poller `Poke()`); callers poll `/v1/status` to observe the result
  - `/v1/reload` stays standalone-only (404 in managed mode — no file to re-read)
- **`IRON_MANAGEMENT_LISTEN`** env override, consistent with the other `IRON_*` vars (managed proxies have no config file)
- **`SyncResponse`** now parses the control plane's `status` / `principal_id` fields; the poller records them in a snapshot (retained across hash-match responses, seeded from the startup sync)
- **Fail-closed startup**: new `proxy.Options.Ready` gates request handling with 503 until the first control-plane config is applied (wired in managed mode; standalone unaffected)

## Tests

- poller: poke triggers immediate sync; status snapshot updates and retains principal across hash-match responses; seed semantics
- management: auth/method/availability matrix for `/v1/status` and `/v1/sync`; `/v1/reload` 404s in managed mode
- proxy: requests 503 while not ready, flow once ready

`go test ./...` — 28/28 packages pass.