### PR TITLE
feat(hostmatch): match rules by source IP / CIDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,26 @@ configured authorize and complete endpoints; ordinary proxied traffic remains
 subject to the full upstream deny list. Public, loopback, link-local, and cloud
 metadata ranges cannot be added through this setting.
 
+### Rule matching
+
+Transforms that take a `rules:` list share one matcher. A rule matches when
+every field it sets matches the request:
+
+```yaml
+rules:
+  - host: "api.openai.com" # domain glob; mutually exclusive with cidr
+    cidr: "10.0.0.0/8" # matches a literal-IP host
+    source_ip: "10.1.0.0/16" # client source address; CIDR or single IP
+    methods: ["POST"] # omitted or ["*"] matches all methods
+    paths: ["/v1/*"] # omitted matches all paths
+```
+
+`source_ip` matches the address the request arrived from, not the destination.
+Use it to give one proxy a different policy per client: each rule applies only
+to the source range it names. A rule that omits `source_ip` matches any
+source. A rule that sets it never matches a client address the proxy cannot
+parse as an IP.
+
 ### Allowlist
 
 Default-deny. Requests must match at least one domain glob or CIDR to proceed.

--- a/internal/hostmatch/hostmatch.go
+++ b/internal/hostmatch/hostmatch.go
@@ -56,6 +56,16 @@ func (m *Matcher) Matches(host string) bool {
 	return false
 }
 
+// MatchesIP returns true if the IP is contained by any configured CIDR.
+func (m *Matcher) MatchesIP(ip net.IP) bool {
+	for _, cidr := range m.cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchGlob matches a domain against a glob pattern.
 // "*" matches any host. "*.example.com" matches any subdomain depth and
 // "example.com" itself.

--- a/internal/hostmatch/hostmatch.go
+++ b/internal/hostmatch/hostmatch.go
@@ -56,16 +56,6 @@ func (m *Matcher) Matches(host string) bool {
 	return false
 }
 
-// MatchesIP returns true if the IP is contained by any configured CIDR.
-func (m *Matcher) MatchesIP(ip net.IP) bool {
-	for _, cidr := range m.cidrs {
-		if cidr.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
 // MatchGlob matches a domain against a glob pattern.
 // "*" matches any host. "*.example.com" matches any subdomain depth and
 // "example.com" itself.

--- a/internal/hostmatch/rule.go
+++ b/internal/hostmatch/rule.go
@@ -2,29 +2,46 @@ package hostmatch
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 )
 
 // RuleConfig is the YAML-decoded form of a host/method/path matching rule.
 type RuleConfig struct {
-	Host    string   `yaml:"host,omitempty"`
-	CIDR    string   `yaml:"cidr,omitempty"`
-	Methods []string `yaml:"methods,omitempty"`
-	Paths   []string `yaml:"paths,omitempty"`
+	Host     string   `yaml:"host,omitempty"`
+	CIDR     string   `yaml:"cidr,omitempty"`
+	SourceIP string   `yaml:"source_ip,omitempty"`
+	Methods  []string `yaml:"methods,omitempty"`
+	Paths    []string `yaml:"paths,omitempty"`
 }
 
 // Rule is a compiled matching rule ready for use.
 type Rule struct {
-	Matcher *Matcher
-	Methods map[string]bool // nil = all methods
-	Paths   []string        // nil = all paths
+	Matcher       *Matcher
+	SourceMatcher *Matcher
+	Methods       map[string]bool // nil = all methods
+	Paths         []string        // nil = all paths
 }
 
 // Matches returns true if the request matches this rule.
 func (r *Rule) Matches(host, method, path string) bool {
+	return r.MatchesWithRemote(host, method, path, "")
+}
+
+// MatchesWithRemote returns true if the request and remote address match this rule.
+func (r *Rule) MatchesWithRemote(host, method, path string, remoteAddr string) bool {
 	if !r.Matcher.Matches(host) {
 		return false
+	}
+	if r.SourceMatcher != nil {
+		remoteIP := remoteAddr
+		if hostPart, _, err := net.SplitHostPort(remoteAddr); err == nil {
+			remoteIP = hostPart
+		}
+		if ip := net.ParseIP(remoteIP); ip == nil || !r.SourceMatcher.MatchesIP(ip) {
+			return false
+		}
 	}
 	if r.Methods != nil && !r.Methods[method] {
 		return false
@@ -60,13 +77,21 @@ func CompileRules(configs []RuleConfig, prefix string) ([]Rule, error) {
 			return nil, fmt.Errorf("%s: rules[%d]: %w", prefix, i, err)
 		}
 
+		var sourceMatcher *Matcher
+		if rc.SourceIP != "" {
+			sourceMatcher, err = New(nil, []string{toSourceCIDR(rc.SourceIP)})
+			if err != nil {
+				return nil, fmt.Errorf("%s: rules[%d]: source_ip: %w", prefix, i, err)
+			}
+		}
+
 		for _, p := range rc.Paths {
 			if !strings.HasPrefix(p, "/") {
 				return nil, fmt.Errorf("%s: rules[%d]: path %q must start with /", prefix, i, p)
 			}
 		}
 
-		r := Rule{Matcher: m}
+		r := Rule{Matcher: m, SourceMatcher: sourceMatcher}
 		if !isWildcard(rc.Methods) {
 			r.Methods = make(map[string]bool, len(rc.Methods))
 			for _, method := range rc.Methods {
@@ -90,9 +115,19 @@ func isWildcard(methods []string) bool {
 func MatchAnyRule(rules []Rule, req *http.Request) bool {
 	host := StripPort(req.Host)
 	for _, r := range rules {
-		if r.Matches(host, req.Method, req.URL.Path) {
+		if r.MatchesWithRemote(host, req.Method, req.URL.Path, req.RemoteAddr) {
 			return true
 		}
 	}
 	return false
+}
+
+func toSourceCIDR(sourceIP string) string {
+	if strings.Contains(sourceIP, "/") {
+		return sourceIP
+	}
+	if strings.Contains(sourceIP, ":") {
+		return sourceIP + "/128"
+	}
+	return sourceIP + "/32"
 }

--- a/internal/hostmatch/rule.go
+++ b/internal/hostmatch/rule.go
@@ -18,30 +18,21 @@ type RuleConfig struct {
 
 // Rule is a compiled matching rule ready for use.
 type Rule struct {
-	Matcher       *Matcher
-	SourceMatcher *Matcher
-	Methods       map[string]bool // nil = all methods
-	Paths         []string        // nil = all paths
+	Matcher  *Matcher
+	SourceIP *net.IPNet      // nil = any source address
+	Methods  map[string]bool // nil = all methods
+	Paths    []string        // nil = all paths
 }
 
-// Matches returns true if the request matches this rule.
-func (r *Rule) Matches(host, method, path string) bool {
-	return r.MatchesWithRemote(host, method, path, "")
-}
-
-// MatchesWithRemote returns true if the request and remote address match this rule.
-func (r *Rule) MatchesWithRemote(host, method, path string, remoteAddr string) bool {
+// Matches returns true if the request matches this rule. remoteAddr is the
+// client address ("host:port" or a bare IP); it is only read when the rule
+// sets SourceIP. A rule with SourceIP never matches an unparsable address.
+func (r *Rule) Matches(host, method, path, remoteAddr string) bool {
 	if !r.Matcher.Matches(host) {
 		return false
 	}
-	if r.SourceMatcher != nil {
-		remoteIP := remoteAddr
-		if hostPart, _, err := net.SplitHostPort(remoteAddr); err == nil {
-			remoteIP = hostPart
-		}
-		if ip := net.ParseIP(remoteIP); ip == nil || !r.SourceMatcher.MatchesIP(ip) {
-			return false
-		}
+	if r.SourceIP != nil && !r.SourceIP.Contains(net.ParseIP(StripPort(remoteAddr))) {
+		return false
 	}
 	if r.Methods != nil && !r.Methods[method] {
 		return false
@@ -77,11 +68,11 @@ func CompileRules(configs []RuleConfig, prefix string) ([]Rule, error) {
 			return nil, fmt.Errorf("%s: rules[%d]: %w", prefix, i, err)
 		}
 
-		var sourceMatcher *Matcher
+		var sourceIP *net.IPNet
 		if rc.SourceIP != "" {
-			sourceMatcher, err = New(nil, []string{toSourceCIDR(rc.SourceIP)})
+			_, sourceIP, err = net.ParseCIDR(sourceCIDR(rc.SourceIP))
 			if err != nil {
-				return nil, fmt.Errorf("%s: rules[%d]: source_ip: %w", prefix, i, err)
+				return nil, fmt.Errorf("%s: rules[%d]: source_ip %q: %w", prefix, i, rc.SourceIP, err)
 			}
 		}
 
@@ -91,7 +82,7 @@ func CompileRules(configs []RuleConfig, prefix string) ([]Rule, error) {
 			}
 		}
 
-		r := Rule{Matcher: m, SourceMatcher: sourceMatcher}
+		r := Rule{Matcher: m, SourceIP: sourceIP}
 		if !isWildcard(rc.Methods) {
 			r.Methods = make(map[string]bool, len(rc.Methods))
 			for _, method := range rc.Methods {
@@ -115,14 +106,16 @@ func isWildcard(methods []string) bool {
 func MatchAnyRule(rules []Rule, req *http.Request) bool {
 	host := StripPort(req.Host)
 	for _, r := range rules {
-		if r.MatchesWithRemote(host, req.Method, req.URL.Path, req.RemoteAddr) {
+		if r.Matches(host, req.Method, req.URL.Path, req.RemoteAddr) {
 			return true
 		}
 	}
 	return false
 }
 
-func toSourceCIDR(sourceIP string) string {
+// sourceCIDR widens a bare IP address into a single-address CIDR block and
+// returns any other input unchanged.
+func sourceCIDR(sourceIP string) string {
 	if strings.Contains(sourceIP, "/") {
 		return sourceIP
 	}

--- a/internal/hostmatch/rule_test.go
+++ b/internal/hostmatch/rule_test.go
@@ -1,6 +1,8 @@
 package hostmatch
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +17,7 @@ func TestCompileRules_WildcardMethodMatchesAll(t *testing.T) {
 	require.Nil(t, rules[0].Methods, "wildcard method should result in nil Methods (match all)")
 
 	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"} {
-		require.True(t, rules[0].Matches("example.com", method, "/"), "method %s should match", method)
+		require.True(t, rules[0].Matches("example.com", method, "/", ""), "method %s should match", method)
 	}
 }
 
@@ -27,9 +29,9 @@ func TestCompileRules_ExplicitMethodsFiltered(t *testing.T) {
 	require.Len(t, rules, 1)
 	require.NotNil(t, rules[0].Methods)
 
-	require.True(t, rules[0].Matches("example.com", "GET", "/"))
-	require.True(t, rules[0].Matches("example.com", "POST", "/"))
-	require.False(t, rules[0].Matches("example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "GET", "/", ""))
+	require.True(t, rules[0].Matches("example.com", "POST", "/", ""))
+	require.False(t, rules[0].Matches("example.com", "DELETE", "/", ""))
 }
 
 func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
@@ -40,6 +42,72 @@ func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
 	require.Len(t, rules, 1)
 	require.Nil(t, rules[0].Methods)
 
-	require.True(t, rules[0].Matches("example.com", "GET", "/"))
-	require.True(t, rules[0].Matches("example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "GET", "/", ""))
+	require.True(t, rules[0].Matches("example.com", "DELETE", "/", ""))
+}
+
+func TestCompileRules_SourceIPMatching(t *testing.T) {
+	cases := []struct {
+		name       string
+		sourceIP   string
+		remoteAddr string
+		want       bool
+	}{
+		{name: "unset matches any source", sourceIP: "", remoteAddr: "203.0.113.9:5000", want: true},
+		{name: "unset matches empty source", sourceIP: "", remoteAddr: "", want: true},
+		{name: "cidr contains address", sourceIP: "10.1.0.0/16", remoteAddr: "10.1.2.3:44321", want: true},
+		{name: "cidr excludes address", sourceIP: "10.1.0.0/16", remoteAddr: "10.2.2.3:44321", want: false},
+		{name: "bare ip matches itself", sourceIP: "10.1.2.3", remoteAddr: "10.1.2.3:44321", want: true},
+		{name: "bare ip rejects neighbour", sourceIP: "10.1.2.3", remoteAddr: "10.1.2.4:44321", want: false},
+		{name: "address without port", sourceIP: "10.1.0.0/16", remoteAddr: "10.1.2.3", want: true},
+		{name: "ipv6 cidr contains address", sourceIP: "fd00::/8", remoteAddr: "[fd00::1]:44321", want: true},
+		{name: "ipv6 bare address", sourceIP: "fd00::1", remoteAddr: "fd00::1", want: true},
+		{name: "unparsable address never matches", sourceIP: "10.1.0.0/16", remoteAddr: "pipe", want: false},
+		{name: "empty address never matches", sourceIP: "10.1.0.0/16", remoteAddr: "", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rules, err := CompileRules([]RuleConfig{
+				{Host: "example.com", SourceIP: tc.sourceIP},
+			}, "test")
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+			require.Equal(t, tc.want, rules[0].Matches("example.com", "GET", "/", tc.remoteAddr))
+		})
+	}
+}
+
+func TestCompileRules_SourceIPCombinesWithHostAndMethod(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{
+		{Host: "example.com", SourceIP: "10.1.0.0/16", Methods: []string{"GET"}},
+	}, "test")
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+
+	require.True(t, rules[0].Matches("example.com", "GET", "/", "10.1.2.3:44321"))
+	require.False(t, rules[0].Matches("other.com", "GET", "/", "10.1.2.3:44321"), "host must still gate")
+	require.False(t, rules[0].Matches("example.com", "POST", "/", "10.1.2.3:44321"), "method must still gate")
+}
+
+func TestCompileRules_SourceIPInvalid(t *testing.T) {
+	_, err := CompileRules([]RuleConfig{
+		{Host: "example.com", SourceIP: "not-an-ip"},
+	}, "test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "source_ip")
+}
+
+func TestMatchAnyRule_SourceIPUsesRequestRemoteAddr(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{
+		{Host: "example.com", SourceIP: "10.1.0.0/16"},
+	}, "test")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.RemoteAddr = "10.1.2.3:44321"
+	require.True(t, MatchAnyRule(rules, req))
+
+	req.RemoteAddr = "10.2.2.3:44321"
+	require.False(t, MatchAnyRule(rules, req))
 }

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -198,7 +198,7 @@ func (p *Policy) MatchServer(req *http.Request) *Server {
 	host := hostmatch.StripPort(req.Host)
 	for _, s := range p.servers {
 		for _, r := range s.rules {
-			if r.Matches(host, req.Method, req.URL.Path) {
+			if r.Matches(host, req.Method, req.URL.Path, req.RemoteAddr) {
 				return s
 			}
 		}

--- a/internal/mcpgateway/gateway.go
+++ b/internal/mcpgateway/gateway.go
@@ -206,7 +206,7 @@ func (g *Gateway) Match(req *http.Request) *Route {
 	host := hostmatch.StripPort(req.Host)
 	for _, route := range g.routes {
 		for _, rule := range route.rules {
-			if rule.Matches(host, req.Method, req.URL.Path) {
+			if rule.Matches(host, req.Method, req.URL.Path, req.RemoteAddr) {
 				return route
 			}
 		}


### PR DESCRIPTION
## Use case

One iron-proxy in front of many mutually-isolated sandbox containers needs a different allowlist and a different secret set per container.
Today that needs one proxy process per container, because a rule can only match the destination.
`source_ip` lets a single rule apply only to requests from one client address range, so one proxy can serve them all.

## What changed

`RuleConfig` takes an optional `source_ip`: a CIDR block or a single IP address, matched against the client's source address.
`Rule.Matches` takes the client address as a fourth argument, so every caller passes it and no path can skip the check.
A rule that leaves `source_ip` unset matches any source, so existing configs behave exactly as before.

## Tests

`go test -race -count=1 ./internal/hostmatch/` — covers a CIDR block, a single IP, IPv6, an address with and without a port, and an unparsable address.
`TestMatchAnyRule_SourceIPUsesRequestRemoteAddr` proves the value reaches the matcher from `http.Request.RemoteAddr`.

## Relation to #184

#184 is the larger change: proxy client authentication plus scoping by proxy login *and* source CIDR.
This PR is only the source-CIDR half, with no auth surface.
If #184 lands first, close this one — the field here is a strict subset.
