### PR TITLE
feat(reload): reload config on SIGHUP in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,19 @@ curl -X POST http://127.0.0.1:9092/v1/reload \
   -H "Authorization: Bearer $IRON_MANAGEMENT_API_KEY"
 ```
 
+### Reload with SIGHUP
+
+A proxy started with `--config` also reloads on `SIGHUP`, which does the same
+work as `POST /v1/reload` and needs no management server and no token:
+
+```bash
+kill -HUP "$(pidof iron-proxy)"
+```
+
+SIGHUP never stops the proxy. An invalid config leaves the running pipeline in
+place and logs the error. Managed mode has no config file to re-read, so it
+logs the signal and ignores it.
+
 ## iron.sh
 
 Need Vault/KMS secret backends, a Kubernetes operator, or centralized policy

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -268,17 +268,32 @@ func main() {
 		logger.Info("transform pipeline", slog.String("transforms", pipeline.Names()))
 	}
 
-	// Wait for shutdown signal or fatal error from any background goroutine.
+	// Wait for reload/shutdown signal or fatal error from any background goroutine.
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-	select {
-	case sig := <-sigc:
-		logger.Info("received signal, shutting down", slog.String("signal", sig.String()))
-	case err := <-errc:
-		logger.Error("fatal error", slog.String("error", err.Error()))
+	for {
+		select {
+		case sig := <-sigc:
+			if sig == syscall.SIGHUP {
+				if !managed && *configPath != "" {
+					if err := newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger)(context.Background()); err != nil {
+						logger.Error("standalone config reload failed", slog.String("error", err.Error()))
+					}
+				} else {
+					logger.Warn("ignoring SIGHUP in managed mode or without config file")
+				}
+				continue
+			}
+			logger.Info("received signal, shutting down", slog.String("signal", sig.String()))
+			goto shutdown
+		case err := <-errc:
+			logger.Error("fatal error", slog.String("error", err.Error()))
+			goto shutdown
+		}
 	}
 
+shutdown:
 	// Cancel context to stop the poller, then shut down services.
 	cancel()
 

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -253,6 +253,14 @@ func main() {
 	// Initialize metrics server.
 	metricsServer := metrics.New(cfg.Metrics.Listen, logger)
 
+	// Standalone mode re-reads the config file on POST /v1/reload and on
+	// SIGHUP. Managed mode keeps the control plane as the source of truth, so
+	// it has no file to re-read and leaves this nil.
+	var reload management.ReloadFunc
+	if !managed && *configPath != "" {
+		reload = newReloadFunc(*configPath, holder, mcpHolder, gatewayHolder, pgManager, bodyLimits, logger)
+	}
+
 	// Initialize management server: /v1/reload in standalone mode,
 	// /v1/status and /v1/sync in managed mode.
 	var mgmtServer *management.Server
@@ -267,7 +275,7 @@ func main() {
 			mgmtOpts.Status = func() any { return poller.Status() }
 			mgmtOpts.SyncNow = poller.Poke
 		} else {
-			mgmtOpts.Reload = newReloadFunc(*configPath, holder, mcpHolder, gatewayHolder, pgManager, bodyLimits, logger)
+			mgmtOpts.Reload = reload
 		}
 		mgmtServer = management.New(mgmtOpts)
 	}
@@ -301,32 +309,13 @@ func main() {
 		logger.Info("transform pipeline", slog.String("transforms", pipeline.Names()))
 	}
 
-	// Wait for reload/shutdown signal or fatal error from any background goroutine.
+	// Wait for a reload signal, a shutdown signal, or a fatal error from any
+	// background goroutine.
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-	for {
-		select {
-		case sig := <-sigc:
-			if sig == syscall.SIGHUP {
-				if !managed && *configPath != "" {
-					if err := newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger)(context.Background()); err != nil {
-						logger.Error("standalone config reload failed", slog.String("error", err.Error()))
-					}
-				} else {
-					logger.Warn("ignoring SIGHUP in managed mode or without config file")
-				}
-				continue
-			}
-			logger.Info("received signal, shutting down", slog.String("signal", sig.String()))
-			goto shutdown
-		case err := <-errc:
-			logger.Error("fatal error", slog.String("error", err.Error()))
-			goto shutdown
-		}
-	}
+	awaitShutdown(ctx, sigc, errc, reload, logger)
 
-shutdown:
 	// Cancel context to stop the poller, then shut down services.
 	cancel()
 
@@ -359,6 +348,34 @@ shutdown:
 	}
 
 	logger.Info("iron-proxy stopped")
+}
+
+// awaitShutdown blocks until a shutdown signal or a fatal error arrives.
+// SIGHUP does not stop the proxy. It runs reload, which re-reads the config
+// file and swaps the transform pipeline in place. A failed reload leaves the
+// running pipeline untouched. A nil reload means there is no config file to
+// re-read, so the signal is logged and ignored.
+func awaitShutdown(ctx context.Context, sigc <-chan os.Signal, errc <-chan error, reload management.ReloadFunc, logger *slog.Logger) {
+	for {
+		select {
+		case sig := <-sigc:
+			if sig == syscall.SIGHUP {
+				if reload == nil {
+					logger.Warn("ignoring SIGHUP: no config file to re-read")
+					continue
+				}
+				if err := reload(ctx); err != nil {
+					logger.Error("config reload failed", slog.String("error", err.Error()))
+				}
+				continue
+			}
+			logger.Info("received signal, shutting down", slog.String("signal", sig.String()))
+			return
+		case err := <-errc:
+			logger.Error("fatal error", slog.String("error", err.Error()))
+			return
+		}
+	}
 }
 
 // initManaged registers with the control plane, performs an initial sync, builds

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -4,13 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ironsh/iron-proxy/internal/management"
 	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
@@ -362,4 +367,95 @@ func TestApplyPipelineSync_PreservesAuditFunc(t *testing.T) {
 
 	holder.Load().EmitAudit(nil)
 	require.True(t, called, "audit func should be carried over to the new pipeline")
+}
+
+// testLogger discards output; these tests assert on behavior, not on logs.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// runAwaitShutdown starts awaitShutdown and returns the channels that drive it
+// plus a channel that closes when it returns.
+func runAwaitShutdown(reload management.ReloadFunc) (chan os.Signal, chan error, chan struct{}) {
+	sigc := make(chan os.Signal, 1)
+	errc := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		awaitShutdown(context.Background(), sigc, errc, reload, testLogger())
+		close(done)
+	}()
+	return sigc, errc, done
+}
+
+func requireStillRunning(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+		t.Fatal("awaitShutdown returned; the proxy must keep running")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func requireStopped(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("awaitShutdown did not return")
+	}
+}
+
+func TestAwaitShutdown_SIGHUPReloadsAndKeepsRunning(t *testing.T) {
+	var reloads atomic.Int32
+	sigc, _, done := runAwaitShutdown(func(context.Context) error {
+		reloads.Add(1)
+		return nil
+	})
+
+	sigc <- syscall.SIGHUP
+	require.Eventually(t, func() bool { return reloads.Load() == 1 },
+		2*time.Second, 5*time.Millisecond, "SIGHUP must trigger a reload")
+	requireStillRunning(t, done)
+
+	sigc <- syscall.SIGHUP
+	require.Eventually(t, func() bool { return reloads.Load() == 2 },
+		2*time.Second, 5*time.Millisecond, "every SIGHUP must trigger a reload")
+	requireStillRunning(t, done)
+
+	sigc <- syscall.SIGTERM
+	requireStopped(t, done)
+	require.Equal(t, int32(2), reloads.Load())
+}
+
+func TestAwaitShutdown_FailedReloadKeepsRunning(t *testing.T) {
+	var reloads atomic.Int32
+	sigc, _, done := runAwaitShutdown(func(context.Context) error {
+		reloads.Add(1)
+		return errors.New("bad config")
+	})
+
+	sigc <- syscall.SIGHUP
+	require.Eventually(t, func() bool { return reloads.Load() == 1 },
+		2*time.Second, 5*time.Millisecond)
+	requireStillRunning(t, done)
+
+	sigc <- syscall.SIGINT
+	requireStopped(t, done)
+}
+
+func TestAwaitShutdown_SIGHUPIgnoredWithoutReload(t *testing.T) {
+	sigc, _, done := runAwaitShutdown(nil)
+
+	sigc <- syscall.SIGHUP
+	requireStillRunning(t, done)
+
+	sigc <- syscall.SIGTERM
+	requireStopped(t, done)
+}
+
+func TestAwaitShutdown_FatalErrorStops(t *testing.T) {
+	_, errc, done := runAwaitShutdown(func(context.Context) error { return nil })
+
+	errc <- errors.New("proxy: listener closed")
+	requireStopped(t, done)
 }


### PR DESCRIPTION
## Use case

Our orchestration rotates allowlists and file-sourced secrets by writing the config file atomically, then telling the proxy to pick it up.
Today that needs the management server plus a bearer token, or a full restart that drops every in-flight connection.
`SIGHUP` gives a long-lived standalone proxy the same reload with no extra listener and no token.

## What changed

A proxy started with `--config` handles `SIGHUP` by running the same reload as `POST /v1/reload`, then keeps serving.
The reload closure is now built once and shared by both paths, instead of the management-server block owning the only copy.
Managed mode has no config file to re-read, so it logs the signal and ignores it. Nothing else about shutdown changes.

## Tests

`go test -race -count=1 ./cmd/iron-proxy/` — four cases on `awaitShutdown`:
SIGHUP reloads and the proxy keeps running, a reload that returns an error keeps it running, a proxy with no config file ignores SIGHUP, and a fatal error on the error channel still stops it.
