### PR TITLE
feat(secrets): allow CONNECT tunnels without a match header

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,13 @@ values before forwarding upstream. You control where it looks:
 - **`require`:** when `true`, requests to a matching host that do **not** contain
   the proxy token are rejected with 403. This prevents a compromised workload
   from bypassing the secret-swap mechanism with alternative credentials. Default: `false`.
+- **`allow_connect_without_header`:** narrows `require` for tunnelled traffic.
+  A `CONNECT` request opens a tunnel and carries none of the headers in
+  `match_headers`, so `require: true` rejects it. Set this to `true` to let
+  such a request through untransformed. A `CONNECT` that does carry a
+  `match_headers` header is still rejected when the token is wrong, and every
+  other method is still rejected. It has no effect when `match_headers` is
+  empty, because an empty list scans all headers. Default: `false`.
 - **`hosts`:** restrict swapping to specific domains or CIDRs.
 
 Query parameters are always scanned.

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -39,19 +39,21 @@ type secretEntry struct {
 
 	// Deprecated top-level fields for backwards compatibility.
 	// Users should migrate to the replace block.
-	ProxyValue   string   `yaml:"proxy_value,omitempty"`
-	MatchHeaders []string `yaml:"match_headers,omitempty"`
-	MatchBody    bool     `yaml:"match_body,omitempty"`
-	Require      bool     `yaml:"require,omitempty"`
+	ProxyValue                string   `yaml:"proxy_value,omitempty"`
+	MatchHeaders              []string `yaml:"match_headers,omitempty"`
+	MatchBody                 bool     `yaml:"match_body,omitempty"`
+	Require                   bool     `yaml:"require,omitempty"`
+	AllowConnectWithoutHeader bool     `yaml:"allow_connect_without_header,omitempty"`
 }
 
 type replaceConfig struct {
-	ProxyValue   string   `yaml:"proxy_value"`
-	MatchHeaders []string `yaml:"match_headers,omitempty"`
-	MatchBody    bool     `yaml:"match_body,omitempty"`
-	MatchPath    bool     `yaml:"match_path,omitempty"`
-	MatchQuery   bool     `yaml:"match_query,omitempty"`
-	Require      bool     `yaml:"require,omitempty"`
+	ProxyValue                string   `yaml:"proxy_value"`
+	MatchHeaders              []string `yaml:"match_headers,omitempty"`
+	MatchBody                 bool     `yaml:"match_body,omitempty"`
+	MatchPath                 bool     `yaml:"match_path,omitempty"`
+	MatchQuery                bool     `yaml:"match_query,omitempty"`
+	Require                   bool     `yaml:"require,omitempty"`
+	AllowConnectWithoutHeader bool     `yaml:"allow_connect_without_header,omitempty"`
 }
 
 type injectConfig struct {
@@ -70,12 +72,13 @@ type resolvedSecret struct {
 	rules  []hostmatch.Rule
 
 	// replace mode fields
-	proxyValue   string
-	matchHeaders []headerMatcher // empty = all headers
-	matchBody    bool
-	matchPath    bool
-	matchQuery   bool
-	require      bool
+	proxyValue                string
+	matchHeaders              []headerMatcher // empty = all headers
+	matchBody                 bool
+	matchPath                 bool
+	matchQuery                bool
+	require                   bool
+	allowConnectWithoutHeader bool
 
 	// inject mode fields
 	injectHeader     string
@@ -240,15 +243,16 @@ func newFromConfig(cfg secretsConfig, registry sourceBuilderRegistry) (*Secrets,
 				return nil, err
 			}
 			resolved = append(resolved, resolvedSecret{
-				source:       source,
-				mode:         "replace",
-				proxyValue:   replace.ProxyValue,
-				matchHeaders: matchers,
-				matchBody:    replace.MatchBody,
-				matchPath:    replace.MatchPath,
-				matchQuery:   replace.MatchQuery,
-				require:      replace.Require,
-				rules:        rules,
+				source:                    source,
+				mode:                      "replace",
+				proxyValue:                replace.ProxyValue,
+				matchHeaders:              matchers,
+				matchBody:                 replace.MatchBody,
+				matchPath:                 replace.MatchPath,
+				matchQuery:                replace.MatchQuery,
+				require:                   replace.Require,
+				allowConnectWithoutHeader: replace.AllowConnectWithoutHeader,
+				rules:                     rules,
 			})
 		}
 	}
@@ -307,10 +311,11 @@ func normalizeEntry(i int, entry *secretEntry) (*replaceConfig, *injectConfig, e
 		return nil, nil, fmt.Errorf("secrets[%d]: proxy_value is required", i)
 	}
 	return &replaceConfig{
-		ProxyValue:   entry.ProxyValue,
-		MatchHeaders: entry.MatchHeaders,
-		MatchBody:    entry.MatchBody,
-		Require:      entry.Require,
+		ProxyValue:                entry.ProxyValue,
+		MatchHeaders:              entry.MatchHeaders,
+		MatchBody:                 entry.MatchBody,
+		Require:                   entry.Require,
+		AllowConnectWithoutHeader: entry.AllowConnectWithoutHeader,
 	}, nil, nil
 }
 
@@ -386,7 +391,7 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 		if len(locations) > 0 {
 			swapped = append(swapped, secretRecord{Secret: name, Locations: locations})
-		} else if sec.require {
+		} else if sec.require && !allowConnectWithoutHeader(req, &sec) {
 			tctx.Annotate("rejected", name)
 			return &transform.TransformResult{Action: transform.ActionReject}, nil
 		}
@@ -403,6 +408,26 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	}
 
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func allowConnectWithoutHeader(req *http.Request, sec *resolvedSecret) bool {
+	if !sec.allowConnectWithoutHeader || req.Method != http.MethodConnect || len(sec.matchHeaders) == 0 {
+		return false
+	}
+	for _, matcher := range sec.matchHeaders {
+		if matcher.re != nil {
+			for headerName := range req.Header {
+				if matcher.re.MatchString(http.CanonicalHeaderKey(headerName)) {
+					return false
+				}
+			}
+			continue
+		}
+		if len(req.Header.Values(matcher.name)) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Secrets) injectSecret(req *http.Request, sec *resolvedSecret, realValue string) ([]string, error) {

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -39,21 +39,25 @@ type secretEntry struct {
 
 	// Deprecated top-level fields for backwards compatibility.
 	// Users should migrate to the replace block.
-	ProxyValue                string   `yaml:"proxy_value,omitempty"`
-	MatchHeaders              []string `yaml:"match_headers,omitempty"`
-	MatchBody                 bool     `yaml:"match_body,omitempty"`
-	Require                   bool     `yaml:"require,omitempty"`
-	AllowConnectWithoutHeader bool     `yaml:"allow_connect_without_header,omitempty"`
+	ProxyValue   string   `yaml:"proxy_value,omitempty"`
+	MatchHeaders []string `yaml:"match_headers,omitempty"`
+	MatchBody    bool     `yaml:"match_body,omitempty"`
+	Require      bool     `yaml:"require,omitempty"`
+
+	AllowConnectWithoutHeader bool `yaml:"allow_connect_without_header,omitempty"`
 }
 
 type replaceConfig struct {
-	ProxyValue                string   `yaml:"proxy_value"`
-	MatchHeaders              []string `yaml:"match_headers,omitempty"`
-	MatchBody                 bool     `yaml:"match_body,omitempty"`
-	MatchPath                 bool     `yaml:"match_path,omitempty"`
-	MatchQuery                bool     `yaml:"match_query,omitempty"`
-	Require                   bool     `yaml:"require,omitempty"`
-	AllowConnectWithoutHeader bool     `yaml:"allow_connect_without_header,omitempty"`
+	ProxyValue   string   `yaml:"proxy_value"`
+	MatchHeaders []string `yaml:"match_headers,omitempty"`
+	MatchBody    bool     `yaml:"match_body,omitempty"`
+	MatchPath    bool     `yaml:"match_path,omitempty"`
+	MatchQuery   bool     `yaml:"match_query,omitempty"`
+	Require      bool     `yaml:"require,omitempty"`
+
+	// AllowConnectWithoutHeader keeps a required secret from rejecting a
+	// CONNECT tunnel that carries none of MatchHeaders.
+	AllowConnectWithoutHeader bool `yaml:"allow_connect_without_header,omitempty"`
 }
 
 type injectConfig struct {
@@ -72,12 +76,13 @@ type resolvedSecret struct {
 	rules  []hostmatch.Rule
 
 	// replace mode fields
-	proxyValue                string
-	matchHeaders              []headerMatcher // empty = all headers
-	matchBody                 bool
-	matchPath                 bool
-	matchQuery                bool
-	require                   bool
+	proxyValue   string
+	matchHeaders []headerMatcher // empty = all headers
+	matchBody    bool
+	matchPath    bool
+	matchQuery   bool
+	require      bool
+
 	allowConnectWithoutHeader bool
 
 	// inject mode fields
@@ -243,16 +248,17 @@ func newFromConfig(cfg secretsConfig, registry sourceBuilderRegistry) (*Secrets,
 				return nil, err
 			}
 			resolved = append(resolved, resolvedSecret{
-				source:                    source,
-				mode:                      "replace",
-				proxyValue:                replace.ProxyValue,
-				matchHeaders:              matchers,
-				matchBody:                 replace.MatchBody,
-				matchPath:                 replace.MatchPath,
-				matchQuery:                replace.MatchQuery,
-				require:                   replace.Require,
+				source:       source,
+				mode:         "replace",
+				proxyValue:   replace.ProxyValue,
+				matchHeaders: matchers,
+				matchBody:    replace.MatchBody,
+				matchPath:    replace.MatchPath,
+				matchQuery:   replace.MatchQuery,
+				require:      replace.Require,
+				rules:        rules,
+
 				allowConnectWithoutHeader: replace.AllowConnectWithoutHeader,
-				rules:                     rules,
 			})
 		}
 	}
@@ -311,10 +317,11 @@ func normalizeEntry(i int, entry *secretEntry) (*replaceConfig, *injectConfig, e
 		return nil, nil, fmt.Errorf("secrets[%d]: proxy_value is required", i)
 	}
 	return &replaceConfig{
-		ProxyValue:                entry.ProxyValue,
-		MatchHeaders:              entry.MatchHeaders,
-		MatchBody:                 entry.MatchBody,
-		Require:                   entry.Require,
+		ProxyValue:   entry.ProxyValue,
+		MatchHeaders: entry.MatchHeaders,
+		MatchBody:    entry.MatchBody,
+		Require:      entry.Require,
+
 		AllowConnectWithoutHeader: entry.AllowConnectWithoutHeader,
 	}, nil, nil
 }
@@ -391,7 +398,7 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 
 		if len(locations) > 0 {
 			swapped = append(swapped, secretRecord{Secret: name, Locations: locations})
-		} else if sec.require && !allowConnectWithoutHeader(req, &sec) {
+		} else if sec.require && !sec.allowsUnmatchedConnect(req) {
 			tctx.Annotate("rejected", name)
 			return &transform.TransformResult{Action: transform.ActionReject}, nil
 		}
@@ -410,7 +417,16 @@ func (s *Secrets) TransformRequest(ctx context.Context, tctx *transform.Transfor
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }
 
-func allowConnectWithoutHeader(req *http.Request, sec *resolvedSecret) bool {
+// allowsUnmatchedConnect reports whether a required secret may pass req
+// through untransformed. It is true only when the secret opts in with
+// allow_connect_without_header, req is a CONNECT tunnel, and req carries none
+// of the headers the secret matches on.
+//
+// A CONNECT that does carry a match header still goes through the normal
+// path, so a tunnel that presents the wrong proxy token is still rejected.
+// A secret with no match headers scans every header, so "without a matching
+// header" has no meaning for it and this always returns false.
+func (sec *resolvedSecret) allowsUnmatchedConnect(req *http.Request) bool {
 	if !sec.allowConnectWithoutHeader || req.Method != http.MethodConnect || len(sec.matchHeaders) == 0 {
 		return false
 	}

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -669,6 +669,33 @@ func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
 	require.Equal(t, transform.ActionReject, res.Action)
 }
 
+func TestSecrets_RequireAllowsConnectWithoutHeaderWhenConfigured(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+		e.AllowConnectWithoutHeader = true
+	})})
+
+	req := httptest.NewRequest(http.MethodConnect, "http://api.openai.com:443", nil)
+	req.Host = "api.openai.com:443"
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+}
+
+func TestSecrets_RequireRejectsConnectWithoutHeaderByDefault(t *testing.T) {
+	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+		e.Require = true
+	})})
+
+	req := httptest.NewRequest(http.MethodConnect, "http://api.openai.com:443", nil)
+	req.Host = "api.openai.com:443"
+
+	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+}
+
 func TestSecrets_RequireWithBodySwap(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
 		e.MatchHeaders = nil
@@ -1504,4 +1531,3 @@ func TestLazy_FailureCachedAcrossRequests(t *testing.T) {
 	defer fr.mu.Unlock()
 	require.Equal(t, 1, fr.fetchCalls["MISSING"])
 }
-

--- a/internal/transform/secrets/secrets_test.go
+++ b/internal/transform/secrets/secrets_test.go
@@ -669,7 +669,73 @@ func TestSecrets_RequireRejectsNoHeaders(t *testing.T) {
 	require.Equal(t, transform.ActionReject, res.Action)
 }
 
-func TestSecrets_RequireAllowsConnectWithoutHeaderWhenConfigured(t *testing.T) {
+func TestSecrets_AllowConnectWithoutHeader(t *testing.T) {
+	cases := []struct {
+		name         string
+		allow        bool
+		method       string
+		matchHeaders []string
+		header       string
+		want         transform.TransformAction
+	}{
+		{
+			name:   "opted in, CONNECT with no header, passes through",
+			allow:  true,
+			method: http.MethodConnect,
+			want:   transform.ActionContinue,
+		},
+		{
+			name:   "not opted in, CONNECT with no header, rejected",
+			allow:  false,
+			method: http.MethodConnect,
+			want:   transform.ActionReject,
+		},
+		{
+			name:   "opted in, GET with no header, still rejected",
+			allow:  true,
+			method: http.MethodGet,
+			want:   transform.ActionReject,
+		},
+		{
+			name:   "opted in, CONNECT carrying a wrong token, still rejected",
+			allow:  true,
+			method: http.MethodConnect,
+			header: "Bearer not-the-proxy-value",
+			want:   transform.ActionReject,
+		},
+		{
+			name:         "opted in, CONNECT but secret scans every header, still rejected",
+			allow:        true,
+			method:       http.MethodConnect,
+			matchHeaders: []string{},
+			want:         transform.ActionReject,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
+				e.Require = true
+				e.AllowConnectWithoutHeader = tc.allow
+				if tc.matchHeaders != nil {
+					e.MatchHeaders = tc.matchHeaders
+				}
+			})})
+
+			req := httptest.NewRequest(tc.method, "http://api.openai.com:443", nil)
+			req.Host = "api.openai.com:443"
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+
+			res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, res.Action)
+		})
+	}
+}
+
+func TestSecrets_AllowConnectWithoutHeaderStillSwapsWhenPresent(t *testing.T) {
 	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
 		e.Require = true
 		e.AllowConnectWithoutHeader = true
@@ -677,23 +743,13 @@ func TestSecrets_RequireAllowsConnectWithoutHeaderWhenConfigured(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodConnect, "http://api.openai.com:443", nil)
 	req.Host = "api.openai.com:443"
+	req.Header.Set("Authorization", "Bearer proxy-openai-abc123")
 
 	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionContinue, res.Action)
-}
-
-func TestSecrets_RequireRejectsConnectWithoutHeaderByDefault(t *testing.T) {
-	s := makeSecrets(t, []secretEntry{defaultEntry(func(e *secretEntry) {
-		e.Require = true
-	})})
-
-	req := httptest.NewRequest(http.MethodConnect, "http://api.openai.com:443", nil)
-	req.Host = "api.openai.com:443"
-
-	res, err := s.TransformRequest(context.Background(), &transform.TransformContext{}, req)
-	require.NoError(t, err)
-	require.Equal(t, transform.ActionReject, res.Action)
+	require.Equal(t, "Bearer sk-real-openai-key", req.Header.Get("Authorization"),
+		"opting in must not stop the swap when the header is present")
 }
 
 func TestSecrets_RequireWithBodySwap(t *testing.T) {


### PR DESCRIPTION
> **Retitled.** The old title and body described a `require: false` flag. That flag already exists on main, and this PR never touched it. The change here is narrower; the text below now matches the diff.

## Use case

We run `require: true` so a compromised sandbox cannot reach an upstream with its own credentials instead of the proxy token.
A `CONNECT` request opens a tunnel and carries none of the headers in `match_headers`, so that rule rejects every tunnelled flow.
`allow_connect_without_header: true` lets one rule keep rejecting ordinary requests while stepping aside for a tunnel it cannot inspect.

## Why not `require: false`

`require: false` drops the check for every request shape, including plain HTTP that omits the token on purpose.
This flag gives up rejection only for `CONNECT` with no match header, so default-deny still covers everything else.

## What changed

`secrets.go` adds 42 lines and deletes one: the `require` check now also asks `allowsUnmatchedConnect`.
That returns true only when the secret opts in, the method is `CONNECT`, and the request carries none of its match headers.
Default is `false`, so behaviour is unchanged unless a rule opts in.

## Tests

`go test -race -count=1 ./internal/transform/secrets/` — a table over the cases the carve-out must **not** open:

- opted in, `CONNECT`, no header — passes through
- not opted in, `CONNECT`, no header — rejected (the default)
- opted in, `GET`, no header — still rejected
- opted in, `CONNECT` carrying a wrong token — still rejected
- opted in, but `match_headers` is empty so the secret scans every header — still rejected
- opted in, `CONNECT` carrying the correct proxy token — the swap still runs
