### PR TITLE
feat(oauth): fail open on token mint failure by default

### DIFF
--- a/internal/transform/oauth/oauth.go
+++ b/internal/transform/oauth/oauth.go
@@ -108,6 +108,13 @@ type tokenEntryConfig struct {
 	Header        string                 `yaml:"header,omitempty"`
 	ValuePrefix   string                 `yaml:"value_prefix,omitempty"`
 
+	// Require rejects the request with a 502 when the token cannot be minted.
+	// When false (default), a mint failure is logged and the request is
+	// forwarded without the token so one broken credential doesn't take down
+	// every request the entry matches. Mirrors the secrets transform's
+	// "require" flag.
+	Require bool `yaml:"require,omitempty"`
+
 	// TokenEndpointHeaders is a map of header name to secret source. Each
 	// resolved value is sent as a request header on the token POST itself —
 	// used by vendors that require an api-key header alongside the standard
@@ -134,6 +141,7 @@ type tokenEntry struct {
 	valuePrefix string
 	cfgEndpoint string // config token_endpoint
 	audience    string // JWT "aud" claim, jwt_bearer grant only
+	require     bool   // reject the request when minting fails
 	logger      *slog.Logger
 
 	// sources holds the entry's credential secret sources, keyed by field.
@@ -246,6 +254,7 @@ func buildEntry(tc tokenEntryConfig, logger *slog.Logger, buildSource sourceBuil
 		valuePrefix:           valuePrefix,
 		cfgEndpoint:           tc.TokenEndpoint,
 		audience:              tc.Audience,
+		require:               tc.Require,
 		sources:               sources,
 		endpointHeaderSources: endpointHeaders,
 		logger:                logger,
@@ -404,13 +413,20 @@ func (o *OAuth) TransformRequest(ctx context.Context, tctx *transform.TransformC
 		reason := entry.logMintFailure(err)
 		tctx.Annotate("grant", entry.grant)
 		tctx.Annotate("error", reason)
-		tctx.Annotate("rejected", "token_unavailable")
-		// Fail closed with a 502: forwarding an unauthenticated request would
-		// surface as a confusing upstream 401.
-		return &transform.TransformResult{
-			Action:   transform.ActionReject,
-			Response: mintFailureResponse(req, entry.grant),
-		}, nil
+		if entry.require {
+			tctx.Annotate("rejected", "token_unavailable")
+			// Fail closed with a 502: forwarding an unauthenticated request
+			// would surface as a confusing upstream 401.
+			return &transform.TransformResult{
+				Action:   transform.ActionReject,
+				Response: mintFailureResponse(req, entry.grant),
+			}, nil
+		}
+		// Fail open: forward the request without the token rather than taking
+		// down every request this entry matches. The header is left untouched,
+		// so the upstream sees the request as if no token were configured.
+		tctx.Annotate("skipped", "token_unavailable")
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 
 	req.Header.Set(entry.header, entry.valuePrefix+tok)

--- a/internal/transform/oauth/oauth_test.go
+++ b/internal/transform/oauth/oauth_test.go
@@ -656,6 +656,7 @@ func TestInvalidGrantFails502(t *testing.T) {
 	o := buildTransformWith(t, `
 tokens:
   - grant: refresh_token
+    require: true
     refresh_token: {type: env, var: RT}
     client_id: {type: env, var: CID}
     client_secret: {type: env, var: CSECRET}
@@ -688,6 +689,7 @@ func TestCredentialUnavailableFails502(t *testing.T) {
 	o := buildTransformWith(t, `
 tokens:
   - grant: refresh_token
+    require: true
     refresh_token: {type: env, var: RT}
     client_id: {type: env, var: CID}
     token_endpoint: "https://oauth2.example.com/token"
@@ -703,6 +705,66 @@ tokens:
 	require.NoError(t, err)
 	require.Equal(t, transform.ActionReject, res.Action)
 	require.Equal(t, http.StatusBadGateway, res.Response.StatusCode)
+}
+
+// By default (require unset) a mint failure must not take down the request:
+// the proxy forwards it without a token instead of rejecting with a 502.
+func TestMintFailureForwardsWithoutTokenByDefault(t *testing.T) {
+	srv := newTokenServer(t, func(url.Values) (int, map[string]any) {
+		return http.StatusBadRequest, map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "Token has been expired or revoked.",
+		}
+	})
+	o := buildTransformWith(t, `
+tokens:
+  - grant: refresh_token
+    refresh_token: {type: env, var: RT}
+    client_id: {type: env, var: CID}
+    client_secret: {type: env, var: CSECRET}
+    token_endpoint: "`+srv.URL+`/token"
+    rules:
+      - host: "gmail.googleapis.com"
+`, mapBuilder(map[string]secrets.Source{
+		"RT":      &staticSource{name: "rt", value: "test-refresh-token"},
+		"CID":     &staticSource{name: "cid", value: "test-client-id"},
+		"CSECRET": &staticSource{name: "cs", value: "test-client-secret"},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	tctx := newContext()
+	res, err := o.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action, "request is forwarded, not rejected")
+	require.Nil(t, res.Response, "no synthetic failure response on fail-open")
+	require.Empty(t, req.Header.Get("Authorization"), "no token is injected when minting fails")
+
+	annotations := tctx.DrainAnnotations()
+	require.Equal(t, "invalid_grant", annotations["error"])
+	require.Equal(t, "token_unavailable", annotations["skipped"])
+	require.NotContains(t, annotations, "rejected")
+}
+
+// A credential source that errors also fails open by default.
+func TestCredentialUnavailableForwardsByDefault(t *testing.T) {
+	o := buildTransformWith(t, `
+tokens:
+  - grant: refresh_token
+    refresh_token: {type: env, var: RT}
+    client_id: {type: env, var: CID}
+    token_endpoint: "https://oauth2.example.com/token"
+    rules:
+      - host: "gmail.googleapis.com"
+`, mapBuilder(map[string]secrets.Source{
+		"RT":  &staticSource{name: "rt", err: io.ErrUnexpectedEOF},
+		"CID": &staticSource{name: "cid", value: "test-client-id"},
+	}))
+
+	req := newRequest(t, http.MethodGet, "https://gmail.googleapis.com/v1/x")
+	res, err := o.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
 }
 
 // --- password grant ---

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -315,7 +315,10 @@ transforms:
   # Authorization: Bearer on matching requests. Each entry under tokens names
   # a grant type, its credential fields, and the hosts it applies to. Token
   # exchange, caching, and refresh are handled automatically. Requires MITM
-  # mode. On a minting failure the request is rejected with a 502.
+  # mode. By default a minting failure is logged and the request is forwarded
+  # without the token, so one broken credential doesn't take down every request
+  # the entry matches. Set "require: true" on an entry to fail closed instead
+  # and reject those requests with a 502 (same flag as the secrets transform).
   #
   # grant is one of:
   #   refresh_token       RFC 6749 — a refresh token plus a client id
@@ -348,6 +351,7 @@ transforms:
   #     tokens:
   #       # Each field resolved from its own source.
   #       - grant: refresh_token
+  #         require: true        # reject with 502 if minting fails (default: forward without token)
   #         refresh_token:
   #           type: 1password_connect
   #           secret_ref: "op://Engineering/GSUITE-OAUTH/refresh-token"


### PR DESCRIPTION
oauth_token previously rejected every matching request with a 502 when a token mint failed, so one broken credential took down all traffic the entry matched. This changes the default to forward the request without the token instead, and adds a per-entry `require: true` flag to opt back into failing closed (502), mirroring the secrets transform's `require` semantics.

Note: this flips the default from fail-closed to fail-open. Existing configs that relied on the 502 rejection should add `require: true`.