### PR TITLE
feat: add MCP gateway routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,11 +598,7 @@ mcp_gateway:
       rules:
         - host: "github.mcp.local"
           paths: ["/mcp", "/mcp/*"]
-      upstream:
-        scheme: "https"                 # defaults to https
-        host: "mcp.github.com"
-        path_prefix: "/v1"              # optional. Prepended to the client path.
-        preserve_host: false            # default. Sends Host for the upstream.
+      upstream: "https://mcp.github.com/v1"
       credentials:
         - source:
             type: env
@@ -612,7 +608,7 @@ mcp_gateway:
             formatter: "Bearer {{ .Value }}"
 ```
 
-Credentials use the same secret sources as the `secrets` transform. They are required by default. Set `require: false` on a credential to skip it when unavailable. Audit logs record the route, upstream host, and credential injection locations, but never the injected credential values.
+Credentials use the same secret sources as the `secrets` transform. They are required by default. Set `require: false` on a credential to skip it when unavailable. Audit logs record the route, upstream URL, and credential injection locations, but never the injected credential values.
 
 Limitations in v1:
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,44 @@ Behavior:
 
 Pipeline ordering: the MCP interceptor runs after the transform pipeline, so `allowlist` still gates which hosts can be reached and `secrets` has already swapped proxy tokens by the time the interceptor evaluates the body.
 
+### MCP Gateway
+
+`mcp_gateway` routes client-facing MCP hosts to concrete upstream servers after the MCP policy accepts the request. This lets agents call stable internal hosts while iron-proxy forwards to the real upstream and injects credentials that never enter the sandbox.
+
+Gateway routes only apply to requests that matched an MCP server. The MCP policy still enforces the tool allowlist first. If policy denies a `tools/call`, the gateway route is not applied and upstream is not reached.
+
+```yaml
+mcp:
+  servers:
+    - name: github
+      rules:
+        - host: "github.mcp.local"
+          paths: ["/mcp", "/mcp/*"]
+      tools:
+        - name: "search_repositories"
+
+mcp_gateway:
+  routes:
+    - name: github
+      rules:
+        - host: "github.mcp.local"
+          paths: ["/mcp", "/mcp/*"]
+      upstream:
+        scheme: "https"                 # defaults to https
+        host: "mcp.github.com"
+        path_prefix: "/v1"              # optional. Prepended to the client path.
+        preserve_host: false            # default. Sends Host for the upstream.
+      credentials:
+        - source:
+            type: env
+            var: GITHUB_MCP_TOKEN
+          inject:
+            header: Authorization
+            formatter: "Bearer {{ .Value }}"
+```
+
+Credentials use the same secret sources as the `secrets` transform. They are required by default. Set `require: false` on a credential to skip it when unavailable. Audit logs record the route, upstream host, and credential injection locations, but never the injected credential values.
+
 Limitations in v1:
 
 - Only Streamable HTTP transport is supported. The legacy HTTP+SSE transport (separate `/messages` and `/sse` endpoints) is not.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/management"
 	"github.com/ironsh/iron-proxy/internal/mcp"
+	"github.com/ironsh/iron-proxy/internal/mcpgateway"
 	"github.com/ironsh/iron-proxy/internal/metrics"
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/postgres"
@@ -119,12 +120,13 @@ func main() {
 
 	var holder *transform.PipelineHolder
 	var mcpHolder *mcp.PolicyHolder
+	var gatewayHolder *mcpgateway.Holder
 	var otelCfg iotel.ExportConfig
 	var poller *controlplane.Poller
 
 	if managed {
 		var ingestToken string
-		holder, mcpHolder, ingestToken, pgListener, poller = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListener, logger)
+		holder, mcpHolder, gatewayHolder, ingestToken, pgListener, poller = initManaged(ctx, cfg, bodyLimits, errc, proxyToken, pgManager, localPgListener, logger)
 		if ingestToken != "" {
 			otelCfg.DefaultEndpoint = "https://ingest.iron.sh/v1/logs"
 			otelCfg.DefaultHeaders = map[string]string{
@@ -132,7 +134,7 @@ func main() {
 			}
 		}
 	} else {
-		holder, mcpHolder = initStandalone(cfg, bodyLimits, logger)
+		holder, mcpHolder, gatewayHolder = initStandalone(cfg, bodyLimits, logger)
 	}
 
 	// 5. Validate the fully-assembled config.
@@ -219,6 +221,7 @@ func main() {
 		Resolver:                      resolver,
 		Guard:                         guard,
 		MCPPolicy:                     mcpHolder,
+		MCPGateway:                    gatewayHolder,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 		UpstreamProxy:                 cfg.Proxy.UpstreamProxy.ProxyFunc(),
@@ -245,7 +248,7 @@ func main() {
 			mgmtOpts.Status = func() any { return poller.Status() }
 			mgmtOpts.SyncNow = poller.Poke
 		} else {
-			mgmtOpts.Reload = newReloadFunc(*configPath, holder, mcpHolder, pgManager, bodyLimits, logger)
+			mgmtOpts.Reload = newReloadFunc(*configPath, holder, mcpHolder, gatewayHolder, pgManager, bodyLimits, logger)
 		}
 		mgmtServer = management.New(mgmtOpts)
 	}
@@ -332,7 +335,7 @@ func main() {
 //
 // Initial MCP policy preference: control-plane-supplied mcp block first, then
 // fall back to cfg.MCP from the YAML if the sync did not include one.
-func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListener *postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, string, *postgres.Listener, *controlplane.Poller) {
+func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.BodyLimits, errc chan<- error, proxyToken string, pgManager *postgres.Manager, localPgListener *postgres.Listener, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, *mcpgateway.Holder, string, *postgres.Listener, *controlplane.Poller) {
 	cpURL := envOrDefault("IRON_CONTROL_PLANE_URL", "https://api.iron.sh")
 	logger.Info("starting in managed mode", slog.String("control_plane_url", cpURL))
 
@@ -389,6 +392,15 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		logger.Error("building initial mcp policy", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
+	gateway, err := mcpgateway.LoadFromNode(cfg.MCPGateway)
+	if err != nil {
+		logger.Error("building initial mcp gateway", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if gateway != nil {
+		logger.Info("mcp gateway enabled")
+	}
+	gatewayHolder := mcpgateway.NewHolder(gateway)
 
 	// Compute the initial postgres listener: the local YAML listener with any
 	// control-plane-synced routes layered on when its env vars are present. If
@@ -427,7 +439,7 @@ func initManaged(ctx context.Context, cfg *config.Config, bodyLimits transform.B
 		errc <- poller.Run(ctx)
 	}()
 
-	return holder, mcpHolder, ingestToken, pgListener, poller
+	return holder, mcpHolder, gatewayHolder, ingestToken, pgListener, poller
 }
 
 // managedReady gates the proxy on the first applied control-plane config.
@@ -461,7 +473,7 @@ func buildInitialMCPHolder(cfg *config.Config, initialMCP json.RawMessage, logge
 }
 
 // initStandalone builds the pipeline and MCP policy from the YAML config.
-func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder) {
+func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger *slog.Logger) (*transform.PipelineHolder, *mcp.PolicyHolder, *mcpgateway.Holder) {
 	pipeline, err := buildPipeline(cfg.Transforms, bodyLimits, logger)
 	if err != nil {
 		logger.Error("building transform pipeline", slog.String("error", err.Error()))
@@ -475,7 +487,15 @@ func initStandalone(cfg *config.Config, bodyLimits transform.BodyLimits, logger 
 	if mcpPolicy != nil {
 		logger.Info("mcp policy enabled")
 	}
-	return transform.NewPipelineHolder(pipeline), mcp.NewPolicyHolder(mcpPolicy)
+	gateway, err := mcpgateway.LoadFromNode(cfg.MCPGateway)
+	if err != nil {
+		logger.Error("loading mcp gateway", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if gateway != nil {
+		logger.Info("mcp gateway enabled")
+	}
+	return transform.NewPipelineHolder(pipeline), mcp.NewPolicyHolder(mcpPolicy), mcpgateway.NewHolder(gateway)
 }
 
 // applyPipelineSync builds a new pipeline from a sync payload and atomically
@@ -633,7 +653,7 @@ func applyPostgresSync(ctx context.Context, mgr *postgres.Manager, local *postgr
 // wrapped in *management.ValidationError so the management server returns
 // 422 and the existing state is left untouched. Validation runs for every
 // component before any state is mutated.
-func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolder *mcp.PolicyHolder, pgManager *postgres.Manager, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
+func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolder *mcp.PolicyHolder, gatewayHolder *mcpgateway.Holder, pgManager *postgres.Manager, bodyLimits transform.BodyLimits, logger *slog.Logger) management.ReloadFunc {
 	return func(ctx context.Context) error {
 		newCfg, err := config.LoadConfig(configPath)
 		if err != nil {
@@ -650,6 +670,10 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolde
 		if err != nil {
 			return &management.ValidationError{Err: err}
 		}
+		newGateway, err := mcpgateway.LoadFromNode(newCfg.MCPGateway)
+		if err != nil {
+			return &management.ValidationError{Err: err}
+		}
 		newPgListener, err := postgres.LoadFromNode(newCfg.Postgres, logger)
 		if err != nil {
 			return &management.ValidationError{Err: err}
@@ -657,6 +681,7 @@ func newReloadFunc(configPath string, holder *transform.PipelineHolder, mcpHolde
 		newPipeline.SetAuditFunc(holder.Load().AuditFunc())
 		holder.Store(newPipeline)
 		mcpHolder.Store(newPolicy)
+		gatewayHolder.Store(newGateway)
 		pgManager.Reload(ctx, newPgListener)
 		logger.Info("pipeline reloaded via management API",
 			slog.String("transforms", newPipeline.Names()),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	TLS          TLS          `yaml:"tls"`
 	Transforms   []Transform  `yaml:"transforms"`
 	MCP          yaml.Node    `yaml:"mcp"`
+	MCPGateway   yaml.Node    `yaml:"mcp_gateway"`
 	Postgres     yaml.Node    `yaml:"postgres"`
 	Metrics      Metrics      `yaml:"metrics"`
 	Management   Management   `yaml:"management"`

--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -9,8 +9,9 @@ import (
 // collects one Message entry per JSON-RPC message observed on either side of
 // the proxy, in the order they were processed.
 type Trace struct {
-	Server   string    `json:"server"`
-	Messages []Message `json:"messages,omitempty"`
+	Server   string         `json:"server"`
+	Messages []Message      `json:"messages,omitempty"`
+	Gateway  map[string]any `json:"gateway,omitempty"`
 
 	mu sync.Mutex
 	// toolsListIDs is the set of JSON-RPC request IDs whose method was
@@ -87,6 +88,17 @@ func (t *Trace) Append(m Message) {
 	t.mu.Unlock()
 }
 
+// SetGateway records MCP gateway metadata on the trace. Values must be
+// JSON-serializable and must not include real credential values.
+func (t *Trace) SetGateway(gateway map[string]any) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.Gateway = gateway
+	t.mu.Unlock()
+}
+
 // recordToolsListID notes that this trace saw a request with method
 // tools/list and the supplied id, so the response-side filter knows to
 // rewrite the matching response. Notification ids (absent or null) are
@@ -160,6 +172,23 @@ func (t *Trace) MessagesSnapshot() []Message {
 	return out
 }
 
+// GatewaySnapshot returns a copy of gateway metadata safe for audit rendering.
+func (t *Trace) GatewaySnapshot() map[string]any {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.Gateway) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(t.Gateway))
+	for k, v := range t.Gateway {
+		out[k] = v
+	}
+	return out
+}
+
 // MCPServer implements transform.MCPAudit.
 func (t *Trace) MCPServer() string {
 	if t == nil {
@@ -203,4 +232,9 @@ func (t *Trace) MCPMessages() []map[string]any {
 		out = append(out, entry)
 	}
 	return out
+}
+
+// MCPGateway implements transform.MCPAudit.
+func (t *Trace) MCPGateway() map[string]any {
+	return t.GatewaySnapshot()
 }

--- a/internal/mcpgateway/gateway.go
+++ b/internal/mcpgateway/gateway.go
@@ -1,0 +1,303 @@
+// Package mcpgateway implements host-based routing for MCP Streamable HTTP
+// servers after MCP policy enforcement has allowed a request.
+package mcpgateway
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+// Config is the YAML shape of the top-level mcp_gateway block.
+type Config struct {
+	Routes []RouteConfig `yaml:"routes"`
+}
+
+// RouteConfig maps one client-facing MCP host/path to a concrete upstream.
+type RouteConfig struct {
+	Name        string                 `yaml:"name"`
+	Rules       []hostmatch.RuleConfig `yaml:"rules"`
+	Upstream    UpstreamConfig         `yaml:"upstream"`
+	Credentials []CredentialConfig     `yaml:"credentials"`
+}
+
+// UpstreamConfig declares where a matched request should be forwarded.
+type UpstreamConfig struct {
+	Scheme       string `yaml:"scheme"`
+	Host         string `yaml:"host"`
+	PathPrefix   string `yaml:"path_prefix"`
+	PreserveHost bool   `yaml:"preserve_host"`
+}
+
+// CredentialConfig injects a secret into a matched upstream request.
+type CredentialConfig struct {
+	Source  yaml.Node    `yaml:"source"`
+	Inject  InjectConfig `yaml:"inject"`
+	Require *bool        `yaml:"require,omitempty"`
+}
+
+// InjectConfig chooses the outbound location and optional formatting for a
+// gateway credential.
+type InjectConfig struct {
+	Header     string `yaml:"header,omitempty"`
+	QueryParam string `yaml:"query_param,omitempty"`
+	Formatter  string `yaml:"formatter,omitempty"`
+}
+
+// Gateway is the compiled, immutable form of Config.
+type Gateway struct {
+	routes []*Route
+}
+
+// Route is a compiled gateway route.
+type Route struct {
+	Name        string
+	rules       []hostmatch.Rule
+	upstream    UpstreamConfig
+	credentials []credential
+}
+
+type credential struct {
+	source     secrets.Source
+	inject     InjectConfig
+	require    bool
+	formatter  *template.Template
+	sourceName string
+}
+
+// AppliedRoute describes the gateway rewrite applied to a request.
+type AppliedRoute struct {
+	Name                  string
+	UpstreamScheme        string
+	UpstreamHost          string
+	UpstreamPath          string
+	UpstreamRawPath       string
+	PreserveHost          bool
+	InjectedCredentialIDs []string
+}
+
+// LoadFromNode decodes a raw yaml.Node into a Config and compiles it. An empty
+// node returns nil so callers can treat an absent mcp_gateway block normally.
+func LoadFromNode(node yaml.Node) (*Gateway, error) {
+	if node.Kind == 0 {
+		return nil, nil
+	}
+	var c Config
+	if err := node.Decode(&c); err != nil {
+		return nil, fmt.Errorf("decoding mcp_gateway config: %w", err)
+	}
+	return Compile(c)
+}
+
+// Compile validates and compiles a Config into a Gateway. Returns nil when no
+// routes are configured.
+func Compile(c Config) (*Gateway, error) {
+	if len(c.Routes) == 0 {
+		return nil, nil
+	}
+	g := &Gateway{routes: make([]*Route, 0, len(c.Routes))}
+	seen := make(map[string]bool, len(c.Routes))
+	for i, rc := range c.Routes {
+		if rc.Name == "" {
+			return nil, fmt.Errorf("mcp_gateway.routes[%d]: name is required", i)
+		}
+		if seen[rc.Name] {
+			return nil, fmt.Errorf("mcp_gateway.routes[%d]: duplicate route name %q", i, rc.Name)
+		}
+		seen[rc.Name] = true
+		if len(rc.Rules) == 0 {
+			return nil, fmt.Errorf("mcp_gateway.routes[%q]: at least one rule is required", rc.Name)
+		}
+		rules, err := hostmatch.CompileRules(rc.Rules, fmt.Sprintf("mcp_gateway.routes[%q]", rc.Name))
+		if err != nil {
+			return nil, err
+		}
+		upstream, err := normalizeUpstream(rc.Name, rc.Upstream)
+		if err != nil {
+			return nil, err
+		}
+		creds, err := compileCredentials(rc.Name, rc.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		g.routes = append(g.routes, &Route{
+			Name:        rc.Name,
+			rules:       rules,
+			upstream:    upstream,
+			credentials: creds,
+		})
+	}
+	return g, nil
+}
+
+func normalizeUpstream(routeName string, u UpstreamConfig) (UpstreamConfig, error) {
+	if u.Scheme == "" {
+		u.Scheme = "https"
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.scheme must be http or https", routeName)
+	}
+	if u.Host == "" {
+		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.host is required", routeName)
+	}
+	if strings.ContainsAny(u.Host, "/?#") {
+		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.host must be a host or host:port", routeName)
+	}
+	if u.PathPrefix != "" && !strings.HasPrefix(u.PathPrefix, "/") {
+		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.path_prefix must start with /", routeName)
+	}
+	return u, nil
+}
+
+func compileCredentials(routeName string, configs []CredentialConfig) ([]credential, error) {
+	creds := make([]credential, 0, len(configs))
+	for i, cc := range configs {
+		src, err := secrets.BuildSource(cc.Source, nil)
+		if err != nil {
+			return nil, fmt.Errorf("mcp_gateway.routes[%q].credentials[%d]: %w", routeName, i, err)
+		}
+		if err := validateInject(routeName, i, cc.Inject); err != nil {
+			return nil, err
+		}
+		require := true
+		if cc.Require != nil {
+			require = *cc.Require
+		}
+		cred := credential{
+			source:     src,
+			inject:     cc.Inject,
+			require:    require,
+			sourceName: src.Name(),
+		}
+		if cc.Inject.Formatter != "" {
+			tmpl, err := template.New(fmt.Sprintf("mcp_gateway.routes[%q].credentials[%d]", routeName, i)).Funcs(templateFuncs).Parse(cc.Inject.Formatter)
+			if err != nil {
+				return nil, fmt.Errorf("mcp_gateway.routes[%q].credentials[%d]: parsing formatter: %w", routeName, i, err)
+			}
+			cred.formatter = tmpl
+		}
+		creds = append(creds, cred)
+	}
+	return creds, nil
+}
+
+var templateFuncs = template.FuncMap{
+	"base64": func(parts ...string) string {
+		return base64.StdEncoding.EncodeToString([]byte(strings.Join(parts, "")))
+	},
+}
+
+func validateInject(routeName string, i int, cfg InjectConfig) error {
+	hasHeader := cfg.Header != ""
+	hasQuery := cfg.QueryParam != ""
+	if !hasHeader && !hasQuery {
+		return fmt.Errorf("mcp_gateway.routes[%q].credentials[%d]: inject must specify either header or query_param", routeName, i)
+	}
+	if hasHeader && hasQuery {
+		return fmt.Errorf("mcp_gateway.routes[%q].credentials[%d]: inject cannot specify both header and query_param", routeName, i)
+	}
+	return nil
+}
+
+// Match returns the first route whose rules match the request, or nil.
+func (g *Gateway) Match(req *http.Request) *Route {
+	if g == nil {
+		return nil
+	}
+	host := hostmatch.StripPort(req.Host)
+	for _, route := range g.routes {
+		for _, rule := range route.rules {
+			if rule.Matches(host, req.Method, req.URL.Path) {
+				return route
+			}
+		}
+	}
+	return nil
+}
+
+// Apply injects route credentials into req and returns the upstream target
+// components the proxy should use when constructing the outbound request.
+func (r *Route) Apply(ctx context.Context, req *http.Request) (*AppliedRoute, error) {
+	if r == nil {
+		return nil, nil
+	}
+	applied := &AppliedRoute{
+		Name:           r.Name,
+		UpstreamScheme: r.upstream.Scheme,
+		UpstreamHost:   r.upstream.Host,
+		UpstreamPath:   rewritePath(r.upstream.PathPrefix, req.URL.Path),
+		PreserveHost:   r.upstream.PreserveHost,
+	}
+	if req.URL.RawPath != "" {
+		applied.UpstreamRawPath = rewritePath(r.upstream.PathPrefix, req.URL.RawPath)
+	}
+	for _, cred := range r.credentials {
+		value, err := cred.source.Get(ctx)
+		if err != nil {
+			if cred.require {
+				return nil, fmt.Errorf("gateway credential %q unavailable: %w", cred.sourceName, err)
+			}
+			continue
+		}
+		value, err = formatCredential(cred.formatter, value)
+		if err != nil {
+			return nil, fmt.Errorf("formatting gateway credential %q: %w", cred.sourceName, err)
+		}
+		if cred.inject.Header != "" {
+			req.Header.Set(cred.inject.Header, value)
+			applied.InjectedCredentialIDs = append(applied.InjectedCredentialIDs, cred.sourceName+":header:"+http.CanonicalHeaderKey(cred.inject.Header))
+			continue
+		}
+		q := req.URL.Query()
+		q.Set(cred.inject.QueryParam, value)
+		req.URL.RawQuery = q.Encode()
+		applied.InjectedCredentialIDs = append(applied.InjectedCredentialIDs, cred.sourceName+":query:"+cred.inject.QueryParam)
+	}
+	return applied, nil
+}
+
+func rewritePath(prefix, escapedPath string) string {
+	if escapedPath == "" {
+		escapedPath = "/"
+	}
+	if prefix == "" || prefix == "/" {
+		return escapedPath
+	}
+	return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(escapedPath, "/")
+}
+
+func formatCredential(tmpl *template.Template, value string) (string, error) {
+	if tmpl == nil {
+		return value, nil
+	}
+	var b strings.Builder
+	err := tmpl.Execute(&b, struct {
+		Value string
+	}{Value: value})
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// UpstreamURL returns an absolute URL string for an applied route, preserving
+// the request's query string.
+func (a *AppliedRoute) UpstreamURL(rawQuery string) string {
+	u := url.URL{
+		Scheme:   a.UpstreamScheme,
+		Host:     a.UpstreamHost,
+		Path:     a.UpstreamPath,
+		RawPath:  a.UpstreamRawPath,
+		RawQuery: rawQuery,
+	}
+	return u.String()
+}

--- a/internal/mcpgateway/gateway.go
+++ b/internal/mcpgateway/gateway.go
@@ -26,16 +26,8 @@ type Config struct {
 type RouteConfig struct {
 	Name        string                 `yaml:"name"`
 	Rules       []hostmatch.RuleConfig `yaml:"rules"`
-	Upstream    UpstreamConfig         `yaml:"upstream"`
+	Upstream    string                 `yaml:"upstream"`
 	Credentials []CredentialConfig     `yaml:"credentials"`
-}
-
-// UpstreamConfig declares where a matched request should be forwarded.
-type UpstreamConfig struct {
-	Scheme       string `yaml:"scheme"`
-	Host         string `yaml:"host"`
-	PathPrefix   string `yaml:"path_prefix"`
-	PreserveHost bool   `yaml:"preserve_host"`
 }
 
 // CredentialConfig injects a secret into a matched upstream request.
@@ -62,7 +54,7 @@ type Gateway struct {
 type Route struct {
 	Name        string
 	rules       []hostmatch.Rule
-	upstream    UpstreamConfig
+	upstream    url.URL
 	credentials []credential
 }
 
@@ -77,11 +69,8 @@ type credential struct {
 // AppliedRoute describes the gateway rewrite applied to a request.
 type AppliedRoute struct {
 	Name                  string
-	UpstreamScheme        string
-	UpstreamHost          string
-	UpstreamPath          string
-	UpstreamRawPath       string
-	PreserveHost          bool
+	Upstream              string
+	RequestURL            string
 	InjectedCredentialIDs []string
 }
 
@@ -139,23 +128,24 @@ func Compile(c Config) (*Gateway, error) {
 	return g, nil
 }
 
-func normalizeUpstream(routeName string, u UpstreamConfig) (UpstreamConfig, error) {
-	if u.Scheme == "" {
-		u.Scheme = "https"
+func normalizeUpstream(routeName, raw string) (url.URL, error) {
+	if raw == "" {
+		return url.URL{}, fmt.Errorf("mcp_gateway.routes[%q].upstream is required", routeName)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return url.URL{}, fmt.Errorf("mcp_gateway.routes[%q].upstream must be a valid URL: %w", routeName, err)
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.scheme must be http or https", routeName)
+		return url.URL{}, fmt.Errorf("mcp_gateway.routes[%q].upstream must use http or https", routeName)
 	}
 	if u.Host == "" {
-		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.host is required", routeName)
+		return url.URL{}, fmt.Errorf("mcp_gateway.routes[%q].upstream must include a host", routeName)
 	}
-	if strings.ContainsAny(u.Host, "/?#") {
-		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.host must be a host or host:port", routeName)
+	if u.Fragment != "" {
+		return url.URL{}, fmt.Errorf("mcp_gateway.routes[%q].upstream must not include a fragment", routeName)
 	}
-	if u.PathPrefix != "" && !strings.HasPrefix(u.PathPrefix, "/") {
-		return UpstreamConfig{}, fmt.Errorf("mcp_gateway.routes[%q].upstream.path_prefix must start with /", routeName)
-	}
-	return u, nil
+	return *u, nil
 }
 
 func compileCredentials(routeName string, configs []CredentialConfig) ([]credential, error) {
@@ -230,15 +220,9 @@ func (r *Route) Apply(ctx context.Context, req *http.Request) (*AppliedRoute, er
 	if r == nil {
 		return nil, nil
 	}
+	upstream := r.upstream
 	applied := &AppliedRoute{
-		Name:           r.Name,
-		UpstreamScheme: r.upstream.Scheme,
-		UpstreamHost:   r.upstream.Host,
-		UpstreamPath:   rewritePath(r.upstream.PathPrefix, req.URL.Path),
-		PreserveHost:   r.upstream.PreserveHost,
-	}
-	if req.URL.RawPath != "" {
-		applied.UpstreamRawPath = rewritePath(r.upstream.PathPrefix, req.URL.RawPath)
+		Name: r.Name,
 	}
 	for _, cred := range r.credentials {
 		value, err := cred.source.Get(ctx)
@@ -262,17 +246,10 @@ func (r *Route) Apply(ctx context.Context, req *http.Request) (*AppliedRoute, er
 		req.URL.RawQuery = q.Encode()
 		applied.InjectedCredentialIDs = append(applied.InjectedCredentialIDs, cred.sourceName+":query:"+cred.inject.QueryParam)
 	}
+	applied.Upstream = upstream.String()
+	upstream.RawQuery = mergeRawQuery(r.upstream.RawQuery, req.URL.RawQuery)
+	applied.RequestURL = upstream.String()
 	return applied, nil
-}
-
-func rewritePath(prefix, escapedPath string) string {
-	if escapedPath == "" {
-		escapedPath = "/"
-	}
-	if prefix == "" || prefix == "/" {
-		return escapedPath
-	}
-	return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(escapedPath, "/")
 }
 
 func formatCredential(tmpl *template.Template, value string) (string, error) {
@@ -289,15 +266,12 @@ func formatCredential(tmpl *template.Template, value string) (string, error) {
 	return b.String(), nil
 }
 
-// UpstreamURL returns an absolute URL string for an applied route, preserving
-// the request's query string.
-func (a *AppliedRoute) UpstreamURL(rawQuery string) string {
-	u := url.URL{
-		Scheme:   a.UpstreamScheme,
-		Host:     a.UpstreamHost,
-		Path:     a.UpstreamPath,
-		RawPath:  a.UpstreamRawPath,
-		RawQuery: rawQuery,
+func mergeRawQuery(base, request string) string {
+	if base == "" {
+		return request
 	}
-	return u.String()
+	if request == "" {
+		return base
+	}
+	return base + "&" + request
 }

--- a/internal/mcpgateway/gateway_test.go
+++ b/internal/mcpgateway/gateway_test.go
@@ -20,13 +20,9 @@ func TestCompileAndApply(t *testing.T) {
 
 	g, err := Compile(Config{
 		Routes: []RouteConfig{{
-			Name:  "github",
-			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp", "/mcp/*"}}},
-			Upstream: UpstreamConfig{
-				Scheme:     "https",
-				Host:       "mcp.github.com",
-				PathPrefix: "/v1",
-			},
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp", "/mcp/*"}}},
+			Upstream: "https://mcp.github.com/v1",
 			Credentials: []CredentialConfig{{
 				Source: mustYAMLNode(t, `type: env
 var: MCP_TOKEN
@@ -47,12 +43,10 @@ var: MCP_TOKEN
 	applied, err := route.Apply(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, "github", applied.Name)
-	require.Equal(t, "https", applied.UpstreamScheme)
-	require.Equal(t, "mcp.github.com", applied.UpstreamHost)
-	require.Equal(t, "/v1/mcp/tools", applied.UpstreamPath)
+	require.Equal(t, "https://mcp.github.com/v1", applied.Upstream)
+	require.Equal(t, "https://mcp.github.com/v1?existing=1", applied.RequestURL)
 	require.Equal(t, "Bearer real-token", req.Header.Get("Authorization"))
 	require.Equal(t, []string{"MCP_TOKEN:header:Authorization"}, applied.InjectedCredentialIDs)
-	require.Equal(t, "https://mcp.github.com/v1/mcp/tools?existing=1", applied.UpstreamURL(req.URL.RawQuery))
 }
 
 func TestApplyInjectsQueryParam(t *testing.T) {
@@ -62,7 +56,7 @@ func TestApplyInjectsQueryParam(t *testing.T) {
 		Routes: []RouteConfig{{
 			Name:     "github",
 			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Upstream: "https://mcp.github.com",
 			Credentials: []CredentialConfig{{
 				Source: mustYAMLNode(t, `type: env
 var: MCP_TOKEN
@@ -77,15 +71,17 @@ var: MCP_TOKEN
 	applied, err := g.Match(req).Apply(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, "real-token", req.URL.Query().Get("access_token"))
+	require.Equal(t, "https://mcp.github.com", applied.Upstream)
+	require.Equal(t, "https://mcp.github.com?access_token=real-token&existing=1", applied.RequestURL)
 	require.Equal(t, []string{"MCP_TOKEN:query:access_token"}, applied.InjectedCredentialIDs)
 }
 
-func TestApplyPathPrefixPreservesTrailingSlash(t *testing.T) {
+func TestApplyUsesFixedUpstreamPath(t *testing.T) {
 	g, err := Compile(Config{
 		Routes: []RouteConfig{{
 			Name:     "github",
 			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-			Upstream: UpstreamConfig{Host: "mcp.github.com", PathPrefix: "/v1/"},
+			Upstream: "https://mcp.github.com/v1/",
 		}},
 	})
 	require.NoError(t, err)
@@ -93,7 +89,8 @@ func TestApplyPathPrefixPreservesTrailingSlash(t *testing.T) {
 	req := newRequest(t, "https://github.mcp.local/mcp/")
 	applied, err := g.Match(req).Apply(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, "/v1/mcp/", applied.UpstreamPath)
+	require.Equal(t, "https://mcp.github.com/v1/", applied.Upstream)
+	require.Equal(t, "https://mcp.github.com/v1/", applied.RequestURL)
 }
 
 func TestApplyRequiredCredentialFailure(t *testing.T) {
@@ -101,7 +98,7 @@ func TestApplyRequiredCredentialFailure(t *testing.T) {
 		Routes: []RouteConfig{{
 			Name:     "github",
 			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Upstream: "https://mcp.github.com",
 			Credentials: []CredentialConfig{{
 				Source: mustYAMLNode(t, `type: env
 var: MISSING_MCP_TOKEN
@@ -123,7 +120,7 @@ func TestApplyOptionalCredentialFailure(t *testing.T) {
 		Routes: []RouteConfig{{
 			Name:     "github",
 			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Upstream: "https://mcp.github.com",
 			Credentials: []CredentialConfig{{
 				Source: mustYAMLNode(t, `type: env
 var: MISSING_MCP_TOKEN
@@ -150,12 +147,12 @@ func TestCompileValidation(t *testing.T) {
 	}{
 		{
 			name:    "missing name",
-			cfg:     Config{Routes: []RouteConfig{{Upstream: UpstreamConfig{Host: "example.com"}}}},
+			cfg:     Config{Routes: []RouteConfig{{Upstream: "https://example.com"}}},
 			wantErr: "name is required",
 		},
 		{
 			name:    "missing rules",
-			cfg:     Config{Routes: []RouteConfig{{Name: "github", Upstream: UpstreamConfig{Host: "example.com"}}}},
+			cfg:     Config{Routes: []RouteConfig{{Name: "github", Upstream: "https://example.com"}}},
 			wantErr: "at least one rule is required",
 		},
 		{
@@ -163,16 +160,25 @@ func TestCompileValidation(t *testing.T) {
 			cfg: Config{Routes: []RouteConfig{{
 				Name:     "github",
 				Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-				Upstream: UpstreamConfig{Scheme: "ftp", Host: "example.com"},
+				Upstream: "ftp://example.com",
 			}}},
-			wantErr: "upstream.scheme must be http or https",
+			wantErr: "upstream must use http or https",
+		},
+		{
+			name: "missing upstream host",
+			cfg: Config{Routes: []RouteConfig{{
+				Name:     "github",
+				Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+				Upstream: "https:///v1",
+			}}},
+			wantErr: "upstream must include a host",
 		},
 		{
 			name: "invalid credential injection",
 			cfg: Config{Routes: []RouteConfig{{
 				Name:     "github",
 				Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
-				Upstream: UpstreamConfig{Host: "example.com"},
+				Upstream: "https://example.com",
 				Credentials: []CredentialConfig{{
 					Source: mustYAMLNode(t, `type: env
 var: MCP_TOKEN

--- a/internal/mcpgateway/gateway_test.go
+++ b/internal/mcpgateway/gateway_test.go
@@ -1,0 +1,217 @@
+package mcpgateway
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestCompileAndApply(t *testing.T) {
+	t.Setenv("MCP_TOKEN", "real-token")
+
+	g, err := Compile(Config{
+		Routes: []RouteConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp", "/mcp/*"}}},
+			Upstream: UpstreamConfig{
+				Scheme:     "https",
+				Host:       "mcp.github.com",
+				PathPrefix: "/v1",
+			},
+			Credentials: []CredentialConfig{{
+				Source: mustYAMLNode(t, `type: env
+var: MCP_TOKEN
+`),
+				Inject: InjectConfig{
+					Header:    "Authorization",
+					Formatter: "Bearer {{ .Value }}",
+				},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := newRequest(t, "https://github.mcp.local/mcp/tools?existing=1")
+	route := g.Match(req)
+	require.NotNil(t, route)
+
+	applied, err := route.Apply(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, "github", applied.Name)
+	require.Equal(t, "https", applied.UpstreamScheme)
+	require.Equal(t, "mcp.github.com", applied.UpstreamHost)
+	require.Equal(t, "/v1/mcp/tools", applied.UpstreamPath)
+	require.Equal(t, "Bearer real-token", req.Header.Get("Authorization"))
+	require.Equal(t, []string{"MCP_TOKEN:header:Authorization"}, applied.InjectedCredentialIDs)
+	require.Equal(t, "https://mcp.github.com/v1/mcp/tools?existing=1", applied.UpstreamURL(req.URL.RawQuery))
+}
+
+func TestApplyInjectsQueryParam(t *testing.T) {
+	t.Setenv("MCP_TOKEN", "real-token")
+
+	g, err := Compile(Config{
+		Routes: []RouteConfig{{
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Credentials: []CredentialConfig{{
+				Source: mustYAMLNode(t, `type: env
+var: MCP_TOKEN
+`),
+				Inject: InjectConfig{QueryParam: "access_token"},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := newRequest(t, "https://github.mcp.local/mcp?existing=1")
+	applied, err := g.Match(req).Apply(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, "real-token", req.URL.Query().Get("access_token"))
+	require.Equal(t, []string{"MCP_TOKEN:query:access_token"}, applied.InjectedCredentialIDs)
+}
+
+func TestApplyPathPrefixPreservesTrailingSlash(t *testing.T) {
+	g, err := Compile(Config{
+		Routes: []RouteConfig{{
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+			Upstream: UpstreamConfig{Host: "mcp.github.com", PathPrefix: "/v1/"},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := newRequest(t, "https://github.mcp.local/mcp/")
+	applied, err := g.Match(req).Apply(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, "/v1/mcp/", applied.UpstreamPath)
+}
+
+func TestApplyRequiredCredentialFailure(t *testing.T) {
+	g, err := Compile(Config{
+		Routes: []RouteConfig{{
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Credentials: []CredentialConfig{{
+				Source: mustYAMLNode(t, `type: env
+var: MISSING_MCP_TOKEN
+`),
+				Inject: InjectConfig{Header: "Authorization"},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := newRequest(t, "https://github.mcp.local/mcp")
+	_, err = g.Match(req).Apply(context.Background(), req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `gateway credential "MISSING_MCP_TOKEN" unavailable`)
+}
+
+func TestApplyOptionalCredentialFailure(t *testing.T) {
+	g, err := Compile(Config{
+		Routes: []RouteConfig{{
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+			Upstream: UpstreamConfig{Host: "mcp.github.com"},
+			Credentials: []CredentialConfig{{
+				Source: mustYAMLNode(t, `type: env
+var: MISSING_MCP_TOKEN
+`),
+				Inject:  InjectConfig{Header: "Authorization"},
+				Require: boolPtr(false),
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	req := newRequest(t, "https://github.mcp.local/mcp")
+	applied, err := g.Match(req).Apply(context.Background(), req)
+	require.NoError(t, err)
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Empty(t, applied.InjectedCredentialIDs)
+}
+
+func TestCompileValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name:    "missing name",
+			cfg:     Config{Routes: []RouteConfig{{Upstream: UpstreamConfig{Host: "example.com"}}}},
+			wantErr: "name is required",
+		},
+		{
+			name:    "missing rules",
+			cfg:     Config{Routes: []RouteConfig{{Name: "github", Upstream: UpstreamConfig{Host: "example.com"}}}},
+			wantErr: "at least one rule is required",
+		},
+		{
+			name: "invalid upstream scheme",
+			cfg: Config{Routes: []RouteConfig{{
+				Name:     "github",
+				Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+				Upstream: UpstreamConfig{Scheme: "ftp", Host: "example.com"},
+			}}},
+			wantErr: "upstream.scheme must be http or https",
+		},
+		{
+			name: "invalid credential injection",
+			cfg: Config{Routes: []RouteConfig{{
+				Name:     "github",
+				Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local"}},
+				Upstream: UpstreamConfig{Host: "example.com"},
+				Credentials: []CredentialConfig{{
+					Source: mustYAMLNode(t, `type: env
+var: MCP_TOKEN
+`),
+					Inject: InjectConfig{Header: "Authorization", QueryParam: "token"},
+				}},
+			}}},
+			wantErr: "inject cannot specify both header and query_param",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Compile(tc.cfg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func newRequest(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return &http.Request{
+		Method: http.MethodPost,
+		URL:    u,
+		Host:   u.Host,
+		Header: http.Header{},
+		Body:   http.NoBody,
+	}
+}
+
+func mustYAMLNode(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	err := yaml.NewDecoder(strings.NewReader(src)).Decode(&doc)
+	require.NoError(t, err)
+	require.Equal(t, yaml.DocumentNode, doc.Kind)
+	require.NotEmpty(t, doc.Content)
+	return *doc.Content[0]
+}

--- a/internal/mcpgateway/holder.go
+++ b/internal/mcpgateway/holder.go
@@ -1,0 +1,28 @@
+package mcpgateway
+
+import "sync/atomic"
+
+// Holder holds an atomically swappable Gateway pointer.
+type Holder struct {
+	g atomic.Pointer[Gateway]
+}
+
+// NewHolder creates a Holder with the given initial gateway.
+func NewHolder(initial *Gateway) *Holder {
+	h := &Holder{}
+	h.g.Store(initial)
+	return h
+}
+
+// Load returns the current gateway snapshot, or nil if none is configured.
+func (h *Holder) Load() *Gateway {
+	if h == nil {
+		return nil
+	}
+	return h.g.Load()
+}
+
+// Store atomically replaces the current gateway with next.
+func (h *Holder) Store(next *Gateway) {
+	h.g.Store(next)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/mcp"
+	"github.com/ironsh/iron-proxy/internal/mcpgateway"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -45,6 +46,7 @@ type Proxy struct {
 	resolver       *net.Resolver
 	guard          *dnsguard.Guard
 	mcpPolicy      *mcp.PolicyHolder
+	mcpGateway     *mcpgateway.Holder
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -72,6 +74,7 @@ type Options struct {
 	Resolver   *net.Resolver
 	Guard      *dnsguard.Guard   // nil is treated as an empty (no-op) guard
 	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
+	MCPGateway *mcpgateway.Holder
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -112,6 +115,7 @@ func New(opts Options) *Proxy {
 		resolver:       opts.Resolver,
 		guard:          guard,
 		mcpPolicy:      opts.MCPPolicy,
+		mcpGateway:     opts.MCPGateway,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -421,16 +425,51 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 
+	upstreamScheme := scheme
+	upstreamHost := host
+	upstreamPath := r.URL.Path
+	upstreamRawPath := r.URL.RawPath
+	upstreamPreserveHost := false
+
+	if mcpServer != nil {
+		gateway := p.mcpGateway.Load()
+		if route := gateway.Match(r); route != nil {
+			applied, err := route.Apply(r.Context(), r)
+			if err != nil {
+				if markIfClientCancel(r, err, result) {
+					return
+				}
+				result.Action = transform.ActionContinue
+				result.StatusCode = http.StatusBadGateway
+				result.Err = err
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			upstreamScheme = applied.UpstreamScheme
+			upstreamHost = applied.UpstreamHost
+			upstreamPath = applied.UpstreamPath
+			upstreamRawPath = applied.UpstreamRawPath
+			upstreamPreserveHost = applied.PreserveHost
+			mcpTrace.SetGateway(map[string]any{
+				"route":                applied.Name,
+				"upstream_scheme":      applied.UpstreamScheme,
+				"upstream_host":        applied.UpstreamHost,
+				"preserve_host":        applied.PreserveHost,
+				"credentials_injected": applied.InjectedCredentialIDs,
+			})
+		}
+	}
+
 	// Build upstream request. Use r.URL (which transforms may have modified)
 	// rather than r.RequestURI (which is immutable). Preserve RawPath so
 	// percent-encoded reserved characters like %2F survive to the upstream —
 	// some APIs (e.g. GCS object names) treat decoded vs encoded slashes as
 	// distinct path segments.
 	upstreamURL := (&url.URL{
-		Scheme:   scheme,
-		Host:     host,
-		Path:     r.URL.Path,
-		RawPath:  r.URL.RawPath,
+		Scheme:   upstreamScheme,
+		Host:     upstreamHost,
+		Path:     upstreamPath,
+		RawPath:  upstreamRawPath,
 		RawQuery: r.URL.RawQuery,
 	}).String()
 
@@ -447,6 +486,9 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 	copyHeaders(upstreamReq.Header, r.Header)
 	sanitizeUpstreamHeaders(upstreamReq.Header)
+	if upstreamPreserveHost {
+		upstreamReq.Host = host
+	}
 	// If a transform buffered the request body, set ContentLength so the
 	// upstream receives a Content-Length header instead of chunked encoding.
 	// Otherwise, preserve the original Content-Length from the client.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -429,7 +429,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	upstreamHost := host
 	upstreamPath := r.URL.Path
 	upstreamRawPath := r.URL.RawPath
-	upstreamPreserveHost := false
+	upstreamURL := ""
 
 	if mcpServer != nil {
 		gateway := p.mcpGateway.Load()
@@ -445,16 +445,10 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 				http.Error(w, "bad gateway", http.StatusBadGateway)
 				return
 			}
-			upstreamScheme = applied.UpstreamScheme
-			upstreamHost = applied.UpstreamHost
-			upstreamPath = applied.UpstreamPath
-			upstreamRawPath = applied.UpstreamRawPath
-			upstreamPreserveHost = applied.PreserveHost
+			upstreamURL = applied.RequestURL
 			mcpTrace.SetGateway(map[string]any{
 				"route":                applied.Name,
-				"upstream_scheme":      applied.UpstreamScheme,
-				"upstream_host":        applied.UpstreamHost,
-				"preserve_host":        applied.PreserveHost,
+				"upstream":             applied.Upstream,
 				"credentials_injected": applied.InjectedCredentialIDs,
 			})
 		}
@@ -465,13 +459,15 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	// percent-encoded reserved characters like %2F survive to the upstream —
 	// some APIs (e.g. GCS object names) treat decoded vs encoded slashes as
 	// distinct path segments.
-	upstreamURL := (&url.URL{
-		Scheme:   upstreamScheme,
-		Host:     upstreamHost,
-		Path:     upstreamPath,
-		RawPath:  upstreamRawPath,
-		RawQuery: r.URL.RawQuery,
-	}).String()
+	if upstreamURL == "" {
+		upstreamURL = (&url.URL{
+			Scheme:   upstreamScheme,
+			Host:     upstreamHost,
+			Path:     upstreamPath,
+			RawPath:  upstreamRawPath,
+			RawQuery: r.URL.RawQuery,
+		}).String()
+	}
 
 	reqBody := transform.RequireBufferedBody(r.Body)
 	// Check Len() before StreamingReader(), which clears the original reader.
@@ -486,9 +482,6 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 	copyHeaders(upstreamReq.Header, r.Header)
 	sanitizeUpstreamHeaders(upstreamReq.Header)
-	if upstreamPreserveHost {
-		upstreamReq.Host = host
-	}
 	// If a transform buffered the request body, set ContentLength so the
 	// upstream receives a Content-Length header instead of chunked encoding.
 	// Otherwise, preserve the original Content-Length from the client.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -228,7 +228,7 @@ func TestMCPGatewayRoutesAllowedCallWithCredential(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reached <- struct{}{}
 		require.Equal(t, "Bearer real-token", r.Header.Get("Authorization"))
-		require.Equal(t, "/upstream/mcp", r.URL.Path)
+		require.Equal(t, "/upstream", r.URL.Path)
 		require.Equal(t, wantHost, r.Host)
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
@@ -253,13 +253,9 @@ func TestMCPGatewayRoutesAllowedCallWithCredential(t *testing.T) {
 	require.NoError(t, err)
 	gateway, err := mcpgateway.Compile(mcpgateway.Config{
 		Routes: []mcpgateway.RouteConfig{{
-			Name:  "github",
-			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
-			Upstream: mcpgateway.UpstreamConfig{
-				Scheme:     upstreamURL.Scheme,
-				Host:       upstreamURL.Host,
-				PathPrefix: "/upstream",
-			},
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
+			Upstream: upstreamURL.String() + "/upstream",
 			Credentials: []mcpgateway.CredentialConfig{{
 				Source: mustYAMLNode(t, `type: env
 var: MCP_TOKEN
@@ -313,7 +309,7 @@ func TestMCPGatewayDeniedToolDoesNotReachUpstream(t *testing.T) {
 		Routes: []mcpgateway.RouteConfig{{
 			Name:     "github",
 			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
-			Upstream: mcpgateway.UpstreamConfig{Scheme: upstreamURL.Scheme, Host: upstreamURL.Host},
+			Upstream: upstreamURL.String(),
 		}},
 	})
 	require.NoError(t, err)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -24,8 +24,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/mcp"
+	"github.com/ironsh/iron-proxy/internal/mcpgateway"
 	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
@@ -134,6 +138,34 @@ func startProxyWithTransforms(t *testing.T, transforms []transform.Transformer) 
 	return p, httpAddr, httpsAddr, pool
 }
 
+func startHTTPProxyWithMCP(t *testing.T, policy *mcp.Policy, gateway *mcpgateway.Gateway) (*Proxy, string) {
+	t.Helper()
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		Pipeline:   transform.NewPipelineHolder(pipeline),
+		MCPPolicy:  mcp.NewPolicyHolder(policy),
+		MCPGateway: mcpgateway.NewHolder(gateway),
+		Logger:     testLogger(),
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = p.httpServer.Serve(ln) }()
+	t.Cleanup(func() { _ = p.httpServer.Close() })
+	return p, ln.Addr().String()
+}
+
+func mustYAMLNode(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	err := yaml.Unmarshal([]byte(src), &doc)
+	require.NoError(t, err)
+	require.Equal(t, yaml.DocumentNode, doc.Kind)
+	require.NotEmpty(t, doc.Content)
+	return *doc.Content[0]
+}
+
 func TestHTTPProxy(t *testing.T) {
 	// Start an upstream HTTP server
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -186,6 +218,120 @@ func TestHTTPProxy_PostBody(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "echo: request body", string(body))
+}
+
+func TestMCPGatewayRoutesAllowedCallWithCredential(t *testing.T) {
+	t.Setenv("MCP_TOKEN", "real-token")
+
+	reached := make(chan struct{}, 1)
+	var wantHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached <- struct{}{}
+		require.Equal(t, "Bearer real-token", r.Header.Get("Authorization"))
+		require.Equal(t, "/upstream/mcp", r.URL.Path)
+		require.Equal(t, wantHost, r.Host)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), `"tools/call"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, err = io.WriteString(w, `{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`)
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	wantHost = upstreamURL.Host
+
+	policy, err := mcp.Compile(mcp.Config{
+		Servers: []mcp.ServerConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
+			Tools: []mcp.ToolConfig{{Name: "search_repositories"}},
+		}},
+	})
+	require.NoError(t, err)
+	gateway, err := mcpgateway.Compile(mcpgateway.Config{
+		Routes: []mcpgateway.RouteConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
+			Upstream: mcpgateway.UpstreamConfig{
+				Scheme:     upstreamURL.Scheme,
+				Host:       upstreamURL.Host,
+				PathPrefix: "/upstream",
+			},
+			Credentials: []mcpgateway.CredentialConfig{{
+				Source: mustYAMLNode(t, `type: env
+var: MCP_TOKEN
+`),
+				Inject: mcpgateway.InjectConfig{
+					Header:    "Authorization",
+					Formatter: "Bearer {{ .Value }}",
+				},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	_, proxyAddr := startHTTPProxyWithMCP(t, policy, gateway)
+
+	req, err := http.NewRequest(http.MethodPost, "http://"+proxyAddr+"/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_repositories","arguments":{}}}`))
+	require.NoError(t, err)
+	req.Host = "github.mcp.local"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gateway upstream was not reached")
+	}
+}
+
+func TestMCPGatewayDeniedToolDoesNotReachUpstream(t *testing.T) {
+	var reached atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	policy, err := mcp.Compile(mcp.Config{
+		Servers: []mcp.ServerConfig{{
+			Name:  "github",
+			Rules: []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
+			Tools: []mcp.ToolConfig{{Name: "search_repositories"}},
+		}},
+	})
+	require.NoError(t, err)
+	gateway, err := mcpgateway.Compile(mcpgateway.Config{
+		Routes: []mcpgateway.RouteConfig{{
+			Name:     "github",
+			Rules:    []hostmatch.RuleConfig{{Host: "github.mcp.local", Paths: []string{"/mcp"}}},
+			Upstream: mcpgateway.UpstreamConfig{Scheme: upstreamURL.Scheme, Host: upstreamURL.Host},
+		}},
+	})
+	require.NoError(t, err)
+	_, proxyAddr := startHTTPProxyWithMCP(t, policy, gateway)
+
+	req, err := http.NewRequest(http.MethodPost, "http://"+proxyAddr+"/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"delete_repository","arguments":{}}}`))
+	require.NoError(t, err)
+	req.Host = "github.mcp.local"
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, string(body), "blocked by iron-proxy policy")
+	require.Equal(t, int32(0), reached.Load())
 }
 
 func TestHTTPSProxy(t *testing.T) {

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -84,6 +84,9 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 			if msgs := result.MCP.MCPMessages(); len(msgs) > 0 {
 				mcpAttrs = append(mcpAttrs, slog.Any("messages", msgs))
 			}
+			if gateway := result.MCP.MCPGateway(); len(gateway) > 0 {
+				mcpAttrs = append(mcpAttrs, slog.Any("gateway", gateway))
+			}
 			attrs = append(attrs, slog.Group("mcp", mcpAttrs...))
 		}
 		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -95,6 +95,9 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 				}
 				mcpKVs = append(mcpKVs, log.KeyValue{Key: "messages", Value: log.SliceValue(vals...)})
 			}
+			if gateway := result.MCP.MCPGateway(); len(gateway) > 0 {
+				mcpKVs = append(mcpKVs, log.KeyValue{Key: "gateway", Value: toLogValue(gateway)})
+			}
 			attrs = append(attrs, log.KeyValue{Key: "mcp", Value: log.MapValue(mcpKVs...)})
 		}
 		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -175,6 +175,9 @@ type MCPAudit interface {
 	// MCPMessages returns the audit messages in observed order. Each entry
 	// is a flat key/value map suitable for JSON encoding (string-keyed).
 	MCPMessages() []map[string]any
+	// MCPGateway returns gateway route metadata, or nil when no gateway route
+	// was applied.
+	MCPGateway() map[string]any
 }
 
 // BodyCapture is the read-only view of a body_capture transform's per-request


### PR DESCRIPTION
Adds an `mcp_gateway` config block that routes client-facing MCP hosts to concrete upstream servers after MCP policy allows a request. Gateway routes can rewrite scheme, host, and path prefix, inject credentials from existing secret sources, and record route metadata in MCP audit output without logging credential values.

This keeps denied MCP tool calls from reaching upstream and preserves the existing transport path so upstream dial guards still apply to the rewritten target.