### PR TITLE
feat: add gcp id token transform

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/awsauth"
 	_ "github.com/ironsh/iron-proxy/internal/transform/bodycapture"
 	_ "github.com/ironsh/iron-proxy/internal/transform/gcpauth"
+	_ "github.com/ironsh/iron-proxy/internal/transform/gcpidtoken"
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/hmacsign"

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -194,6 +194,27 @@ func TestApplyPipelineSync_ValidConfig_Swaps(t *testing.T) {
 	require.Contains(t, logBuf.String(), "pipeline reloaded")
 }
 
+func TestApplyPipelineSync_GCPIDTokenTransformFromControlPlane(t *testing.T) {
+	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	holder := transform.NewPipelineHolder(original)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	transforms := json.RawMessage(`[
+		{
+			"name": "gcp_id_token",
+			"config": {
+				"keyfile_path": "/does/not/read/until/request.json",
+				"audience": "https://private-service-abc123-uc.a.run.app",
+				"rules": [{"host":"private-service-abc123-uc.a.run.app"}]
+			}
+		}
+	]`)
+	require.NoError(t, applyPipelineSync(holder, transform.BodyLimits{}, logger, nil, nil, transforms))
+
+	require.NotSame(t, original, holder.Load(), "pipeline should have been swapped")
+	require.Equal(t, "gcp_id_token", holder.Load().Names())
+}
+
 func TestApplyPipelineSync_InvalidJSON_KeepsExistingPipeline(t *testing.T) {
 	original := transform.NewPipeline(nil, transform.BodyLimits{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	holder := transform.NewPipelineHolder(original)

--- a/integration_test/gcp_id_token_test.go
+++ b/integration_test/gcp_id_token_test.go
@@ -1,0 +1,149 @@
+package integration_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGCPIDToken drives the gcp_id_token transform end-to-end without real GCP
+// infra by steering the service-account token_uri at a local httptest server.
+func TestGCPIDToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	binary := proxyBinary(t)
+
+	const audience = "https://private-service.run.app"
+	var (
+		tokenCalls atomic.Int64
+		gotAud     atomic.Value
+	)
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls.Add(1)
+		require.NoError(t, r.ParseForm())
+		assertion := r.PostForm.Get("assertion")
+		claims := decodeJWTClaims(t, assertion)
+		targetAudience, ok := claims["target_audience"].(string)
+		require.True(t, ok, "service account assertion must include target_audience")
+		gotAud.Store(targetAudience)
+		idToken := fakeGoogleIDToken(t, targetAudience)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id_token":   idToken,
+			"token_type": "Bearer",
+			"expires_in": 3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	var (
+		mu      sync.Mutex
+		gotAuth string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	keyfile := writeIDTokenKeyfile(t, tmpDir, tokenSrv.URL)
+	cfgPath := renderConfig(t, tmpDir, "gcp_id_token.yaml", struct {
+		KeyfilePath string
+		Audience    string
+	}{
+		KeyfilePath: keyfile,
+		Audience:    audience,
+	})
+	proxy := startProxy(t, binary, cfgPath, nil)
+	upstreamHost := upstream.Listener.Addr().String()
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/private", proxy.HTTPAddr), nil)
+	require.NoError(t, err)
+	req.Host = upstreamHost
+	req.Header.Set("Authorization", "Bearer agent-placeholder")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, gotAuth)
+	require.NotContains(t, gotAuth, "agent-placeholder", "agent placeholder bearer must be replaced")
+	require.True(t, strings.HasPrefix(gotAuth, "Bearer "), "ID token must be injected as a bearer")
+	claims := decodeJWTClaims(t, strings.TrimPrefix(gotAuth, "Bearer "))
+	require.Equal(t, audience, claims["aud"])
+	require.Equal(t, audience, gotAud.Load())
+	require.Equal(t, int64(1), tokenCalls.Load(), "token endpoint should be hit exactly once and then cached")
+}
+
+func writeIDTokenKeyfile(t *testing.T, dir, tokenURI string) string {
+	t.Helper()
+	keyfile := map[string]string{
+		"type":         "service_account",
+		"project_id":   "iron-proxy-id-token-test",
+		"private_key":  generateServiceAccountKeyPEM(t),
+		"client_email": "cloud-run-caller@iron-proxy-test.iam.gserviceaccount.com",
+		"token_uri":    tokenURI,
+	}
+	data, err := json.MarshalIndent(keyfile, "", "  ")
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "cloud-run-sa.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func fakeGoogleIDToken(t *testing.T, audience string) string {
+	t.Helper()
+	now := time.Now()
+	header := map[string]any{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+	claims := map[string]any{
+		"iss":            "https://accounts.google.com",
+		"aud":            audience,
+		"azp":            "112010400000000710080",
+		"sub":            "112010400000000710080",
+		"email":          "cloud-run-caller@iron-proxy-test.iam.gserviceaccount.com",
+		"email_verified": true,
+		"iat":            now.Unix(),
+		"exp":            now.Add(time.Hour).Unix(),
+	}
+	return encodeJWTPart(t, header) + "." + encodeJWTPart(t, claims) + "." + encodeJWTPart(t, "signature")
+}
+
+func decodeJWTClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "token is not a JWT")
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(raw, &claims))
+	return claims
+}
+
+func encodeJWTPart(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/integration_test/testdata/gcp_id_token.yaml
+++ b/integration_test/testdata/gcp_id_token.yaml
@@ -1,0 +1,32 @@
+dns:
+  proxy_ip: "127.0.0.1"
+  listen: "127.0.0.1:0"
+
+proxy:
+  http_listen: "127.0.0.1:0"
+  https_listen: "127.0.0.1:0"
+  max_request_body_bytes: 1048576
+  upstream_deny_cidrs: []
+
+tls:
+  ca_cert: tmp/ca.crt
+  ca_key: tmp/ca.key
+
+transforms:
+  - name: allowlist
+    config:
+      domains:
+        - "127.0.0.1"
+
+  - name: gcp_id_token
+    config:
+      keyfile_path: "{{ .KeyfilePath }}"
+      audience: "{{ .Audience }}"
+      rules:
+        - host: "127.0.0.1"
+
+metrics:
+  listen: "127.0.0.1:0"
+
+log:
+  level: info

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -17,8 +17,8 @@ import (
 // for the allowlist transform, secrets → {"secrets": [...]} for the secrets
 // transform. The transforms field is the control plane's already-shaped
 // transform array — each element a {name, config} object bundling the
-// gcp_auth, hmac_sign, and oauth_token transforms granted to the proxy's
-// principal.
+// gcp_auth, gcp_id_token, hmac_sign, and oauth_token transforms granted to the
+// proxy's principal.
 //
 // Pipeline order is allowlist, then secrets, then the control-plane transforms
 // in delivered order. Secrets runs before the transforms so a body-mutating

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -283,7 +283,7 @@ func TestTransformsFromSync_GCPIDTokenTransform(t *testing.T) {
 			"config": {
 				"keyfile": {"type": "control_plane", "value": "{\"type\":\"service_account\"}"},
 				"audience": "https://private-service-abc123-uc.a.run.app",
-				"header": "x_serverless_authorization",
+				"header": "x-serverless-authorization",
 				"rules": [{"host": "private-service-abc123-uc.a.run.app"}]
 			}
 		}
@@ -309,7 +309,7 @@ func TestTransformsFromSync_GCPIDTokenTransform(t *testing.T) {
 	require.Equal(t, "control_plane", decoded.Keyfile.Type)
 	require.JSONEq(t, `{"type":"service_account"}`, decoded.Keyfile.Value)
 	require.Equal(t, "https://private-service-abc123-uc.a.run.app", decoded.Audience)
-	require.Equal(t, "x_serverless_authorization", decoded.Header)
+	require.Equal(t, "x-serverless-authorization", decoded.Header)
 	require.Equal(t, "private-service-abc123-uc.a.run.app", decoded.Rules[0].Host)
 }
 

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -276,6 +276,43 @@ func TestTransformsFromSync_OAuthTokenTransform(t *testing.T) {
 	require.Equal(t, "slack.com", decoded.Tokens[0].Rules[0].Host)
 }
 
+func TestTransformsFromSync_GCPIDTokenTransform(t *testing.T) {
+	transformsRaw := json.RawMessage(`[
+		{
+			"name": "gcp_id_token",
+			"config": {
+				"keyfile": {"type": "control_plane", "value": "{\"type\":\"service_account\"}"},
+				"audience": "https://private-service-abc123-uc.a.run.app",
+				"header": "x_serverless_authorization",
+				"rules": [{"host": "private-service-abc123-uc.a.run.app"}]
+			}
+		}
+	]`)
+
+	transforms, err := TransformsFromSync(nil, nil, transformsRaw)
+	require.NoError(t, err)
+	require.Len(t, transforms, 1)
+	require.Equal(t, "gcp_id_token", transforms[0].Name)
+
+	var decoded struct {
+		Keyfile struct {
+			Type  string `yaml:"type"`
+			Value string `yaml:"value"`
+		} `yaml:"keyfile"`
+		Audience string `yaml:"audience"`
+		Header   string `yaml:"header"`
+		Rules    []struct {
+			Host string `yaml:"host"`
+		} `yaml:"rules"`
+	}
+	require.NoError(t, transforms[0].Config.Decode(&decoded))
+	require.Equal(t, "control_plane", decoded.Keyfile.Type)
+	require.JSONEq(t, `{"type":"service_account"}`, decoded.Keyfile.Value)
+	require.Equal(t, "https://private-service-abc123-uc.a.run.app", decoded.Audience)
+	require.Equal(t, "x_serverless_authorization", decoded.Header)
+	require.Equal(t, "private-service-abc123-uc.a.run.app", decoded.Rules[0].Host)
+}
+
 func TestTransformsFromSync_TransformsAfterSecrets(t *testing.T) {
 	// allowlist, then secrets, then the control-plane transforms in delivered
 	// order — so a body-mutating secret swap runs before hmac_sign signs.

--- a/internal/controlplane/client.go
+++ b/internal/controlplane/client.go
@@ -16,9 +16,9 @@ type SyncResponse struct {
 	Rules      json.RawMessage `json:"rules"`
 	Secrets    json.RawMessage `json:"secrets"`
 	// Transforms is the control plane's pre-shaped transform array, bundling
-	// the gcp_auth, hmac_sign, and oauth_token transforms granted to the
-	// proxy's principal. Unlike rules/secrets it is already in {name, config}
-	// form.
+	// the gcp_auth, gcp_id_token, hmac_sign, and oauth_token transforms granted
+	// to the proxy's principal. Unlike rules/secrets it is already in {name,
+	// config} form.
 	Transforms  json.RawMessage `json:"transforms"`
 	MCP         json.RawMessage `json:"mcp"`
 	Postgres    json.RawMessage `json:"postgres"`

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -25,11 +25,15 @@
 package gcpauth
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -49,6 +53,11 @@ import (
 // value here is never sent to Google: it just has to look like an opaque token
 // to the client SDK.
 const stubAccessToken = "iron-proxy-stub-token"
+
+const (
+	jwtBearerGrantType       = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	maxTokenRequestBodyBytes = 1 << 20
+)
 
 var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","expires_in":3600,"token_type":"Bearer"}`)
 
@@ -258,12 +267,53 @@ func isTokenEndpoint(req *http.Request) bool {
 	}
 	switch host {
 	case "oauth2.googleapis.com":
-		return path == "/token"
+		return path == "/token" && !isIDTokenJWTBearerRequest(req)
 	case "metadata.google.internal", "169.254.169.254":
 		return strings.HasPrefix(path, "/computeMetadata/v1/instance/service-accounts/") &&
 			strings.HasSuffix(path, "/token")
 	}
 	return false
+}
+
+func isIDTokenJWTBearerRequest(req *http.Request) bool {
+	if req.Body == nil {
+		return false
+	}
+	if req.ContentLength < 0 || req.ContentLength > maxTokenRequestBodyBytes {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxTokenRequestBodyBytes+1))
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil || closeErr != nil || len(body) > maxTokenRequestBodyBytes {
+		return false
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return false
+	}
+	if values.Get("grant_type") != jwtBearerGrantType {
+		return false
+	}
+	return assertionHasTargetAudience(values.Get("assertion"))
+}
+
+func assertionHasTargetAudience(assertion string) bool {
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		TargetAudience string `json:"target_audience"`
+	}
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return false
+	}
+	return claims.TargetAudience != ""
 }
 
 func stubTokenResponse(req *http.Request) *http.Response {

--- a/internal/transform/gcpauth/gcpauth.go
+++ b/internal/transform/gcpauth/gcpauth.go
@@ -25,15 +25,11 @@
 package gcpauth
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -44,6 +40,7 @@ import (
 
 	"github.com/ironsh/iron-proxy/internal/hostmatch"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/gcpjwt"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -53,11 +50,6 @@ import (
 // value here is never sent to Google: it just has to look like an opaque token
 // to the client SDK.
 const stubAccessToken = "iron-proxy-stub-token"
-
-const (
-	jwtBearerGrantType       = "urn:ietf:params:oauth:grant-type:jwt-bearer"
-	maxTokenRequestBodyBytes = 1 << 20
-)
 
 var stubTokenJSON = []byte(`{"access_token":"` + stubAccessToken + `","expires_in":3600,"token_type":"Bearer"}`)
 
@@ -276,44 +268,8 @@ func isTokenEndpoint(req *http.Request) bool {
 }
 
 func isIDTokenJWTBearerRequest(req *http.Request) bool {
-	if req.Body == nil {
-		return false
-	}
-	if req.ContentLength < 0 || req.ContentLength > maxTokenRequestBodyBytes {
-		return false
-	}
-	body, err := io.ReadAll(io.LimitReader(req.Body, maxTokenRequestBodyBytes+1))
-	closeErr := req.Body.Close()
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	if err != nil || closeErr != nil || len(body) > maxTokenRequestBodyBytes {
-		return false
-	}
-	values, err := url.ParseQuery(string(body))
-	if err != nil {
-		return false
-	}
-	if values.Get("grant_type") != jwtBearerGrantType {
-		return false
-	}
-	return assertionHasTargetAudience(values.Get("assertion"))
-}
-
-func assertionHasTargetAudience(assertion string) bool {
-	parts := strings.Split(assertion, ".")
-	if len(parts) != 3 {
-		return false
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return false
-	}
-	var claims struct {
-		TargetAudience string `json:"target_audience"`
-	}
-	if err := json.Unmarshal(raw, &claims); err != nil {
-		return false
-	}
-	return claims.TargetAudience != ""
+	_, ok := gcpjwt.JWTBearerTargetAudience(req)
+	return ok
 }
 
 func stubTokenResponse(req *http.Request) *http.Response {

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/gcpjwt"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -422,7 +423,7 @@ rules:
 	require.NoError(t, err)
 
 	form := url.Values{}
-	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("grant_type", gcpjwt.JWTBearerGrantType)
 	form.Set("assertion", unsignedAssertion(t, map[string]any{
 		"iss":             "stub@p.iam.gserviceaccount.com",
 		"aud":             "https://oauth2.googleapis.com/token",

--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -402,6 +403,47 @@ rules:
 	require.Equal(t, int64(0), calls.Load(), "real GCP token endpoint must not be hit when stubbing")
 }
 
+func TestGCPAuth_DoesNotStubIDTokenJWTBearer(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfgYAML := `
+keyfile_path: ` + path + `
+scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+rules:
+  - host: "bigquery.googleapis.com"
+`
+	var c config
+	node := yamlFromString(t, cfgYAML)
+	require.NoError(t, node.Decode(&c))
+	g, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"iss":             "stub@p.iam.gserviceaccount.com",
+		"aud":             "https://oauth2.googleapis.com/token",
+		"target_audience": "https://service.run.app",
+	}))
+	body := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Empty(t, tctx.DrainAnnotations())
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, int64(0), calls.Load(), "gcp_auth must not stub or mint for ID-token JWT bearer requests")
+}
+
 func TestGCPAuth_StubsMetadataServerToken(t *testing.T) {
 	srv, _ := fakeTokenServer(t, "minted-token", 3600)
 	dir := t.TempDir()
@@ -503,6 +545,16 @@ func decodeJWTClaims(t *testing.T, assertion string) map[string]any {
 	var claims map[string]any
 	require.NoError(t, json.Unmarshal(raw, &claims))
 	return claims
+}
+
+func unsignedAssertion(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]any{"alg": "RS256", "typ": "JWT"})
+	require.NoError(t, err)
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".sig"
 }
 
 // TestGCPAuth_Subject verifies that the subject field drives domain-wide

--- a/internal/transform/gcpidtoken/gcpidtoken.go
+++ b/internal/transform/gcpidtoken/gcpidtoken.go
@@ -214,7 +214,7 @@ func (g *GCPIDToken) TransformRequest(ctx context.Context, tctx *transform.Trans
 		tctx.Annotate("service_account", g.principal)
 	}
 	tctx.Annotate("audience", g.audience)
-	tctx.Annotate("injected", []string{"header:" + http.CanonicalHeaderKey(g.header)})
+	tctx.Annotate("injected", []string{"header:" + g.header})
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }
 
@@ -301,6 +301,9 @@ func metadataIdentityAudience(req *http.Request) (string, bool) {
 	if req.URL != nil {
 		audience = req.URL.Query().Get("audience")
 	}
+	if audience == "" {
+		return "", false
+	}
 	return audience, true
 }
 
@@ -320,10 +323,10 @@ func jwtBearerIDTokenAudience(req *http.Request) (string, bool) {
 		return "", false
 	}
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxTokenRequestBodyBytes+1))
 	closeErr := req.Body.Close()
 	req.Body = io.NopCloser(bytes.NewReader(body))
-	if err != nil || closeErr != nil {
+	if err != nil || closeErr != nil || len(body) > maxTokenRequestBodyBytes {
 		return "", false
 	}
 	values, err := url.ParseQuery(string(body))

--- a/internal/transform/gcpidtoken/gcpidtoken.go
+++ b/internal/transform/gcpidtoken/gcpidtoken.go
@@ -147,10 +147,10 @@ func normalizeHeader(raw string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "", "authorization":
 		return defaultHeader, nil
-	case "x-serverless-authorization", "x_serverless_authorization":
+	case "x-serverless-authorization":
 		return serverlessHeader, nil
 	default:
-		return "", fmt.Errorf("gcp_id_token: \"header\" must be \"authorization\" or \"x_serverless_authorization\"")
+		return "", fmt.Errorf("gcp_id_token: \"header\" must be \"authorization\" or \"x-serverless-authorization\"")
 	}
 }
 

--- a/internal/transform/gcpidtoken/gcpidtoken.go
+++ b/internal/transform/gcpidtoken/gcpidtoken.go
@@ -16,16 +16,13 @@
 package gcpidtoken
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -37,15 +34,14 @@ import (
 
 	"github.com/ironsh/iron-proxy/internal/hostmatch"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/gcpjwt"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
 const (
 	defaultHeader              = "Authorization"
 	serverlessHeader           = "X-Serverless-Authorization"
-	jwtBearerGrantType         = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 	stubAudience               = "iron-proxy-stub-audience"
-	maxTokenRequestBodyBytes   = 1 << 20
 	stubIDTokenLifetimeSeconds = 3600
 )
 
@@ -316,45 +312,7 @@ func jwtBearerIDTokenAudience(req *http.Request) (string, bool) {
 	if host != "oauth2.googleapis.com" || path != "/token" {
 		return "", false
 	}
-	if req.Body == nil {
-		return "", false
-	}
-	if req.ContentLength < 0 || req.ContentLength > maxTokenRequestBodyBytes {
-		return "", false
-	}
-
-	body, err := io.ReadAll(io.LimitReader(req.Body, maxTokenRequestBodyBytes+1))
-	closeErr := req.Body.Close()
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	if err != nil || closeErr != nil || len(body) > maxTokenRequestBodyBytes {
-		return "", false
-	}
-	values, err := url.ParseQuery(string(body))
-	if err != nil {
-		return "", false
-	}
-	if values.Get("grant_type") != jwtBearerGrantType {
-		return "", false
-	}
-	return targetAudienceFromAssertion(values.Get("assertion"))
-}
-
-func targetAudienceFromAssertion(assertion string) (string, bool) {
-	parts := strings.Split(assertion, ".")
-	if len(parts) != 3 {
-		return "", false
-	}
-	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", false
-	}
-	var claims struct {
-		TargetAudience string `json:"target_audience"`
-	}
-	if err := json.Unmarshal(raw, &claims); err != nil {
-		return "", false
-	}
-	return claims.TargetAudience, claims.TargetAudience != ""
+	return gcpjwt.JWTBearerTargetAudience(req)
 }
 
 func fakeIDToken(audience string) (string, error) {

--- a/internal/transform/gcpidtoken/gcpidtoken.go
+++ b/internal/transform/gcpidtoken/gcpidtoken.go
@@ -1,0 +1,423 @@
+// Package gcpidtoken implements a transform that mints Google-signed OIDC
+// ID tokens and injects them as Bearer headers on matching requests.
+//
+// This is intended for private Cloud Run, Cloud Run functions, IAP, API
+// Gateway, and other Google-backed targets that authenticate with an ID token
+// whose aud claim names the receiving service. Unlike gcp_auth, this transform
+// is audience-based and does not use OAuth scopes.
+//
+// Credentials come from exactly one service-account JSON source:
+//   - keyfile_path: a service account JSON keyfile loaded from disk.
+//   - keyfile: a service account JSON keyfile loaded from any registered
+//     secret source (env, aws_sm, aws_ssm, 1password, 1password_connect).
+//
+// Like all header-injecting transforms, this requires MITM mode; sni-only
+// mode has no way to rewrite headers.
+package gcpidtoken
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+const (
+	defaultHeader              = "Authorization"
+	serverlessHeader           = "X-Serverless-Authorization"
+	jwtBearerGrantType         = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	stubAudience               = "iron-proxy-stub-audience"
+	maxTokenRequestBodyBytes   = 1 << 20
+	stubIDTokenLifetimeSeconds = 3600
+)
+
+func init() {
+	transform.Register("gcp_id_token", factory)
+}
+
+type config struct {
+	KeyfilePath string                 `yaml:"keyfile_path,omitempty"`
+	Keyfile     yaml.Node              `yaml:"keyfile,omitempty"`
+	Audience    string                 `yaml:"audience"`
+	Header      string                 `yaml:"header,omitempty"`
+	Rules       []hostmatch.RuleConfig `yaml:"rules"`
+}
+
+// GCPIDToken is the transform.
+type GCPIDToken struct {
+	rules    []hostmatch.Rule
+	audience string
+	header   string
+	tsLoader tokenSourceLoader
+	logger   *slog.Logger
+
+	mu          sync.Mutex
+	tokenSource oauth2.TokenSource
+	principal   string
+}
+
+// tokenSourceLoader returns a fresh token source for one transform instance,
+// plus a best-effort principal identifier for audit annotations.
+type tokenSourceLoader func(ctx context.Context) (oauth2.TokenSource, string, error)
+
+// sourceBuilder is the signature of secrets.BuildSource. Pulled out so tests
+// can inject a stub instead of constructing real source backends.
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing gcp_id_token config: %w", err)
+	}
+	return newFromConfig(c, logger, os.ReadFile, secrets.BuildSource)
+}
+
+func newFromConfig(c config, logger *slog.Logger, readFile func(string) ([]byte, error), buildSource sourceBuilder) (*GCPIDToken, error) {
+	hasPath := c.KeyfilePath != ""
+	hasNested := c.Keyfile.Kind != 0
+	if hasPath == hasNested {
+		return nil, fmt.Errorf("gcp_id_token: requires exactly one of \"keyfile_path\" or \"keyfile\"")
+	}
+	if c.Audience == "" {
+		return nil, fmt.Errorf("gcp_id_token: \"audience\" is required")
+	}
+	rules, err := hostmatch.CompileRules(c.Rules, "gcp_id_token")
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("gcp_id_token: at least one entry in \"rules\" is required")
+	}
+	header, err := normalizeHeader(c.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	var tsLoader tokenSourceLoader
+	switch {
+	case hasPath:
+		path := c.KeyfilePath
+		audience := c.Audience
+		tsLoader = func(ctx context.Context) (oauth2.TokenSource, string, error) {
+			data, err := readFile(path)
+			if err != nil {
+				return nil, "", fmt.Errorf("reading GCP service account keyfile %q: %w", path, err)
+			}
+			return tokenSourceFromKeyfile(ctx, data, audience)
+		}
+	case hasNested:
+		nested, err := buildSource(c.Keyfile, logger)
+		if err != nil {
+			return nil, fmt.Errorf("gcp_id_token: building keyfile source: %w", err)
+		}
+		audience := c.Audience
+		tsLoader = func(ctx context.Context) (oauth2.TokenSource, string, error) {
+			v, err := nested.Get(ctx)
+			if err != nil {
+				return nil, "", fmt.Errorf("loading GCP service account keyfile from %q: %w", nested.Name(), err)
+			}
+			return tokenSourceFromKeyfile(ctx, []byte(v), audience)
+		}
+	}
+
+	return &GCPIDToken{
+		rules:    rules,
+		audience: c.Audience,
+		header:   header,
+		tsLoader: tsLoader,
+		logger:   logger,
+	}, nil
+}
+
+func normalizeHeader(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "authorization":
+		return defaultHeader, nil
+	case "x-serverless-authorization", "x_serverless_authorization":
+		return serverlessHeader, nil
+	default:
+		return "", fmt.Errorf("gcp_id_token: \"header\" must be \"authorization\" or \"x_serverless_authorization\"")
+	}
+}
+
+// tokenSourceFromKeyfile parses a service-account JSON keyfile and returns a
+// token source that exchanges a signed JWT assertion for a Google-signed ID
+// token whose aud claim is audience.
+func tokenSourceFromKeyfile(ctx context.Context, keyJSON []byte, audience string) (oauth2.TokenSource, string, error) {
+	cfg, err := google.JWTConfigFromJSON(keyJSON)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing GCP service account keyfile: %w", err)
+	}
+	cfg.PrivateClaims = map[string]any{"target_audience": audience}
+	cfg.UseIDToken = true
+
+	var meta struct {
+		ClientEmail string `json:"client_email"`
+	}
+	email := ""
+	if err := json.Unmarshal(keyJSON, &meta); err == nil {
+		email = meta.ClientEmail
+	}
+	return cfg.TokenSource(ctx), email, nil
+}
+
+func (g *GCPIDToken) Name() string { return "gcp_id_token" }
+
+func (g *GCPIDToken) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	if audience, kind, ok := stubRequest(req); ok {
+		tok, err := fakeIDToken(audience)
+		if err != nil {
+			return nil, err
+		}
+		tctx.Annotate("stubbed", kind)
+		if audience != "" {
+			tctx.Annotate("audience", audience)
+		}
+		return &transform.TransformResult{
+			Action:   transform.ActionStub,
+			Response: stubResponse(req, kind, tok),
+		}, nil
+	}
+
+	if !hostmatch.MatchAnyRule(g.rules, req) {
+		return &transform.TransformResult{Action: transform.ActionContinue}, nil
+	}
+
+	tok, err := g.mintToken(ctx)
+	if err != nil {
+		reason := g.logMintFailure(err)
+		tctx.Annotate("error", reason)
+		tctx.Annotate("rejected", "token_unavailable")
+		return &transform.TransformResult{Action: transform.ActionReject}, nil
+	}
+
+	req.Header.Set(g.header, "Bearer "+tok)
+	if g.principal != "" {
+		tctx.Annotate("service_account", g.principal)
+	}
+	tctx.Annotate("audience", g.audience)
+	tctx.Annotate("injected", []string{"header:" + http.CanonicalHeaderKey(g.header)})
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (g *GCPIDToken) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+func (g *GCPIDToken) mintToken(ctx context.Context) (string, error) {
+	ts, err := g.loadTokenSource(ctx)
+	if err != nil {
+		return "", err
+	}
+	tok, err := ts.Token()
+	if err != nil {
+		return "", fmt.Errorf("minting GCP ID token: %w", err)
+	}
+	if tok.AccessToken == "" {
+		return "", fmt.Errorf("GCP ID token source returned empty token")
+	}
+	return tok.AccessToken, nil
+}
+
+func (g *GCPIDToken) loadTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.tokenSource != nil {
+		return g.tokenSource, nil
+	}
+	ts, principal, err := g.tsLoader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	g.tokenSource = ts
+	g.principal = principal
+	return g.tokenSource, nil
+}
+
+func (g *GCPIDToken) logMintFailure(err error) string {
+	reason := classifyMintError(err)
+	if g.logger != nil {
+		g.logger.Warn("gcp_id_token mint failed", "reason", reason, "error", err)
+	}
+	return reason
+}
+
+func classifyMintError(err error) string {
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		switch {
+		case re.ErrorCode != "":
+			return re.ErrorCode
+		case re.Response != nil:
+			return fmt.Sprintf("token_endpoint_http_%d", re.Response.StatusCode)
+		default:
+			return "token_endpoint_error"
+		}
+	}
+	return "mint_failed"
+}
+
+func stubRequest(req *http.Request) (audience string, kind string, ok bool) {
+	if audience, ok := metadataIdentityAudience(req); ok {
+		return audience, "gcp_metadata_identity_endpoint", true
+	}
+	if audience, ok := jwtBearerIDTokenAudience(req); ok {
+		return audience, "gcp_oauth2_id_token_endpoint", true
+	}
+	return "", "", false
+}
+
+func metadataIdentityAudience(req *http.Request) (string, bool) {
+	host := hostmatch.StripPort(req.Host)
+	if host != "metadata.google.internal" && host != "169.254.169.254" {
+		return "", false
+	}
+	path := ""
+	if req.URL != nil {
+		path = req.URL.Path
+	}
+	if !strings.HasPrefix(path, "/computeMetadata/v1/instance/service-accounts/") || !strings.HasSuffix(path, "/identity") {
+		return "", false
+	}
+	audience := ""
+	if req.URL != nil {
+		audience = req.URL.Query().Get("audience")
+	}
+	return audience, true
+}
+
+func jwtBearerIDTokenAudience(req *http.Request) (string, bool) {
+	host := hostmatch.StripPort(req.Host)
+	path := ""
+	if req.URL != nil {
+		path = req.URL.Path
+	}
+	if host != "oauth2.googleapis.com" || path != "/token" {
+		return "", false
+	}
+	if req.Body == nil {
+		return "", false
+	}
+	if req.ContentLength < 0 || req.ContentLength > maxTokenRequestBodyBytes {
+		return "", false
+	}
+
+	body, err := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if err != nil || closeErr != nil {
+		return "", false
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return "", false
+	}
+	if values.Get("grant_type") != jwtBearerGrantType {
+		return "", false
+	}
+	return targetAudienceFromAssertion(values.Get("assertion"))
+}
+
+func targetAudienceFromAssertion(assertion string) (string, bool) {
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", false
+	}
+	var claims struct {
+		TargetAudience string `json:"target_audience"`
+	}
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return "", false
+	}
+	return claims.TargetAudience, claims.TargetAudience != ""
+}
+
+func fakeIDToken(audience string) (string, error) {
+	if audience == "" {
+		audience = stubAudience
+	}
+	now := time.Now()
+	header := map[string]any{
+		"alg": "RS256",
+		"typ": "JWT",
+	}
+	claims := map[string]any{
+		"iss":            "https://accounts.google.com",
+		"aud":            audience,
+		"azp":            "iron-proxy-stub",
+		"sub":            "iron-proxy-stub",
+		"email":          "stub@iron-proxy.local",
+		"email_verified": true,
+		"iat":            now.Unix(),
+		"exp":            now.Add(stubIDTokenLifetimeSeconds * time.Second).Unix(),
+	}
+	h, err := encodeJWTPart(header)
+	if err != nil {
+		return "", err
+	}
+	c, err := encodeJWTPart(claims)
+	if err != nil {
+		return "", err
+	}
+	sig := base64.RawURLEncoding.EncodeToString([]byte("stub-signature"))
+	return h + "." + c + "." + sig, nil
+}
+
+func encodeJWTPart(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("encoding stub ID token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func stubResponse(req *http.Request, kind, token string) *http.Response {
+	if kind == "gcp_metadata_identity_endpoint" {
+		body := []byte(token)
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Status:        "200 OK",
+			Proto:         "HTTP/1.1",
+			ProtoMajor:    1,
+			ProtoMinor:    1,
+			Header:        http.Header{"Content-Type": {"text/plain"}},
+			Body:          transform.NewBufferedBodyFromBytes(body),
+			ContentLength: int64(len(body)),
+			Request:       req,
+		}
+	}
+	body := []byte(`{"id_token":"` + token + `","expires_in":3600,"token_type":"Bearer"}`)
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Status:        "200 OK",
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          transform.NewBufferedBodyFromBytes(body),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
+}

--- a/internal/transform/gcpidtoken/gcpidtoken_test.go
+++ b/internal/transform/gcpidtoken/gcpidtoken_test.go
@@ -402,6 +402,20 @@ func TestGCPIDToken_DoesNotStubAccessTokenJWTBearer(t *testing.T) {
 	require.Equal(t, body, string(restored))
 }
 
+func TestGCPIDToken_DoesNotInspectOversizedTokenEndpointBody(t *testing.T) {
+	body := strings.Repeat("x", maxTokenRequestBodyBytes+1)
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+
+	g := newStubOnlyTransform(t)
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
 func TestGCPIDToken_StubsMetadataIdentityEndpoint(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https%3A%2F%2Fservice.run.app", nil)
 	require.NoError(t, err)
@@ -416,6 +430,16 @@ func TestGCPIDToken_StubsMetadataIdentityEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	claims := decodeJWTClaims(t, string(body))
 	require.Equal(t, "https://service.run.app", claims["aud"])
+}
+
+func TestGCPIDToken_DoesNotStubMetadataIdentityWithoutAudience(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity", nil)
+	require.NoError(t, err)
+
+	g := newStubOnlyTransform(t)
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
 }
 
 func TestGCPIDToken_MintFailureRejectsWithSanitizedReason(t *testing.T) {

--- a/internal/transform/gcpidtoken/gcpidtoken_test.go
+++ b/internal/transform/gcpidtoken/gcpidtoken_test.go
@@ -237,7 +237,7 @@ func TestGCPIDToken_InjectsServerlessHeader(t *testing.T) {
 	cfg := config{
 		KeyfilePath: path,
 		Audience:    "https://service.run.app",
-		Header:      "x_serverless_authorization",
+		Header:      "x-serverless-authorization",
 		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
 	}
 	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))

--- a/internal/transform/gcpidtoken/gcpidtoken_test.go
+++ b/internal/transform/gcpidtoken/gcpidtoken_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ironsh/iron-proxy/internal/hostmatch"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/gcpjwt"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -355,7 +356,7 @@ func TestGCPIDToken_NestedSourceBuildError(t *testing.T) {
 
 func TestGCPIDToken_StubsOAuth2IDTokenEndpoint(t *testing.T) {
 	form := url.Values{}
-	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("grant_type", gcpjwt.JWTBearerGrantType)
 	form.Set("assertion", unsignedAssertion(t, map[string]any{
 		"iss":             "stub@p.iam.gserviceaccount.com",
 		"aud":             "https://oauth2.googleapis.com/token",
@@ -382,7 +383,7 @@ func TestGCPIDToken_StubsOAuth2IDTokenEndpoint(t *testing.T) {
 
 func TestGCPIDToken_DoesNotStubAccessTokenJWTBearer(t *testing.T) {
 	form := url.Values{}
-	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("grant_type", gcpjwt.JWTBearerGrantType)
 	form.Set("assertion", unsignedAssertion(t, map[string]any{
 		"iss":   "stub@p.iam.gserviceaccount.com",
 		"aud":   "https://oauth2.googleapis.com/token",
@@ -403,7 +404,7 @@ func TestGCPIDToken_DoesNotStubAccessTokenJWTBearer(t *testing.T) {
 }
 
 func TestGCPIDToken_DoesNotInspectOversizedTokenEndpointBody(t *testing.T) {
-	body := strings.Repeat("x", maxTokenRequestBodyBytes+1)
+	body := strings.Repeat("x", gcpjwt.MaxTokenRequestBodyBytes+1)
 	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
 	require.NoError(t, err)
 

--- a/internal/transform/gcpidtoken/gcpidtoken_test.go
+++ b/internal/transform/gcpidtoken/gcpidtoken_test.go
@@ -1,0 +1,489 @@
+package gcpidtoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+type staticSource struct {
+	name  string
+	value string
+	err   error
+	calls atomic.Int64
+}
+
+func (s *staticSource) Name() string { return s.name }
+func (s *staticSource) Get(context.Context) (string, error) {
+	s.calls.Add(1)
+	return s.value, s.err
+}
+
+func staticBuilder(src secrets.Source) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return src, nil }
+}
+
+func failingBuilder(err error) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return nil, err }
+}
+
+func testKeyfileJSON(t *testing.T, tokenURL, email string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	keyfile := map[string]string{
+		"type":         "service_account",
+		"project_id":   "test-project",
+		"private_key":  string(pemBytes),
+		"client_email": email,
+		"token_uri":    tokenURL,
+	}
+	data, err := json.Marshal(keyfile)
+	require.NoError(t, err)
+	return data
+}
+
+func fakeIDTokenServer(t *testing.T, accessToken string) (*httptest.Server, *atomic.Int64, *atomic.Value) {
+	t.Helper()
+	var calls atomic.Int64
+	var assertion atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		require.NoError(t, r.ParseForm())
+		assertion.Store(r.PostForm.Get("assertion"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id_token":   accessToken,
+			"token_type": "Bearer",
+			"expires_in": stubIDTokenLifetimeSeconds,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls, &assertion
+}
+
+func yamlFromString(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	return *node.Content[0]
+}
+
+func newRequest(t *testing.T, host string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, "https://"+host+"/v1/resource", nil)
+	require.NoError(t, err)
+	return r
+}
+
+func newContext() *transform.TransformContext {
+	return &transform.TransformContext{Mode: transform.ModeMITM}
+}
+
+func decodeJWTClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "token is not a JWT")
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(raw, &claims))
+	return claims
+}
+
+func unsignedAssertion(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, err := encodeJWTPart(map[string]any{"alg": "RS256", "typ": "JWT"})
+	require.NoError(t, err)
+	body, err := encodeJWTPart(claims)
+	require.NoError(t, err)
+	return header + "." + body + ".sig"
+}
+
+func TestGCPIDToken_Validation(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantError string
+	}{
+		{
+			name: "missing both keyfile sources",
+			yaml: `
+audience: https://service.run.app
+rules:
+  - host: service.run.app
+`,
+			wantError: "exactly one",
+		},
+		{
+			name: "both keyfile sources set",
+			yaml: `
+keyfile_path: /tmp/k.json
+keyfile:
+  type: env
+  var: X
+audience: https://service.run.app
+rules:
+  - host: service.run.app
+`,
+			wantError: "exactly one",
+		},
+		{
+			name: "missing audience",
+			yaml: `
+keyfile_path: /tmp/k.json
+rules:
+  - host: service.run.app
+`,
+			wantError: "audience",
+		},
+		{
+			name: "missing rules",
+			yaml: `
+keyfile_path: /tmp/k.json
+audience: https://service.run.app
+`,
+			wantError: "rules",
+		},
+		{
+			name: "invalid header",
+			yaml: `
+keyfile_path: /tmp/k.json
+audience: https://service.run.app
+header: X-Other
+rules:
+  - host: service.run.app
+`,
+			wantError: "header",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c config
+			node := yamlFromString(t, tc.yaml)
+			require.NoError(t, node.Decode(&c))
+			_, err := newFromConfig(c, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+			require.ErrorContains(t, err, tc.wantError)
+		})
+	}
+}
+
+func TestGCPIDToken_InjectsBearerFromKeyfilePath(t *testing.T) {
+	wantIDToken, err := fakeIDToken("https://service.run.app")
+	require.NoError(t, err)
+	srv, calls, assertion := fakeIDTokenServer(t, wantIDToken)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "service.run.app")
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+wantIDToken, req.Header.Get("Authorization"))
+	require.Equal(t, int64(1), calls.Load())
+
+	claims := decodeJWTClaims(t, assertion.Load().(string))
+	require.Equal(t, "sa@p.iam.gserviceaccount.com", claims["iss"])
+	require.Equal(t, srv.URL, claims["aud"])
+	require.Equal(t, "https://service.run.app", claims["target_audience"])
+
+	annotations := tctx.DrainAnnotations()
+	require.Equal(t, "sa@p.iam.gserviceaccount.com", annotations["service_account"])
+	require.Equal(t, "https://service.run.app", annotations["audience"])
+}
+
+func TestGCPIDToken_InjectsServerlessHeader(t *testing.T) {
+	wantIDToken, err := fakeIDToken("https://service.run.app")
+	require.NoError(t, err)
+	srv, _, _ := fakeIDTokenServer(t, wantIDToken)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Header:      "x_serverless_authorization",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "service.run.app")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, "Bearer "+wantIDToken, req.Header.Get("X-Serverless-Authorization"))
+}
+
+func TestGCPIDToken_InjectsBearerFromNestedSource(t *testing.T) {
+	wantIDToken, err := fakeIDToken("https://nested.run.app")
+	require.NoError(t, err)
+	srv, _ := fakeIDTokenServerNoAssertion(t, wantIDToken)
+	keyJSON := testKeyfileJSON(t, srv.URL, "nested@p.iam.gserviceaccount.com")
+	nested := &staticSource{name: "op://vault/gcp-sa/credential", value: string(keyJSON)}
+
+	cfg := config{
+		Keyfile:  yamlFromString(t, "type: 1password_connect\nsecret_ref: \"op://vault/gcp-sa/credential\"\n"),
+		Audience: "https://nested.run.app",
+		Rules:    []hostmatch.RuleConfig{hostmatchRuleConfig(t, "nested.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(nested))
+	require.NoError(t, err)
+
+	req := newRequest(t, "nested.run.app")
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "Bearer "+wantIDToken, req.Header.Get("Authorization"))
+	require.Equal(t, int64(1), nested.calls.Load())
+}
+
+func TestGCPIDToken_HostRulesRestrictInjection(t *testing.T) {
+	wantIDToken, err := fakeIDToken("https://service.run.app")
+	require.NoError(t, err)
+	srv, calls, _ := fakeIDTokenServer(t, wantIDToken)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "service.run.app")
+	_, err = g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer "+wantIDToken, req.Header.Get("Authorization"))
+
+	other := newRequest(t, "api.openai.com")
+	_, err = g.TransformRequest(context.Background(), newContext(), other)
+	require.NoError(t, err)
+	require.Empty(t, other.Header.Get("Authorization"))
+	require.Equal(t, int64(1), calls.Load())
+}
+
+func TestGCPIDToken_CachesTokenAcrossRequests(t *testing.T) {
+	wantIDToken, err := fakeIDToken("https://service.run.app")
+	require.NoError(t, err)
+	srv, calls, _ := fakeIDTokenServer(t, wantIDToken)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		req := newRequest(t, "service.run.app")
+		_, err := g.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		require.Equal(t, "Bearer "+wantIDToken, req.Header.Get("Authorization"))
+	}
+	require.Equal(t, int64(1), calls.Load())
+}
+
+func TestGCPIDToken_KeyfileMissing_Rejects(t *testing.T) {
+	cfg := config{
+		KeyfilePath: "/does/not/exist.json",
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "service.run.app")
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, "mint_failed", tctx.DrainAnnotations()["error"])
+}
+
+func TestGCPIDToken_NestedSourceBuildError(t *testing.T) {
+	cfg := config{
+		Keyfile:  yamlFromString(t, "type: 1password_connect\nsecret_ref: \"op://vault/missing\"\n"),
+		Audience: "https://service.run.app",
+		Rules:    []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	_, err := newFromConfig(cfg, slog.Default(), os.ReadFile, failingBuilder(fmt.Errorf("not configured")))
+	require.ErrorContains(t, err, "building keyfile source")
+	require.ErrorContains(t, err, "not configured")
+}
+
+func TestGCPIDToken_StubsOAuth2IDTokenEndpoint(t *testing.T) {
+	form := url.Values{}
+	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"iss":             "stub@p.iam.gserviceaccount.com",
+		"aud":             "https://oauth2.googleapis.com/token",
+		"target_audience": "https://service.run.app",
+	}))
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	g := newStubOnlyTransform(t)
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionStub, res.Action)
+	require.Equal(t, "gcp_oauth2_id_token_endpoint", tctx.DrainAnnotations()["stubbed"])
+
+	var out struct {
+		IDToken string `json:"id_token"`
+	}
+	require.NoError(t, json.NewDecoder(res.Response.Body).Decode(&out))
+	claims := decodeJWTClaims(t, out.IDToken)
+	require.Equal(t, "https://service.run.app", claims["aud"])
+}
+
+func TestGCPIDToken_DoesNotStubAccessTokenJWTBearer(t *testing.T) {
+	form := url.Values{}
+	form.Set("grant_type", jwtBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"iss":   "stub@p.iam.gserviceaccount.com",
+		"aud":   "https://oauth2.googleapis.com/token",
+		"scope": "https://www.googleapis.com/auth/cloud-platform",
+	}))
+	body := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	g := newStubOnlyTransform(t)
+	res, err := g.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestGCPIDToken_StubsMetadataIdentityEndpoint(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https%3A%2F%2Fservice.run.app", nil)
+	require.NoError(t, err)
+
+	g := newStubOnlyTransform(t)
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionStub, res.Action)
+	require.Equal(t, "gcp_metadata_identity_endpoint", tctx.DrainAnnotations()["stubbed"])
+	body, err := io.ReadAll(res.Response.Body)
+	require.NoError(t, err)
+	claims := decodeJWTClaims(t, string(body))
+	require.Equal(t, "https://service.run.app", claims["aud"])
+}
+
+func TestGCPIDToken_MintFailureRejectsWithSanitizedReason(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.Copy(io.Discard, r.Body)
+		require.NoError(t, err)
+		http.Error(w, "upstream token endpoint failed", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+
+	req := newRequest(t, "service.run.app")
+	tctx := newContext()
+	res, err := g.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionReject, res.Action)
+	require.Equal(t, "token_endpoint_http_500", tctx.DrainAnnotations()["error"])
+}
+
+func newStubOnlyTransform(t *testing.T) *GCPIDToken {
+	t.Helper()
+	wantIDToken, err := fakeIDToken("https://service.run.app")
+	require.NoError(t, err)
+	srv, _ := fakeIDTokenServerNoAssertion(t, wantIDToken)
+	path := filepath.Join(t.TempDir(), "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+	cfg := config{
+		KeyfilePath: path,
+		Audience:    "https://service.run.app",
+		Rules:       []hostmatch.RuleConfig{hostmatchRuleConfig(t, "service.run.app")},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}))
+	require.NoError(t, err)
+	return g
+}
+
+func fakeIDTokenServerNoAssertion(t *testing.T, accessToken string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, err := io.Copy(io.Discard, r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id_token":   accessToken,
+			"token_type": "Bearer",
+			"expires_in": stubIDTokenLifetimeSeconds,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func hostmatchRuleConfig(t *testing.T, host string) hostmatch.RuleConfig {
+	t.Helper()
+	var rules struct {
+		Rules []hostmatch.RuleConfig `yaml:"rules"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("rules:\n  - host: "+host+"\n"), &rules))
+	return rules.Rules[0]
+}

--- a/internal/transform/gcpjwt/gcpjwt.go
+++ b/internal/transform/gcpjwt/gcpjwt.go
@@ -1,0 +1,93 @@
+// Package gcpjwt contains small helpers shared by GCP auth transforms for
+// recognizing Google JWT-bearer token exchange requests.
+package gcpjwt
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	// JWTBearerGrantType is the OAuth2 grant type used by Google service
+	// account keyfiles when exchanging a signed JWT assertion.
+	JWTBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+	// MaxTokenRequestBodyBytes caps token endpoint body inspection. Requests
+	// above this size are left for the normal request path.
+	MaxTokenRequestBodyBytes = 1 << 20
+)
+
+// JWTBearerTargetAudience returns the target_audience claim from a JWT-bearer
+// token request body. The request body is restored before returning.
+func JWTBearerTargetAudience(req *http.Request) (string, bool) {
+	body, ok := tokenRequestBody(req)
+	if !ok {
+		return "", false
+	}
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		return "", false
+	}
+	if values.Get("grant_type") != JWTBearerGrantType {
+		return "", false
+	}
+	return TargetAudienceFromAssertion(values.Get("assertion"))
+}
+
+// TargetAudienceFromAssertion extracts the target_audience private claim from
+// an unsigned inspection of a JWT assertion.
+func TargetAudienceFromAssertion(assertion string) (string, bool) {
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		return "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", false
+	}
+	var claims struct {
+		TargetAudience string `json:"target_audience"`
+	}
+	if err := json.Unmarshal(raw, &claims); err != nil {
+		return "", false
+	}
+	return claims.TargetAudience, claims.TargetAudience != ""
+}
+
+func tokenRequestBody(req *http.Request) ([]byte, bool) {
+	if req.Body == nil {
+		return nil, false
+	}
+	if req.ContentLength < 0 || req.ContentLength > MaxTokenRequestBodyBytes {
+		return nil, false
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, MaxTokenRequestBodyBytes+1))
+	if err != nil || len(body) > MaxTokenRequestBodyBytes {
+		req.Body = &replayReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), req.Body),
+			closer: req.Body,
+		}
+		return nil, false
+	}
+	closeErr := req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if closeErr != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+type replayReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (r *replayReadCloser) Close() error {
+	return r.closer.Close()
+}

--- a/internal/transform/gcpjwt/gcpjwt_test.go
+++ b/internal/transform/gcpjwt/gcpjwt_test.go
@@ -1,0 +1,64 @@
+package gcpjwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJWTBearerTargetAudience(t *testing.T) {
+	form := url.Values{}
+	form.Set("grant_type", JWTBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"target_audience": "https://service.run.app",
+	}))
+	body := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+
+	audience, ok := JWTBearerTargetAudience(req)
+	require.True(t, ok)
+	require.Equal(t, "https://service.run.app", audience)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestJWTBearerTargetAudienceRestoresOversizedBody(t *testing.T) {
+	body := strings.Repeat("x", MaxTokenRequestBodyBytes+1)
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+
+	audience, ok := JWTBearerTargetAudience(req)
+	require.False(t, ok)
+	require.Empty(t, audience)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestTargetAudienceFromAssertionRejectsMissingAudience(t *testing.T) {
+	audience, ok := TargetAudienceFromAssertion(unsignedAssertion(t, map[string]any{
+		"scope": "https://www.googleapis.com/auth/cloud-platform",
+	}))
+	require.False(t, ok)
+	require.Empty(t, audience)
+}
+
+func unsignedAssertion(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header, err := json.Marshal(map[string]any{"alg": "RS256", "typ": "JWT"})
+	require.NoError(t, err)
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -311,6 +311,42 @@ transforms:
   #     rules:
   #       - host: "*.googleapis.com"
 
+  # GCP OIDC ID token authentication. Mints a Google-signed ID token with
+  # the configured audience and sets Authorization: Bearer on matching
+  # requests. This is the token shape required by private Cloud Run services,
+  # Cloud Run functions, IAP, API Gateway, and other audience-authenticated
+  # Google targets. Tokens are cached and refreshed automatically before
+  # expiry. Requires MITM mode (sni-only mode cannot rewrite headers). On
+  # token-minting failure the request is rejected (403).
+  #
+  # The service account JSON can come from disk via keyfile_path, or from any
+  # configured secret source (env, aws_sm, aws_ssm, 1password,
+  # 1password_connect) via a nested keyfile block. Use exactly one.
+  #
+  # Cloud Run checks the aud claim against the receiving service URL or a
+  # configured custom audience. For Cloud Run, custom domains are not valid
+  # audience values.
+  # - name: gcp_id_token
+  #   config:
+  #     keyfile_path: "/etc/iron-proxy/cloud-run-caller.json"
+  #     audience: "https://my-service-abc123-uc.a.run.app"
+  #     # Optional. Use x_serverless_authorization when the upstream app needs
+  #     # the Authorization header for its own application auth.
+  #     header: authorization
+  #     rules:
+  #       - host: "my-service-abc123-uc.a.run.app"
+  #
+  # Same thing, service account JSON sourced from 1Password Connect:
+  # - name: gcp_id_token
+  #   config:
+  #     keyfile:
+  #       type: 1password_connect
+  #       secret_ref: "op://Engineering/Cloud-Run-Caller/credential"
+  #     audience: "https://my-service-abc123-uc.a.run.app"
+  #     header: x_serverless_authorization
+  #     rules:
+  #       - host: "my-service-abc123-uc.a.run.app"
+
   # OAuth2 token injection. Mints short-lived OAuth2 access tokens and sets
   # Authorization: Bearer on matching requests. Each entry under tokens names
   # a grant type, its credential fields, and the hosts it applies to. Token

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -330,7 +330,7 @@ transforms:
   #   config:
   #     keyfile_path: "/etc/iron-proxy/cloud-run-caller.json"
   #     audience: "https://my-service-abc123-uc.a.run.app"
-  #     # Optional. Use x_serverless_authorization when the upstream app needs
+  #     # Optional. Use x-serverless-authorization when the upstream app needs
   #     # the Authorization header for its own application auth.
   #     header: authorization
   #     rules:
@@ -343,7 +343,7 @@ transforms:
   #       type: 1password_connect
   #       secret_ref: "op://Engineering/Cloud-Run-Caller/credential"
   #     audience: "https://my-service-abc123-uc.a.run.app"
-  #     header: x_serverless_authorization
+  #     header: x-serverless-authorization
   #     rules:
   #       - host: "my-service-abc123-uc.a.run.app"
 


### PR DESCRIPTION
Adds a gcp_id_token transform for Google-signed OIDC ID token injection, including service-account keyfile sources, Cloud Run-friendly audience config, optional serverless header injection, and token endpoint stubbing.

Also wires the transform into managed sync/pipeline initialization and documents the config in the example YAML.