### PR TITLE
feat: add upstream deny CIDR env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Single binary. Single YAML config.
   to dial it if its resolved address falls inside a denied CIDR — closing
   the SSRF/DNS-rebinding gap where an allowlisted hostname points at IMDS
   or loopback. Cloud metadata endpoints (`169.254.169.254`) and loopback are
-  denied by default; override via `proxy.upstream_deny_cidrs`.
+  denied by default; override via `proxy.upstream_deny_cidrs` or
+  `IRON_PROXY_UPSTREAM_DENY_CIDRS`.
 - **Boundary-level secret injection.** Workloads send proxy tokens; iron-proxy
   replaces them with real secrets before the request leaves. If the sandbox is
   compromised, the attacker gets tokens that are useless outside the proxy.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 )
 
 // applyEnvOverrides layers IRON_* environment variables on top of an existing
@@ -94,6 +97,18 @@ func applyEnvOverrides(cfg *Config) error {
 		cfg.Proxy.UpstreamResponseHeaderTimeout = Duration(d)
 	}
 
+	if v := os.Getenv("IRON_PROXY_UPSTREAM_DENY_CIDRS"); v != "" {
+		cidrs, err := splitCIDREnvList(v)
+		if err != nil {
+			return fmt.Errorf("IRON_PROXY_UPSTREAM_DENY_CIDRS: %w", err)
+		}
+		if err := dnsguard.ValidateCIDRs(cidrs); err != nil {
+			return fmt.Errorf("IRON_PROXY_UPSTREAM_DENY_CIDRS: %w", err)
+		}
+		cfg.Proxy.UpstreamDenyCIDRs.Values = cidrs
+		cfg.Proxy.UpstreamDenyCIDRs.Set = true
+	}
+
 	if v := os.Getenv("IRON_CONTROL_PLANE_POLL_INTERVAL"); v != "" {
 		d, err := time.ParseDuration(v)
 		if err != nil {
@@ -103,4 +118,17 @@ func applyEnvOverrides(cfg *Config) error {
 	}
 
 	return nil
+}
+
+func splitCIDREnvList(v string) ([]string, error) {
+	parts := strings.Split(v, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			return nil, fmt.Errorf("empty CIDR entry")
+		}
+		values = append(values, trimmed)
+	}
+	return values, nil
 }

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,7 @@ func TestLoadConfig_EnvOnly_AllOverrides(t *testing.T) {
 		"IRON_PROXY_MAX_REQUEST_BODY_BYTES":           "2097152",
 		"IRON_PROXY_MAX_RESPONSE_BODY_BYTES":          "4194304",
 		"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT": "5m",
+		"IRON_PROXY_UPSTREAM_DENY_CIDRS":              "10.0.0.0/8, 192.168.0.0/16",
 		"IRON_TLS_CA_CERT":                            "/custom/ca.pem",
 		"IRON_TLS_CA_KEY":                             "/custom/ca-key.pem",
 		"IRON_TLS_CERT_CACHE_SIZE":                    "500",
@@ -66,6 +68,8 @@ func TestLoadConfig_EnvOnly_AllOverrides(t *testing.T) {
 	require.Equal(t, ":1080", cfg.Proxy.TunnelListen)
 	require.Equal(t, int64(2097152), cfg.Proxy.MaxRequestBodyBytes)
 	require.Equal(t, int64(4194304), cfg.Proxy.MaxResponseBodyBytes)
+	require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+	require.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, cfg.Proxy.UpstreamDenyCIDRs.Values)
 	require.Equal(t, "/custom/ca.pem", cfg.TLS.CACert)
 	require.Equal(t, "/custom/ca-key.pem", cfg.TLS.CAKey)
 	require.Equal(t, 500, cfg.TLS.CertCacheSize)
@@ -264,6 +268,66 @@ func TestApplyEnvOverrides_UpstreamResponseHeaderTimeout(t *testing.T) {
 	})
 }
 
+func TestApplyEnvOverrides_UpstreamDenyCIDRs(t *testing.T) {
+	t.Run("env override applied", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_DENY_CIDRS": "10.0.0.0/8,192.168.0.0/16",
+		})
+
+		var cfg Config
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+		require.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("env override beats yaml value", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_DENY_CIDRS": "10.0.0.0/8",
+		})
+
+		cfg := Config{Proxy: Proxy{UpstreamDenyCIDRs: CIDRList{
+			Values: []string{"169.254.169.254/32"},
+			Set:    true,
+		}}}
+		require.NoError(t, applyEnvOverrides(&cfg))
+		require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+		require.Equal(t, []string{"10.0.0.0/8"}, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("unset keeps default", func(t *testing.T) {
+		setEnvs(t, map[string]string{})
+
+		cfg, err := LoadConfig("")
+		require.NoError(t, err)
+		require.True(t, cfg.Proxy.UpstreamDenyCIDRs.Set)
+		require.Equal(t, dnsguard.DefaultDenyCIDRs, cfg.Proxy.UpstreamDenyCIDRs.Values)
+	})
+
+	t.Run("invalid cidr rejected", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_DENY_CIDRS": "1.2.3.4",
+		})
+
+		var cfg Config
+		err := applyEnvOverrides(&cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "IRON_PROXY_UPSTREAM_DENY_CIDRS")
+		require.Contains(t, err.Error(), "must be CIDR notation")
+	})
+
+	t.Run("empty entry rejected", func(t *testing.T) {
+		setEnvs(t, map[string]string{
+			"IRON_PROXY_UPSTREAM_DENY_CIDRS": "10.0.0.0/8,",
+		})
+
+		var cfg Config
+		err := applyEnvOverrides(&cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "IRON_PROXY_UPSTREAM_DENY_CIDRS")
+		require.Contains(t, err.Error(), "empty CIDR entry")
+	})
+}
+
 func TestApplyEnvOverrides_ControlPlanePollInterval(t *testing.T) {
 	t.Run("env override applied", func(t *testing.T) {
 		setEnvs(t, map[string]string{
@@ -374,6 +438,7 @@ func setEnvs(t *testing.T, envs map[string]string) {
 		"IRON_PROXY_MAX_REQUEST_BODY_BYTES",
 		"IRON_PROXY_MAX_RESPONSE_BODY_BYTES",
 		"IRON_PROXY_UPSTREAM_RESPONSE_HEADER_TIMEOUT",
+		"IRON_PROXY_UPSTREAM_DENY_CIDRS",
 		"IRON_TLS_CA_CERT",
 		"IRON_TLS_CA_KEY",
 		"IRON_TLS_CERT_CACHE_SIZE",

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -53,6 +53,8 @@ proxy:
   # Set an explicit list to override the defaults. Use an empty list
   # (upstream_deny_cidrs: []) if you intentionally need to allow IMDS or
   # loopback traffic to upstreams.
+  # The equivalent environment override is a comma-separated list:
+  # IRON_PROXY_UPSTREAM_DENY_CIDRS="169.254.169.254/32,127.0.0.0/8"
   # upstream_deny_cidrs:
   #   - "169.254.169.254/32"
   #   - "127.0.0.0/8"


### PR DESCRIPTION
Adds IRON_PROXY_UPSTREAM_DENY_CIDRS as a comma-separated environment override for proxy.upstream_deny_cidrs. The override validates CIDR syntax, takes precedence over YAML, and is documented in the README and example config.