### PR TITLE
fix: support HTTP proxy requests on tunnel listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Single binary. Single YAML config.
 - **Streaming-aware.** WebSocket upgrades and Server-Sent Events are proxied
   natively. No special configuration for agent workloads that hold long-lived
   connections.
-- **CONNECT and SOCKS5 support.** Optional tunnel listener for tools that
-  natively support proxy configuration via `HTTPS_PROXY` or SOCKS5 settings.
+- **Explicit proxy support.** Optional tunnel listener for tools that natively
+  support proxy configuration via `HTTP_PROXY`, `HTTPS_PROXY`, or SOCKS5
+  settings.
 - **PostgreSQL MITM proxy.** Optional listener that authenticates clients
   against proxy-managed credentials, injects `SET ROLE` on the upstream
   session, and rejects client attempts to mutate the role (`SET ROLE`,
@@ -634,12 +635,13 @@ Bodies are buffered incrementally as transforms read them, and automatically
 rewound between pipeline stages. If a transform doesn't read the body, no
 buffering occurs and the body streams through untouched.
 
-### Tunnel listener (CONNECT/SOCKS5)
+### Tunnel listener (HTTP/CONNECT/SOCKS5)
 
-The tunnel listener accepts HTTP CONNECT and SOCKS5 connections on a
-dedicated port. This is useful for tools that natively support proxy
-configuration via `HTTPS_PROXY`/`ALL_PROXY` environment variables or
-SOCKS5 settings, rather than relying on DNS-based routing.
+The tunnel listener accepts absolute-form HTTP proxy requests, HTTP CONNECT,
+and SOCKS5 connections on a dedicated port. This is useful for tools that
+natively support proxy configuration via `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`
+environment variables or SOCKS5 settings, rather than relying on DNS-based
+routing.
 
 To enable it, set `tunnel_listen` under `proxy`:
 
@@ -650,10 +652,11 @@ proxy:
 
 When omitted, the tunnel listener is disabled.
 
-Both protocols go through the same transform pipeline as regular HTTP/HTTPS
-requests. The proxy evaluates a synthetic CONNECT request against your
-allowlist and secrets transforms, so tunnel connections are subject to the
-same default-deny policy.
+All protocols go through the same transform pipeline as regular HTTP/HTTPS
+requests. Absolute-form HTTP requests are handled by the normal HTTP proxy
+path. For CONNECT and SOCKS5, the proxy evaluates a synthetic CONNECT request
+against your allowlist and secrets transforms, so tunnel connections are
+subject to the same default-deny policy.
 
 After the CONNECT or SOCKS5 handshake, the proxy peeks at the first byte to
 detect the inner protocol:
@@ -672,6 +675,13 @@ curl -x http://172.20.0.2:8080 \
   https://httpbin.org/get
 ```
 
+**Plain HTTP proxy example:**
+
+```bash
+curl -x http://172.20.0.2:8080 \
+  http://httpbin.org/get
+```
+
 **SOCKS5 example:**
 
 ```bash
@@ -684,6 +694,7 @@ You can also set the standard environment variables so all tools route
 through the tunnel automatically:
 
 ```bash
+export HTTP_PROXY=http://172.20.0.2:8080
 export HTTPS_PROXY=http://172.20.0.2:8080
 export ALL_PROXY=socks5h://172.20.0.2:8080
 ```

--- a/charts/iron-proxy/README.md
+++ b/charts/iron-proxy/README.md
@@ -33,7 +33,7 @@ listeners, configured under `.Values.listeners`:
 | HTTP | `http` | 80/TCP | yes |
 | HTTPS | `https` | 443/TCP | yes |
 | Metrics / health (`GET /healthz`) | `metrics` | 9090/TCP | yes |
-| Tunnel (CONNECT/SOCKS5) | `tunnel` | 8080/TCP | no |
+| Tunnel (HTTP/CONNECT/SOCKS5) | `tunnel` | 8080/TCP | no |
 | Postgres MITM | `postgres` | 5432/TCP | no |
 | Management API | `management` | 9092/TCP | no |
 
@@ -57,7 +57,7 @@ listeners:
   https:
     port: 8443        # Service port, container port, and proxy bind all become 8443
   tunnel:
-    enabled: true     # turn on the optional CONNECT/SOCKS5 tunnel
+    enabled: true     # turn on the optional HTTP/CONNECT/SOCKS5 explicit proxy
   dns:
     enabled: false    # disable the DNS server entirely (IRON_DNS_ENABLED=false)
 ```

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/transform"
@@ -80,7 +81,11 @@ func (p *Proxy) serveTunnelProxyHTTP(conn net.Conn) error {
 			p.handleTunnelCONNECT(w, r)
 			return
 		}
-		p.handleHTTP(w, r, nil)
+		if r.URL.Scheme != "http" {
+			http.Error(w, "unsupported proxy request scheme", http.StatusBadRequest)
+			return
+		}
+		p.handleDirectHTTP(w, r)
 	}))
 }
 
@@ -95,6 +100,7 @@ func (p *Proxy) handleTunnelCONNECT(w http.ResponseWriter, req *http.Request) {
 
 	ok, rejectResp, tunnelInfo := p.tunnelTransformCheck(req.RemoteAddr, host, req.Header)
 	if !ok {
+		w.Header().Set("Connection", "close")
 		if rejectResp == nil {
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
@@ -397,15 +403,18 @@ func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string, tunnelInfo *
 func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 	ln := newOneConnListener(conn)
 	srv := &http.Server{
-		Handler: handler,
-		ConnState: func(c net.Conn, state http.ConnState) {
-			if c == conn && (state == http.StateClosed || state == http.StateHijacked) {
-				_ = ln.Close()
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       10 * time.Second,
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateClosed || state == http.StateHijacked {
+				ln.closeDone()
 			}
 		},
 	}
+	srv.SetKeepAlivesEnabled(false)
 	err := srv.Serve(ln)
-	if errors.Is(err, net.ErrClosed) || errors.Is(err, http.ErrServerClosed) {
+	if errors.Is(err, net.ErrClosed) {
 		return nil
 	}
 	return err
@@ -459,12 +468,16 @@ func (l *oneConnListener) Accept() (net.Conn, error) {
 }
 
 func (l *oneConnListener) Close() error {
+	l.closeDone()
+	return nil
+}
+
+func (l *oneConnListener) closeDone() {
 	select {
 	case <-l.done:
 	default:
 		close(l.done)
 	}
-	return nil
 }
 
 func (l *oneConnListener) Addr() net.Addr {

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -412,7 +412,6 @@ func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 			}
 		},
 	}
-	srv.SetKeepAlivesEnabled(false)
 	err := srv.Serve(ln)
 	if errors.Is(err, net.ErrClosed) {
 		return nil

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -44,7 +45,7 @@ func (p *Proxy) listenTunnel() error {
 	}
 }
 
-// handleTunnel peeks at the first byte to dispatch to CONNECT or SOCKS5.
+// handleTunnel peeks at the first byte to dispatch to HTTP proxy or SOCKS5.
 // This is the single logging point for tunnel connection errors.
 func (p *Proxy) handleTunnel(conn net.Conn) {
 	br := bufio.NewReader(conn)
@@ -63,28 +64,28 @@ func (p *Proxy) handleTunnel(conn net.Conn) {
 		return
 	}
 
-	// Otherwise assume HTTP CONNECT
-	if err := p.handleCONNECT(conn, br); err != nil {
-		p.logger.Debug("tunnel connect error", slog.String("error", err.Error()))
+	// Otherwise assume HTTP proxy traffic. This supports both CONNECT and
+	// absolute-form HTTP requests on the same explicit proxy port.
+	if err := p.serveTunnelProxyHTTP(newPeekedConn(conn, br)); err != nil {
+		p.logger.Debug("tunnel http error", slog.String("error", err.Error()))
 	}
 }
 
-// handleCONNECT handles HTTP CONNECT tunnel requests.
-func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) error {
-	defer conn.Close()
-
-	req, err := http.ReadRequest(br)
-	if err != nil {
-		return fmt.Errorf("read request: %w", err)
-	}
-
-	if req.Method != http.MethodConnect {
-		if _, err := fmt.Fprintf(conn, "HTTP/1.1 405 Method Not Allowed\r\n\r\n"); err != nil {
-			return fmt.Errorf("write 405: %w", err)
+// serveTunnelProxyHTTP serves HTTP proxy requests on the tunnel listener.
+// CONNECT establishes a tunnel; all other methods are forwarded through the
+// normal HTTP proxy path.
+func (p *Proxy) serveTunnelProxyHTTP(conn net.Conn) error {
+	return serveOneHTTPConn(conn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			p.handleTunnelCONNECT(w, r)
+			return
 		}
-		return nil
-	}
+		p.handleHTTP(w, r, nil)
+	}))
+}
 
+// handleTunnelCONNECT handles HTTP CONNECT tunnel requests.
+func (p *Proxy) handleTunnelCONNECT(w http.ResponseWriter, req *http.Request) {
 	host := req.Host
 	if _, _, err := net.SplitHostPort(host); err != nil {
 		host = net.JoinHostPort(host, "443")
@@ -92,30 +93,41 @@ func (p *Proxy) handleCONNECT(conn net.Conn, br *bufio.Reader) error {
 
 	p.logger.Debug("tunnel CONNECT", slog.String("target", host))
 
-	ok, rejectResp, tunnelInfo := p.tunnelTransformCheck(conn.RemoteAddr().String(), host, req.Header)
+	ok, rejectResp, tunnelInfo := p.tunnelTransformCheck(req.RemoteAddr, host, req.Header)
 	if !ok {
 		if rejectResp == nil {
-			rejectResp = &http.Response{
-				StatusCode: http.StatusForbidden,
-				Proto:      "HTTP/1.1",
-				ProtoMajor: 1,
-				ProtoMinor: 1,
-				Header:     http.Header{},
-				Body:       http.NoBody,
-			}
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			return
 		}
-		if err := rejectResp.Write(conn); err != nil {
-			return fmt.Errorf("write rejection: %w", err)
-		}
-		return nil
+		p.writeResponse(w, rejectResp)
+		return
 	}
 
-	// Send 200 to signal tunnel established
-	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
-		return fmt.Errorf("write 200: %w", err)
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	conn, rw, err := hj.Hijack()
+	if err != nil {
+		p.logger.Warn("tunnel hijack error", slog.String("error", err.Error()))
+		return
+	}
+	defer conn.Close()
+
+	// Send 200 to signal tunnel established.
+	if _, err := rw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		p.logger.Warn("tunnel write 200 error", slog.String("error", err.Error()))
+		return
+	}
+	if err := rw.Flush(); err != nil {
+		p.logger.Warn("tunnel flush 200 error", slog.String("error", err.Error()))
+		return
 	}
 
-	return p.serveTunnel(conn, host, tunnelInfo)
+	if err := p.serveTunnelWithReader(conn, rw.Reader, host, tunnelInfo); err != nil {
+		p.logger.Debug("tunnel connect error", slog.String("error", err.Error()))
+	}
 }
 
 // handleSOCKS5 handles SOCKS5 tunnel requests.
@@ -325,6 +337,10 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string, connectHeaders h
 // plain HTTP is served directly through handleHTTP. Anything else is rejected.
 func (p *Proxy) serveTunnel(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	br := bufio.NewReader(clientConn)
+	return p.serveTunnelWithReader(clientConn, br, target, tunnelInfo)
+}
+
+func (p *Proxy) serveTunnelWithReader(clientConn net.Conn, br *bufio.Reader, target string, tunnelInfo *transform.TunnelInfo) error {
 	first, err := br.Peek(1)
 	if err != nil {
 		return fmt.Errorf("peek client protocol: %w", err)
@@ -364,26 +380,35 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string, tunnelInfo *t
 		return fmt.Errorf("TLS handshake for %s: %w", target, err)
 	}
 
-	ln := newOneConnListener(tlsConn)
-	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			p.handleHTTP(w, r, tunnelInfo)
-		}),
-	}
-	return srv.Serve(ln)
+	return serveOneHTTPConn(tlsConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.handleHTTP(w, r, tunnelInfo)
+	}))
 }
 
 // serveTunnelHTTP serves plain HTTP requests through the normal handleHTTP handler.
 func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	defer clientConn.Close()
 
-	ln := newOneConnListener(clientConn)
+	return serveOneHTTPConn(clientConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.handleHTTP(w, r, tunnelInfo)
+	}))
+}
+
+func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
+	ln := newOneConnListener(conn)
 	srv := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			p.handleHTTP(w, r, tunnelInfo)
-		}),
+		Handler: handler,
+		ConnState: func(c net.Conn, state http.ConnState) {
+			if c == conn && (state == http.StateClosed || state == http.StateHijacked) {
+				_ = ln.Close()
+			}
+		},
 	}
-	return srv.Serve(ln)
+	err := srv.Serve(ln)
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 func cloneTunnelInfo(info *transform.TunnelInfo) *transform.TunnelInfo {

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -168,8 +168,24 @@ func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 	defer resp2.Body.Close()
 
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
+	require.False(t, resp2.Close)
 
 	body, err := io.ReadAll(resp2.Body)
+	require.NoError(t, err)
+	require.Equal(t, "hello from tls tunnel", string(body))
+
+	req2, err := http.NewRequest("GET", fmt.Sprintf("https://%s/again", fakeHost), nil)
+	require.NoError(t, err)
+
+	err = req2.Write(tlsConn)
+	require.NoError(t, err)
+
+	resp3, err := http.ReadResponse(tlsBr, req2)
+	require.NoError(t, err)
+	defer resp3.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp3.StatusCode)
+	body, err = io.ReadAll(resp3.Body)
 	require.NoError(t, err)
 	require.Equal(t, "hello from tls tunnel", string(body))
 }

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -173,20 +174,32 @@ func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 	require.Equal(t, "hello from tls tunnel", string(body))
 }
 
-func TestTunnel_CONNECT_MethodNotAllowed(t *testing.T) {
+func TestTunnel_HTTPProxyAbsoluteForm(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/test?x=1", r.RequestURI)
+		w.Header().Set("X-Tunnel-HTTP", "true")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "hello from http proxy")
+	}))
+	defer upstream.Close()
+
 	_, tunnelAddr, _ := startTunnelProxy(t, nil)
 
-	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	proxyURL, err := url.Parse("http://" + tunnelAddr)
 	require.NoError(t, err)
-	defer conn.Close()
+	transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	defer transport.CloseIdleConnections()
 
-	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(upstream.URL + "/test?x=1")
 	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	br := bufio.NewReader(conn)
-	resp, err := http.ReadResponse(br, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "true", resp.Header.Get("X-Tunnel-HTTP"))
+	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	require.Equal(t, "hello from http proxy", string(body))
 }
 
 func TestTunnel_SOCKS5_HTTP(t *testing.T) {

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -202,6 +202,24 @@ func TestTunnel_HTTPProxyAbsoluteForm(t *testing.T) {
 	require.Equal(t, "hello from http proxy", string(body))
 }
 
+func TestTunnel_HTTPProxyRejectsAbsoluteFormHTTPS(t *testing.T) {
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "GET https://example.com/test HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestTunnel_SOCKS5_HTTP(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Socks", "true")
@@ -361,6 +379,14 @@ func TestTunnel_TransformReject(t *testing.T) {
 	resp, err := http.ReadResponse(br, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	err = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	require.NoError(t, err)
+	_, err = br.Peek(1)
+	require.ErrorIs(t, err, io.EOF)
 }
 
 func TestTunnel_CONNECTHeadersAndRejectResponse(t *testing.T) {


### PR DESCRIPTION
Allow the tunnel listener to handle absolute-form HTTP proxy requests in addition to CONNECT and SOCKS5, so HTTP_PROXY and HTTPS_PROXY can point at the same exposed port. This routes plain HTTP requests through the normal proxy path while preserving existing CONNECT and SOCKS5 behavior, and updates the docs to describe the listener as the explicit proxy port.