### PR TITLE
fix: keep tunnel connections alive during hijacked WebSocket relays

### DIFF
--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ironsh/iron-proxy/internal/config"
@@ -402,17 +403,33 @@ func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string, tunnelInfo *
 
 func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 	ln := newOneConnListener(conn)
+	var hijacked atomic.Bool
+	var handlers sync.WaitGroup
 	srv := &http.Server{
-		Handler:           handler,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlers.Add(1)
+			defer handlers.Done()
+			handler.ServeHTTP(w, r)
+		}),
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       10 * time.Second,
 		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateHijacked {
+				hijacked.Store(true)
+			}
 			if state == http.StateClosed || state == http.StateHijacked {
 				ln.closeDone()
 			}
 		},
 	}
 	err := srv.Serve(ln)
+	// A hijacking handler (WebSocket relay, CONNECT tunnel) owns the
+	// connection until it returns. Serve comes back as soon as the hijack
+	// happens, so wait for the handler before returning: callers defer
+	// Close on the connection and must not run it mid-relay.
+	if hijacked.Load() {
+		handlers.Wait()
+	}
 	if errors.Is(err, net.ErrClosed) {
 		return nil
 	}

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -577,3 +577,217 @@ func (t *tunnelInfoTransform) TransformRequest(_ context.Context, tctx *transfor
 func (t *tunnelInfoTransform) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }
+
+// startWebSocketEchoUpstream starts a raw TCP server that accepts a single
+// connection, answers a WebSocket upgrade request with 101 Switching
+// Protocols, then echoes all subsequent bytes back to the client.
+func startWebSocketEchoUpstream(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		br := bufio.NewReader(conn)
+		if _, err := http.ReadRequest(br); err != nil {
+			return
+		}
+
+		resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n\r\n"
+		if _, err := conn.Write([]byte(resp)); err != nil {
+			return
+		}
+
+		buf := make([]byte, 4096)
+		for {
+			n, err := br.Read(buf)
+			if err != nil {
+				return
+			}
+			if _, err := conn.Write(buf[:n]); err != nil {
+				return
+			}
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
+// wsUpgradeAndEcho sends a WebSocket upgrade request for target over conn,
+// verifies the 101 response, then checks that payload bytes echo back.
+func wsUpgradeAndEcho(t *testing.T, conn net.Conn, br *bufio.Reader, target string) {
+	t.Helper()
+
+	upgradeReq := fmt.Sprintf("GET /ws HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"+
+		"Sec-WebSocket-Version: 13\r\n\r\n",
+		target)
+	_, err := conn.Write([]byte(upgradeReq))
+	require.NoError(t, err)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	statusLine, err := br.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, statusLine, "101")
+	for {
+		line, err := br.ReadString('\n')
+		require.NoError(t, err)
+		if line == "\r\n" {
+			break
+		}
+	}
+
+	_, err = conn.Write([]byte("hello websocket"))
+	require.NoError(t, err)
+
+	buf := make([]byte, 4096)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	n, err := br.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, "hello websocket", string(buf[:n]))
+}
+
+func TestTunnel_CONNECT_WebSocket(t *testing.T) {
+	target := startWebSocketEchoUpstream(t)
+
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	wsUpgradeAndEcho(t, conn, br, target)
+}
+
+func TestTunnel_SOCKS5_WebSocket(t *testing.T) {
+	target := startWebSocketEchoUpstream(t)
+
+	_, tunnelAddr, _ := startTunnelProxy(t, nil)
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	targetHost, targetPortStr, err := net.SplitHostPort(target)
+	require.NoError(t, err)
+
+	// SOCKS5 auth negotiation: version 5, 1 method (no auth)
+	_, err = conn.Write([]byte{0x05, 0x01, 0x00})
+	require.NoError(t, err)
+
+	authResp := make([]byte, 2)
+	_, err = io.ReadFull(conn, authResp)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x05, 0x00}, authResp)
+
+	// SOCKS5 connect request: IPv4
+	ip := net.ParseIP(targetHost).To4()
+	require.NotNil(t, ip)
+
+	var port uint16
+	_, err = fmt.Sscanf(targetPortStr, "%d", &port)
+	require.NoError(t, err)
+
+	connectReq := []byte{0x05, 0x01, 0x00, 0x01} // ver, cmd=connect, rsv, atyp=IPv4
+	connectReq = append(connectReq, ip...)
+	portBuf := make([]byte, 2)
+	binary.BigEndian.PutUint16(portBuf, port)
+	connectReq = append(connectReq, portBuf...)
+
+	_, err = conn.Write(connectReq)
+	require.NoError(t, err)
+
+	connectResp := make([]byte, 10)
+	_, err = io.ReadFull(conn, connectResp)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x05), connectResp[0]) // version
+	require.Equal(t, byte(0x00), connectResp[1]) // success
+
+	wsUpgradeAndEcho(t, conn, bufio.NewReader(conn), target)
+}
+
+// TestServeOneHTTPConn_HijackWaitsForHandler pins the contract that lets
+// hijacking handlers (WebSocket relays, CONNECT tunnels) survive their
+// callers' deferred conn.Close(): serveOneHTTPConn must not return until a
+// hijacking handler has finished with the connection. This covers the TLS
+// MITM branch too, which cannot be exercised end-to-end because
+// handleWebSocket verifies upstream certificates against system roots.
+func TestServeOneHTTPConn_HijackWaitsForHandler(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	release := make(chan struct{})
+	serveReturned := make(chan struct{})
+
+	go func() {
+		defer close(serveReturned)
+		err := serveOneHTTPConn(serverConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Background HTTP handler: report failures via t.Error.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Error("hijacking not supported")
+				return
+			}
+			conn, rw, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			defer conn.Close()
+			if _, err := rw.WriteString("HTTP/1.1 101 Switching Protocols\r\n\r\n"); err != nil {
+				t.Errorf("write 101: %v", err)
+				return
+			}
+			if err := rw.Flush(); err != nil {
+				t.Errorf("flush 101: %v", err)
+				return
+			}
+			<-release
+		}))
+		if err != nil {
+			t.Errorf("serveOneHTTPConn: %v", err)
+		}
+	}()
+
+	_, err := clientConn.Write([]byte("GET /ws HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	require.NoError(t, err)
+
+	// Read the 101 status line so the hijack has definitely happened.
+	br := bufio.NewReader(clientConn)
+	statusLine, err := br.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, statusLine, "101")
+
+	select {
+	case <-serveReturned:
+		t.Fatal("serveOneHTTPConn returned while the hijacking handler was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-serveReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveOneHTTPConn did not return after the hijacking handler finished")
+	}
+}


### PR DESCRIPTION
#208 made `serveOneHTTPConn` return as soon as a handler hijacked the connection, which let callers' deferred `conn.Close()` calls tear down the client connection while the WebSocket relay was still running — breaking WebSockets through CONNECT and SOCKS5 tunnels. This makes `serveOneHTTPConn` wait for a hijacking handler to finish before returning, restoring the pre-#208 connection lifetime without reintroducing the goroutine leak that PR fixed. Adds regression tests for WebSocket upgrades through CONNECT and SOCKS5 tunnels, plus a test pinning the hijack-lifetime contract of `serveOneHTTPConn` itself (which also covers the TLS MITM branch).