### PR TITLE
fix: preserve buffered body for GCP token inspection

### DIFF
--- a/internal/transform/gcpauth/gcpauth_test.go
+++ b/internal/transform/gcpauth/gcpauth_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/gcpjwt"
 	"github.com/ironsh/iron-proxy/internal/transform/secrets"
@@ -401,6 +402,50 @@ rules:
 	require.Equal(t, "oauth2_token_endpoint", annotations["stubbed"])
 
 	require.Empty(t, req.Header.Get("Authorization"))
+	require.Equal(t, int64(0), calls.Load(), "real GCP token endpoint must not be hit when stubbing")
+}
+
+func TestGCPAuth_StubsOAuth2TokenEndpointWithBufferedJWTBody(t *testing.T) {
+	srv, calls := fakeTokenServer(t, "minted-token", 3600)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sa.json")
+	require.NoError(t, os.WriteFile(path, testKeyfileJSON(t, srv.URL, "sa@p.iam.gserviceaccount.com"), 0o600))
+
+	cfg := config{
+		KeyfilePath: path,
+		Scopes:      []string{"https://www.googleapis.com/auth/cloud-platform"},
+		Rules: []hostmatch.RuleConfig{
+			{Host: "bigquery.googleapis.com"},
+		},
+	}
+	g, err := newFromConfig(cfg, slog.Default(), os.ReadFile, staticBuilder(&staticSource{}), errTokenSourceBuilder)
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("grant_type", gcpjwt.JWTBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"iss":   "stub@p.iam.gserviceaccount.com",
+		"aud":   "https://oauth2.googleapis.com/token",
+		"scope": "https://www.googleapis.com/auth/cloud-platform",
+	}))
+	body := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Body = transform.NewBufferedBody(req.Body, 0)
+
+	p := transform.NewPipeline([]transform.Transformer{g}, transform.BodyLimits{}, slog.Default())
+	var traces []transform.TransformTrace
+	resp, err := p.ProcessRequest(context.Background(), newContext(), req, &traces)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, traces, 1)
+	require.Equal(t, transform.ActionStub, traces[0].Action)
+	require.IsType(t, &transform.BufferedBody{}, req.Body)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
 	require.Equal(t, int64(0), calls.Load(), "real GCP token endpoint must not be hit when stubbing")
 }
 

--- a/internal/transform/gcpjwt/gcpjwt.go
+++ b/internal/transform/gcpjwt/gcpjwt.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
 const (
@@ -67,16 +69,25 @@ func tokenRequestBody(req *http.Request) ([]byte, bool) {
 		return nil, false
 	}
 
+	buffered, isBuffered := req.Body.(*transform.BufferedBody)
 	body, err := io.ReadAll(io.LimitReader(req.Body, MaxTokenRequestBodyBytes+1))
 	if err != nil || len(body) > MaxTokenRequestBodyBytes {
-		req.Body = &replayReadCloser{
-			Reader: io.MultiReader(bytes.NewReader(body), req.Body),
-			closer: req.Body,
+		if isBuffered {
+			buffered.Reset()
+		} else {
+			req.Body = &replayReadCloser{
+				Reader: io.MultiReader(bytes.NewReader(body), req.Body),
+				closer: req.Body,
+			}
 		}
 		return nil, false
 	}
 	closeErr := req.Body.Close()
-	req.Body = io.NopCloser(bytes.NewReader(body))
+	if isBuffered {
+		buffered.Reset()
+	} else {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
 	if closeErr != nil {
 		return nil, false
 	}

--- a/internal/transform/gcpjwt/gcpjwt_test.go
+++ b/internal/transform/gcpjwt/gcpjwt_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
 )
 
 func TestJWTBearerTargetAudience(t *testing.T) {
@@ -31,6 +33,27 @@ func TestJWTBearerTargetAudience(t *testing.T) {
 	require.Equal(t, body, string(restored))
 }
 
+func TestJWTBearerTargetAudiencePreservesBufferedBody(t *testing.T) {
+	form := url.Values{}
+	form.Set("grant_type", JWTBearerGrantType)
+	form.Set("assertion", unsignedAssertion(t, map[string]any{
+		"target_audience": "https://service.run.app",
+	}))
+	body := form.Encode()
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Body = transform.NewBufferedBody(req.Body, 0)
+
+	audience, ok := JWTBearerTargetAudience(req)
+	require.True(t, ok)
+	require.Equal(t, "https://service.run.app", audience)
+	require.IsType(t, &transform.BufferedBody{}, req.Body)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
 func TestJWTBearerTargetAudienceRestoresOversizedBody(t *testing.T) {
 	body := strings.Repeat("x", MaxTokenRequestBodyBytes+1)
 	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
@@ -39,6 +62,22 @@ func TestJWTBearerTargetAudienceRestoresOversizedBody(t *testing.T) {
 	audience, ok := JWTBearerTargetAudience(req)
 	require.False(t, ok)
 	require.Empty(t, audience)
+
+	restored, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, string(restored))
+}
+
+func TestJWTBearerTargetAudiencePreservesBufferedOversizedBody(t *testing.T) {
+	body := strings.Repeat("x", MaxTokenRequestBodyBytes+1)
+	req, err := http.NewRequest(http.MethodPost, "https://oauth2.googleapis.com/token", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Body = transform.NewBufferedBody(req.Body, 0)
+
+	audience, ok := JWTBearerTargetAudience(req)
+	require.False(t, ok)
+	require.Empty(t, audience)
+	require.IsType(t, &transform.BufferedBody{}, req.Body)
 
 	restored, err := io.ReadAll(req.Body)
 	require.NoError(t, err)


### PR DESCRIPTION
Preserves the proxy's BufferedBody wrapper when GCP JWT token inspection reads and restores oauth2.googleapis.com/token request bodies. This prevents the transform pipeline from panicking when gcp_auth distinguishes access-token JWT bearer requests from ID-token requests, and adds regression coverage for buffered and oversized token bodies.