### PR TITLE
feat(proxy): support HTTP/2 (gRPC) upstreams in MITM mode

### DIFF
--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
 	"github.com/ironsh/iron-proxy/internal/transform"
@@ -494,3 +495,179 @@ func TestIntegration_SOCKS5(t *testing.T) {
 	})
 }
 
+// TestIntegration_CONNECT_HTTP2 verifies a gRPC-style HTTP/2 client can tunnel
+// through the MITM proxy: ALPN negotiates h2 on both the client->proxy and
+// proxy->upstream hops, and upstream trailers (where gRPC carries grpc-status)
+// reach the client. This is the regression test for HTTP/2/gRPC MITM support.
+func TestIntegration_CONNECT_HTTP2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// HTTP/2 upstream that records its negotiated protocol and sends a trailer
+	// after the body, mirroring how gRPC delivers grpc-status.
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Trailer", "X-Test-Trailer")
+		w.Header().Set("X-Upstream-Proto", r.Proto)
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "h2 integration response")
+		w.Header().Set("X-Test-Trailer", "trailer-value")
+	}))
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	defer upstream.Close()
+	upstreamAddr := upstream.Listener.Addr().String()
+
+	const allowedHost = "allowed.example.com"
+	p, tunnelAddr, caPool := startTunnelIntegrationProxy(t, []string{allowedHost}, logger)
+
+	// Route all dials to the h2 upstream. ForceAttemptHTTP2 mirrors the
+	// production buildTransport change so the proxy negotiates h2 upstream.
+	p.transport = &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: true,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
+		},
+	}
+
+	// HTTP/2 client that CONNECT-tunnels through the proxy and trusts the MITM CA.
+	client := &http.Client{
+		Transport: &http2.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caPool,
+				ServerName: allowedHost,
+				NextProtos: []string{"h2"},
+			},
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+				if err != nil {
+					return nil, err
+				}
+				if _, err := fmt.Fprintf(conn, "CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", allowedHost, allowedHost); err != nil {
+					_ = conn.Close()
+					return nil, err
+				}
+				resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					_ = conn.Close()
+					return nil, err
+				}
+				if resp.StatusCode != http.StatusOK {
+					_ = conn.Close()
+					return nil, fmt.Errorf("CONNECT failed: %d", resp.StatusCode)
+				}
+				tlsConn := tls.Client(conn, cfg)
+				if err := tlsConn.HandshakeContext(ctx); err != nil {
+					_ = conn.Close()
+					return nil, err
+				}
+				return tlsConn, nil
+			},
+		},
+	}
+	defer client.CloseIdleConnections()
+
+	resp, err := client.Get(fmt.Sprintf("https://%s/test", allowedHost))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, 2, resp.ProtoMajor, "client<->proxy hop must be HTTP/2")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "h2 integration response", string(body))
+	require.Equal(t, "HTTP/2.0", resp.Header.Get("X-Upstream-Proto"), "proxy<->upstream hop must be HTTP/2")
+	// The trailer must survive proxying — this is where gRPC carries grpc-status.
+	require.Equal(t, "trailer-value", resp.Trailer.Get("X-Test-Trailer"))
+}
+
+// startDirectHTTPSProxy starts a proxy serving its direct HTTPS (MITM) listener
+// (not the CONNECT tunnel) and routes all upstream dials to upstreamAddr.
+// Returns the proxy, the HTTPS listener address, and the CA pool to trust.
+func startDirectHTTPSProxy(t *testing.T, allowedHosts []string, upstreamAddr string, logger *slog.Logger) (*Proxy, string, *x509.CertPool) {
+	t.Helper()
+
+	ca := newIntegrationCA(t)
+	al, err := allowlist.New(allowedHosts, nil)
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+	holder := transform.NewPipelineHolder(pipeline)
+
+	p := New(Options{
+		HTTPAddr:  "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		CertCache: ca.certCache,
+		Pipeline:  holder,
+		Logger:    logger,
+	})
+
+	httpsLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tlsLn := tls.NewListener(httpsLn, p.httpsServer.TLSConfig)
+	httpsAddr := httpsLn.Addr().String()
+	go func() { _ = p.httpsServer.Serve(tlsLn) }()
+	t.Cleanup(func() { _ = p.httpsServer.Close() })
+
+	p.transport = &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		ForceAttemptHTTP2: true,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, upstreamAddr)
+		},
+	}
+	return p, httpsAddr, ca.caPool
+}
+
+// trailerUpstream returns an HTTP/2 test server that sends a body followed by a
+// trailer, mirroring how gRPC delivers grpc-status.
+func trailerUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Trailer", "X-Test-Trailer")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "trailer body")
+		w.Header().Set("X-Test-Trailer", "trailer-value")
+	}))
+	s.EnableHTTP2 = true
+	s.StartTLS()
+	return s
+}
+
+// TestIntegration_DirectHTTPS_HTTP2 verifies the direct HTTPS MITM listener
+// (not the CONNECT tunnel) negotiates h2 and forwards response trailers.
+func TestIntegration_DirectHTTPS_HTTP2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	upstream := trailerUpstream(t)
+	defer upstream.Close()
+
+	const fakeHost = "direct-h2.example.com"
+	_, httpsAddr, caPool := startDirectHTTPSProxy(t, []string{fakeHost}, upstream.Listener.Addr().String(), logger)
+
+	client := &http.Client{
+		Transport: &http2.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: caPool, ServerName: fakeHost, NextProtos: []string{"h2"}},
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				return (&tls.Dialer{Config: cfg}).DialContext(ctx, "tcp", httpsAddr)
+			},
+		},
+	}
+	defer client.CloseIdleConnections()
+
+	resp, err := client.Get("https://" + fakeHost + "/test")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, 2, resp.ProtoMajor, "direct HTTPS listener must serve HTTP/2")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "trailer body", string(body))
+	require.Equal(t, "trailer-value", resp.Trailer.Get("X-Test-Trailer"))
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/mcpgateway"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"golang.org/x/net/http2"
 )
 
 // Proxy is the HTTP/HTTPS proxy server. When Mode is TLSModeMITM, the HTTPS
@@ -133,6 +134,9 @@ func New(opts Options) *Proxy {
 			GetCertificate: p.getCertificate,
 		},
 	}
+	// Enable HTTP/2 on the HTTPS listener (adds h2 to the TLS ALPN and serves
+	// negotiated conns through the existing handler); zero config never errors.
+	_ = http2.ConfigureServer(p.httpsServer, &http2.Server{})
 
 	return p
 }
@@ -762,6 +766,8 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 
 func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
+	// Forward upstream trailers (e.g. gRPC status) after the body.
+	defer writeTrailers(w, resp)
 	if buf, ok := resp.Body.(*transform.BufferedBody); ok {
 		// If a transform buffered the response body, set Content-Length
 		// from the buffered data. Otherwise preserve the upstream header
@@ -809,8 +815,11 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
-		Proxy:                 proxyFunc,
-		DialContext:           dialer.DialContext,
+		Proxy:       proxyFunc,
+		DialContext: dialer.DialContext,
+		// A custom DialContext disables net/http's automatic HTTP/2; opt back in
+		// so gRPC upstreams negotiate h2 over the same (dnsguard-controlled) dialer.
+		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
@@ -850,6 +859,16 @@ func copyHeaders(dst, src http.Header) {
 	for k, vs := range src {
 		for _, v := range vs {
 			dst.Add(k, v)
+		}
+	}
+}
+
+// writeTrailers forwards upstream response trailers (e.g. gRPC status) to the
+// client after the body, via the TrailerPrefix convention.
+func writeTrailers(w http.ResponseWriter, resp *http.Response) {
+	for k, vs := range resp.Trailer {
+		for _, v := range vs {
+			w.Header().Add(http.TrailerPrefix+k, v)
 		}
 	}
 }

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ironsh/iron-proxy/internal/config"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	"golang.org/x/net/http2"
 )
 
 // listenTunnel starts the CONNECT/SOCKS5 tunnel listener.
@@ -380,6 +381,7 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string, tunnelInfo *t
 
 	tlsConn := tls.Server(clientConn, &tls.Config{
 		GetCertificate: p.getCertificate,
+		NextProtos:     []string{"h2", "http/1.1"}, // offer HTTP/2 to tunnelled clients
 	})
 	defer func() { _ = tlsConn.Close() }()
 
@@ -422,6 +424,8 @@ func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 			}
 		},
 	}
+	// Serve HTTP/2 when a tunnelled conn negotiates it; zero config never errors.
+	_ = http2.ConfigureServer(srv, &http2.Server{})
 	err := srv.Serve(ln)
 	// A hijacking handler (WebSocket relay, CONNECT tunnel) owns the
 	// connection until it returns. Serve comes back as soon as the hijack


### PR DESCRIPTION
In MITM mode the leaf advertised no ALPN and both listeners served HTTP/1.1 only, so gRPC clients (grpc-go >=1.67 enforces ALPN) failed the TLS handshake with "missing selected ALPN property", the upstream transport never negotiated h2, and response trailers were dropped so a gRPC status never reached the client.

This adds HTTP/2 to MITM mode:

- Enable HTTP/2 on both MITM listeners via `http2.ConfigureServer`, so h2-negotiated connections run through the existing handler. The CONNECT-tunnel leaf also sets `h2` in its ALPN explicitly, since it terminates TLS itself rather than through the `http.Server` `ConfigureServer` configures.
- Set `ForceAttemptHTTP2` on the upstream transport: h2 when the upstream offers it, HTTP/1.1 fallback otherwise.
- Forward upstream response trailers via `http.TrailerPrefix` (where gRPC carries `grpc-status`), as `net/http/httputil`'s `ReverseProxy` does.

`net/http` presents HTTP/1.1 and HTTP/2 as the same `http.Request`, so the transform pipeline (allowlist, secrets, header allowlist) is unchanged.

Tests: `TestIntegration_CONNECT_HTTP2` and `TestIntegration_DirectHTTPS_HTTP2` exercise both MITM listeners — ALPN `h2` on both hops plus trailer propagation.