### PR TITLE
feat: add bounded response retry handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,21 @@ through the proxy. Exceptions:
   `*.internal.corp`). Traffic to these hosts bypasses the proxy entirely.
 - **`records`:** static A or CNAME records. Highest precedence.
 
+### Response retry handler
+
+Set `IRON_RESPONSE_RETRY_HANDLER_URL` and a comma-separated
+`IRON_RESPONSE_RETRY_STATUSES` list to let a trusted external service decide
+whether selected upstream responses should be retried. The handler receives
+request metadata, the response status, and response headers, then either
+declines or returns request headers for one exact replay. Response bodies are
+never sent to the handler, destinations cannot change, and connection/framing
+headers are rejected.
+
+The request uses the proxy bearer token by default. Set
+`IRON_RESPONSE_RETRY_HANDLER_TOKEN` only when the handler uses a separate
+token. Replay requires a positive `proxy.max_request_body_bytes` limit. The
+handler URL must use HTTPS; loopback HTTP is accepted for local tests.
+
 ### Allowlist
 
 Default-deny. Requests must match at least one domain glob or CIDR to proceed.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -9,8 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -26,6 +29,7 @@ import (
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/proxy"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/version"
 
@@ -211,6 +215,28 @@ func main() {
 		)
 	}
 
+	var responseRetryHandler *responseretry.Handler
+	if handlerURL := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_URL"); handlerURL != "" {
+		handlerToken := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_TOKEN")
+		if handlerToken == "" {
+			handlerToken = proxyToken
+		}
+		statuses, parseErr := parseResponseRetryStatuses(os.Getenv("IRON_RESPONSE_RETRY_STATUSES"))
+		if parseErr != nil {
+			logger.Error("parsing response retry statuses", slog.String("error", parseErr.Error()))
+			os.Exit(1)
+		}
+		responseRetryHandler, err = responseretry.New(handlerURL, handlerToken, statuses, &http.Client{
+			Transport: &http.Transport{},
+			Timeout:   time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
+		})
+		if err != nil {
+			logger.Error("initializing response retry handler", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+		logger.Info("response retry handler enabled", slog.Any("statuses", statuses))
+	}
+
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
@@ -223,6 +249,7 @@ func main() {
 		Guard:                         guard,
 		MCPPolicy:                     mcpHolder,
 		MCPGateway:                    gatewayHolder,
+		ResponseRetryHandler:          responseRetryHandler,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 		UpstreamProxy:                 cfg.Proxy.UpstreamProxy.ProxyFunc(),
@@ -714,4 +741,20 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func parseResponseRetryStatuses(value string) ([]int, error) {
+	var statuses []int
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		status, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid status %q", part)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
 }

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +20,58 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
+
+func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testing.T) {
+	const body = "same request body"
+	calls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		gotBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, string(gotBody))
+		if r.Header.Get("X-Retry-Token") == "retry-token" {
+			_, err := w.Write([]byte("paid"))
+			require.NoError(t, err)
+			return
+		}
+		w.Header().Set("X-Retry-Challenge", "challenge")
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer upstream.Close()
+
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"X-Retry-Token":"retry-token"}}`))
+		require.NoError(t, err)
+	}))
+	defer authorizer.Close()
+	handler, err := responseretry.New(authorizer.URL, "proxy-token", []int{http.StatusConflict}, authorizer.Client())
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
+		MaxRequestBodyBytes:  1 << 20,
+		MaxResponseBodyBytes: 1 << 20,
+	}, logger)
+	p := New(Options{
+		Pipeline:   transform.NewPipelineHolder(pipeline),
+		Logger:     logger,
+		ResponseRetryHandler: handler,
+	})
+	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "paid", recorder.Body.String())
+	require.Equal(t, 2, calls)
+}
 
 // integrationCA bundles the test CA certificate, cert cache, and trust pool.
 type integrationCA struct {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -24,6 +25,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/mcpgateway"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"golang.org/x/net/http2"
 )
@@ -48,6 +50,7 @@ type Proxy struct {
 	guard          *dnsguard.Guard
 	mcpPolicy      *mcp.PolicyHolder
 	mcpGateway     *mcpgateway.Holder
+	responseRetryHandler *responseretry.Handler
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -76,6 +79,9 @@ type Options struct {
 	Guard      *dnsguard.Guard   // nil is treated as an empty (no-op) guard
 	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
 	MCPGateway *mcpgateway.Holder
+	// ResponseRetryHandler may add headers and replay the exact transformed
+	// request once after selected upstream response statuses.
+	ResponseRetryHandler *responseretry.Handler
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -117,6 +123,7 @@ func New(opts Options) *Proxy {
 		guard:          guard,
 		mcpPolicy:      opts.MCPPolicy,
 		mcpGateway:     opts.MCPGateway,
+		responseRetryHandler: opts.ResponseRetryHandler,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -495,6 +502,27 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		upstreamReq.ContentLength = r.ContentLength
 	}
 
+	var replayBody []byte
+	if p.responseRetryHandler != nil {
+		if bodyLimits.MaxRequestBodyBytes <= 0 {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusBadGateway
+			result.Err = fmt.Errorf("response retry requires a positive request body limit")
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		replayBody, err = io.ReadAll(io.LimitReader(upstreamReq.Body, bodyLimits.MaxRequestBodyBytes+1))
+		if err != nil || int64(len(replayBody)) > bodyLimits.MaxRequestBodyBytes {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusRequestEntityTooLarge
+			result.Err = fmt.Errorf("request body exceeds response retry limit")
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		upstreamReq.Body = io.NopCloser(bytes.NewReader(replayBody))
+		upstreamReq.ContentLength = int64(len(replayBody))
+	}
+
 	resp, err := p.doUpstream(upstreamReq)
 	if err != nil {
 		if markIfClientCancel(r, err, result) {
@@ -507,6 +535,42 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 	defer resp.Body.Close()
+
+	if p.responseRetryHandler != nil {
+		retryHeaders, replay, retryErr := p.responseRetryHandler.Decide(r.Context(), upstreamReq, resp)
+		if retryErr != nil {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusBadGateway
+			result.Err = retryErr
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		if replay {
+			_ = resp.Body.Close() // The 402 body is never returned after authorization.
+			replayReq := upstreamReq.Clone(r.Context())
+			replayReq.Body = io.NopCloser(bytes.NewReader(replayBody))
+			replayReq.ContentLength = int64(len(replayBody))
+			replayReq.Header = upstreamReq.Header.Clone()
+			for name, values := range retryHeaders {
+				replayReq.Header.Del(name)
+				for _, value := range values {
+					replayReq.Header.Add(name, value)
+				}
+			}
+			resp, err = p.doUpstream(replayReq)
+			if err != nil {
+				if markIfClientCancel(r, err, result) {
+					return
+				}
+				result.Action = transform.ActionContinue
+				result.StatusCode = http.StatusBadGateway
+				result.Err = err
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+		}
+	}
 
 	// Wrap response body for lazy buffering by transforms.
 	resp.Body = transform.NewBufferedBody(resp.Body, bodyLimits.MaxResponseBodyBytes)

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -1,0 +1,133 @@
+// Package responseretry implements a protocol-neutral, externally decided
+// response retry hook.
+package responseretry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+var forbiddenRetryHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Content-Length":      {},
+	"Host":                {},
+	"Proxy-Authorization": {},
+	"Transfer-Encoding":   {},
+}
+
+// Handler asks a trusted service whether a bounded upstream response should
+// be retried and which request headers to add. It does not interpret response
+// protocols or credentials.
+type Handler struct {
+	endpoint *url.URL
+	token    string
+	statuses map[int]struct{}
+	client   *http.Client
+}
+
+// DecisionRequest describes the completed request and response. Response
+// bodies are deliberately excluded.
+type DecisionRequest struct {
+	Host            string              `json:"host"`
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	Status          int                 `json:"status"`
+	ResponseHeaders map[string][]string `json:"response_headers"`
+}
+
+// DecisionResponse authorizes at most one replay with additional headers.
+type DecisionResponse struct {
+	Retry   bool              `json:"retry"`
+	Headers map[string]string `json:"headers"`
+}
+
+// New creates a Handler for the configured response status codes.
+func New(endpoint, token string, statuses []int, client *http.Client) (*Handler, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return nil, fmt.Errorf("response retry handler URL must be absolute")
+	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopback(u.Hostname())) {
+		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless it is loopback")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("response retry handler token is required")
+	}
+	statusSet := make(map[int]struct{}, len(statuses))
+	for _, status := range statuses {
+		if status < 100 || status > 599 {
+			return nil, fmt.Errorf("invalid response retry status %s", strconv.Itoa(status))
+		}
+		statusSet[status] = struct{}{}
+	}
+	if len(statusSet) == 0 {
+		return nil, fmt.Errorf("at least one response retry status is required")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Handler{endpoint: u, token: token, statuses: statusSet, client: client}, nil
+}
+
+// Decide returns request headers for one replay. retry is false when the
+// response status is outside the configured set or the handler declines.
+func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Response) (headers http.Header, retry bool, err error) {
+	if _, ok := h.statuses[resp.StatusCode]; !ok {
+		return nil, false, nil
+	}
+	payload, err := json.Marshal(DecisionRequest{
+		Host:            req.URL.Host,
+		Method:          req.Method,
+		Path:            req.URL.EscapedPath(),
+		Status:          resp.StatusCode,
+		ResponseHeaders: resp.Header,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("encode response retry decision request: %w", err)
+	}
+	decisionReq, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, false, fmt.Errorf("create response retry decision request: %w", err)
+	}
+	decisionReq.Header.Set("Authorization", "Bearer "+h.token)
+	decisionReq.Header.Set("Content-Type", "application/json")
+	decisionResp, err := h.client.Do(decisionReq)
+	if err != nil {
+		return nil, false, fmt.Errorf("request response retry decision: %w", err)
+	}
+	defer decisionResp.Body.Close()
+	if decisionResp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(decisionResp.Body, 64<<10))
+		return nil, false, fmt.Errorf("response retry handler rejected request with status %d", decisionResp.StatusCode)
+	}
+	var decision DecisionResponse
+	if err := json.NewDecoder(io.LimitReader(decisionResp.Body, 64<<10)).Decode(&decision); err != nil {
+		return nil, false, fmt.Errorf("decode response retry decision: %w", err)
+	}
+	if !decision.Retry {
+		return nil, false, nil
+	}
+	headers = make(http.Header, len(decision.Headers))
+	for name, value := range decision.Headers {
+		canonical := http.CanonicalHeaderKey(name)
+		if canonical == "" {
+			return nil, false, fmt.Errorf("response retry handler returned an invalid header name")
+		}
+		if _, forbidden := forbiddenRetryHeaders[canonical]; forbidden {
+			return nil, false, fmt.Errorf("response retry handler returned forbidden header %s", canonical)
+		}
+		headers.Set(canonical, value)
+	}
+	return headers, true, nil
+}
+
+func isLoopback(host string) bool {
+	return host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1"
+}

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -1,0 +1,60 @@
+package responseretry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerDecide(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"Authorization":"credential"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "https://service.example/v1/search", nil)
+	require.NoError(t, err)
+	resp := &http.Response{StatusCode: 409, Header: http.Header{"Www-Authenticate": {"challenge"}}}
+
+	headers, retry, err := handler.Decide(context.Background(), req, resp)
+
+	require.NoError(t, err)
+	require.True(t, retry)
+	require.Equal(t, "credential", headers.Get("Authorization"))
+}
+
+func TestHandlerSkipsUnconfiguredStatus(t *testing.T) {
+	handler, err := New("http://127.0.0.1/decide", "proxy-token", []int{409}, nil)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	headers, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: 429})
+
+	require.NoError(t, err)
+	require.False(t, retry)
+	require.Nil(t, headers)
+}
+
+func TestHandlerRejectsForbiddenReplayHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"Host":"other.example"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: 409})
+
+	require.ErrorContains(t, err, "forbidden header Host")
+}


### PR DESCRIPTION
## Summary

- Add a protocol-neutral external response-retry decision hook.
- Call the handler only for configured response statuses and authenticate with the existing proxy identity.
- Replay the exact bounded post-transform request at most once with narrowly validated additional headers.
- Keep response bodies, destination changes, connection headers, protocol parsing, signing, and policy outside iron-proxy.

## Validation

- `git diff --check`
- Go tooling is unavailable in the current sandbox, so `go test ./...` remains for CI.

Prompted by: @gakonst