### PR TITLE
feat: add authenticated response retry handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
           OP_CONNECT_CREDENTIALS_JSON: ${{ secrets.OP_CONNECT_CREDENTIALS_JSON }}
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
         run: |
+          if [ -z "$OP_CONNECT_CREDENTIALS_JSON" ] || [ -z "$OP_CONNECT_TOKEN" ]; then
+            echo "Skipping 1Password Connect setup: credentials are unavailable"
+            exit 0
+          fi
           printf '%s' "$OP_CONNECT_CREDENTIALS_JSON" > 1password-credentials.json
           docker compose up -d
           # Wait for connect-sync to populate the shared data volume so the

--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ retries. The authorization handler receives the exact authority, method,
 path/query, replayability, response status and headers, trace context, and
 sandbox identity. It may return request headers plus an attempt ID for one
 exact replay. The completion handler then receives the replay status and
-receipt header.
+response headers selected by `IRON_RESPONSE_RETRY_COMPLETION_HEADERS`, which
+defaults to `Payment-Receipt`.
 
 Response bodies are never sent to either handler, destinations cannot change,
 and connection/framing headers are rejected. Requests over
@@ -298,7 +299,8 @@ and connection/framing headers are rejected. Requests over
 if challenged, their original response is returned. Handler failures also
 preserve the original response. Handler URLs must use HTTPS unless loopback or
 `IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP=true` is explicitly configured for a
-trusted internal network.
+trusted internal network. Redirects are rejected, and the response retry token
+must be configured independently from the control-plane token.
 
 ### Allowlist
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ if challenged, their original response is returned. Handler failures also
 preserve the original response. Handler URLs must use HTTPS unless loopback or
 `IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP=true` is explicitly configured for a
 trusted internal network. Redirects are rejected, and the response retry token
-must be configured independently from the control-plane token.
+must be configured independently from the control-plane token. WebSocket,
+gRPC, and unknown-length streaming requests bypass response retry handling.
 
 ### Allowlist
 

--- a/README.md
+++ b/README.md
@@ -282,18 +282,23 @@ through the proxy. Exceptions:
 
 ### Response retry handler
 
-Set `IRON_RESPONSE_RETRY_HANDLER_URL` and a comma-separated
-`IRON_RESPONSE_RETRY_STATUSES` list to let a trusted external service decide
-whether selected upstream responses should be retried. The handler receives
-request metadata, the response status, and response headers, then either
-declines or returns request headers for one exact replay. Response bodies are
-never sent to the handler, destinations cannot change, and connection/framing
-headers are rejected.
+Set `IRON_RESPONSE_RETRY_HANDLER_URL`,
+`IRON_RESPONSE_RETRY_COMPLETE_URL`, `IRON_RESPONSE_RETRY_HANDLER_TOKEN`,
+`IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID`, and a comma-separated
+`IRON_RESPONSE_RETRY_STATUSES` list to enable externally authorized response
+retries. The authorization handler receives the exact authority, method,
+path/query, replayability, response status and headers, trace context, and
+sandbox identity. It may return request headers plus an attempt ID for one
+exact replay. The completion handler then receives the replay status and
+receipt header.
 
-The request uses the proxy bearer token by default. Set
-`IRON_RESPONSE_RETRY_HANDLER_TOKEN` only when the handler uses a separate
-token. Replay requires a positive `proxy.max_request_body_bytes` limit. The
-handler URL must use HTTPS; loopback HTTP is accepted for local tests.
+Response bodies are never sent to either handler, destinations cannot change,
+and connection/framing headers are rejected. Requests over
+`proxy.max_request_body_bytes` proceed normally but are marked non-replayable;
+if challenged, their original response is returned. Handler failures also
+preserve the original response. Handler URLs must use HTTPS unless loopback or
+`IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP=true` is explicitly configured for a
+trusted internal network.
 
 ### Allowlist
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,21 @@ through the proxy. Exceptions:
   `*.internal.corp`). Traffic to these hosts bypasses the proxy entirely.
 - **`records`:** static A or CNAME records. Highest precedence.
 
+### Response retry handler
+
+Set `IRON_RESPONSE_RETRY_HANDLER_URL` and a comma-separated
+`IRON_RESPONSE_RETRY_STATUSES` list to let a trusted external service decide
+whether selected upstream responses should be retried. The handler receives
+request metadata, the response status, and response headers, then either
+declines or returns request headers for one exact replay. Response bodies are
+never sent to the handler, destinations cannot change, and connection/framing
+headers are rejected.
+
+The request uses the proxy bearer token by default. Set
+`IRON_RESPONSE_RETRY_HANDLER_TOKEN` only when the handler uses a separate
+token. Replay requires a positive `proxy.max_request_body_bytes` limit. The
+handler URL must use HTTPS; loopback HTTP is accepted for local tests.
+
 ### Allowlist
 
 Default-deny. Requests must match at least one domain glob or CIDR to proceed.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -9,8 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -26,6 +29,7 @@ import (
 	iotel "github.com/ironsh/iron-proxy/internal/otel"
 	"github.com/ironsh/iron-proxy/internal/postgres"
 	"github.com/ironsh/iron-proxy/internal/proxy"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/version"
 
@@ -211,6 +215,28 @@ func main() {
 		)
 	}
 
+	var responseRetryHandler *responseretry.Handler
+	if handlerURL := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_URL"); handlerURL != "" {
+		handlerToken := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_TOKEN")
+		if handlerToken == "" {
+			handlerToken = proxyToken
+		}
+		statuses, parseErr := parseResponseRetryStatuses(os.Getenv("IRON_RESPONSE_RETRY_STATUSES"))
+		if parseErr != nil {
+			logger.Error("parsing response retry statuses", slog.String("error", parseErr.Error()))
+			os.Exit(1)
+		}
+		responseRetryHandler, err = responseretry.New(handlerURL, handlerToken, statuses, &http.Client{
+			Transport: &http.Transport{},
+			Timeout:   time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
+		})
+		if err != nil {
+			logger.Error("initializing response retry handler", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+		logger.Info("response retry handler enabled", slog.Any("statuses", statuses))
+	}
+
 	// Initialize proxy.
 	p := proxy.New(proxy.Options{
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
@@ -223,6 +249,7 @@ func main() {
 		Guard:                         guard,
 		MCPPolicy:                     mcpHolder,
 		MCPGateway:                    gatewayHolder,
+		ResponseRetryHandler:          responseRetryHandler,
 		Logger:                        logger,
 		UpstreamResponseHeaderTimeout: time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 		UpstreamProxy:                 cfg.Proxy.UpstreamProxy.ProxyFunc(),
@@ -714,4 +741,20 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func parseResponseRetryStatuses(value string) ([]int, error) {
+	var statuses []int
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		status, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid status %q", part)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
 }

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -215,37 +215,16 @@ func main() {
 		)
 	}
 
-	var responseRetryHandler *responseretry.Handler
-	if handlerURL := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_URL"); handlerURL != "" {
-		completeURL := os.Getenv("IRON_RESPONSE_RETRY_COMPLETE_URL")
-		sandboxID := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID")
-		handlerToken := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_TOKEN")
-		if handlerToken == "" {
-			handlerToken = proxyToken
-		}
-		allowHTTPValue := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP")
-		if allowHTTPValue == "" {
-			allowHTTPValue = "false"
-		}
-		allowHTTP, parseErr := strconv.ParseBool(allowHTTPValue)
-		if parseErr != nil {
-			logger.Error("parsing response retry HTTP allowance", slog.String("error", parseErr.Error()))
-			os.Exit(1)
-		}
-		statuses, parseErr := parseResponseRetryStatuses(os.Getenv("IRON_RESPONSE_RETRY_STATUSES"))
-		if parseErr != nil {
-			logger.Error("parsing response retry statuses", slog.String("error", parseErr.Error()))
-			os.Exit(1)
-		}
-		responseRetryHandler, err = responseretry.New(handlerURL, completeURL, handlerToken, sandboxID, statuses, allowHTTP, &http.Client{
-			Transport: &http.Transport{},
-			Timeout:   time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
-		})
-		if err != nil {
-			logger.Error("initializing response retry handler", slog.String("error", err.Error()))
-			os.Exit(1)
-		}
-		logger.Info("response retry handler enabled", slog.Any("statuses", statuses))
+	responseRetryHandler, responseRetryStatuses, err := responseRetryHandlerFromEnv(
+		os.Getenv,
+		time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
+	)
+	if err != nil {
+		logger.Error("initializing response retry handler", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if responseRetryHandler != nil {
+		logger.Info("response retry handler enabled", slog.Any("statuses", responseRetryStatuses))
 	}
 
 	// Initialize proxy.
@@ -756,11 +735,7 @@ func envOrDefault(key, def string) string {
 
 func parseResponseRetryStatuses(value string) ([]int, error) {
 	var statuses []int
-	for _, part := range strings.Split(value, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
+	for _, part := range splitCommaSeparated(value) {
 		status, err := strconv.Atoi(part)
 		if err != nil {
 			return nil, fmt.Errorf("invalid status %q", part)
@@ -768,4 +743,54 @@ func parseResponseRetryStatuses(value string) ([]int, error) {
 		statuses = append(statuses, status)
 	}
 	return statuses, nil
+}
+
+func responseRetryHandlerFromEnv(getenv func(string) string, timeout time.Duration) (*responseretry.Handler, []int, error) {
+	handlerURL := getenv("IRON_RESPONSE_RETRY_HANDLER_URL")
+	if handlerURL == "" {
+		return nil, nil, nil
+	}
+	allowHTTPValue := getenv("IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP")
+	if allowHTTPValue == "" {
+		allowHTTPValue = "false"
+	}
+	allowHTTP, err := strconv.ParseBool(allowHTTPValue)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse HTTP allowance: %w", err)
+	}
+	statuses, err := parseResponseRetryStatuses(getenv("IRON_RESPONSE_RETRY_STATUSES"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse statuses: %w", err)
+	}
+	completionHeaders := getenv("IRON_RESPONSE_RETRY_COMPLETION_HEADERS")
+	if completionHeaders == "" {
+		completionHeaders = "Payment-Receipt"
+	}
+	handler, err := responseretry.New(responseretry.Options{
+		AuthorizeEndpoint: handlerURL,
+		CompleteEndpoint:  getenv("IRON_RESPONSE_RETRY_COMPLETE_URL"),
+		Token:             getenv("IRON_RESPONSE_RETRY_HANDLER_TOKEN"),
+		SandboxID:         getenv("IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID"),
+		Statuses:          statuses,
+		AllowHTTP:         allowHTTP,
+		CompletionHeaders: splitCommaSeparated(completionHeaders),
+		Client: &http.Client{
+			Transport: &http.Transport{},
+			Timeout:   timeout,
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return handler, statuses, nil
+}
+
+func splitCommaSeparated(value string) []string {
+	var values []string
+	for _, part := range strings.Split(value, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
 }

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -217,16 +217,27 @@ func main() {
 
 	var responseRetryHandler *responseretry.Handler
 	if handlerURL := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_URL"); handlerURL != "" {
+		completeURL := os.Getenv("IRON_RESPONSE_RETRY_COMPLETE_URL")
+		sandboxID := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID")
 		handlerToken := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_TOKEN")
 		if handlerToken == "" {
 			handlerToken = proxyToken
+		}
+		allowHTTPValue := os.Getenv("IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP")
+		if allowHTTPValue == "" {
+			allowHTTPValue = "false"
+		}
+		allowHTTP, parseErr := strconv.ParseBool(allowHTTPValue)
+		if parseErr != nil {
+			logger.Error("parsing response retry HTTP allowance", slog.String("error", parseErr.Error()))
+			os.Exit(1)
 		}
 		statuses, parseErr := parseResponseRetryStatuses(os.Getenv("IRON_RESPONSE_RETRY_STATUSES"))
 		if parseErr != nil {
 			logger.Error("parsing response retry statuses", slog.String("error", parseErr.Error()))
 			os.Exit(1)
 		}
-		responseRetryHandler, err = responseretry.New(handlerURL, handlerToken, statuses, &http.Client{
+		responseRetryHandler, err = responseretry.New(handlerURL, completeURL, handlerToken, sandboxID, statuses, allowHTTP, &http.Client{
 			Transport: &http.Transport{},
 			Timeout:   time.Duration(cfg.Proxy.UpstreamResponseHeaderTimeout),
 		})

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -30,6 +31,76 @@ func mapEnv(m map[string]string) func(string) string {
 
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestParseResponseRetryStatuses(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		want    []int
+		wantErr string
+	}{
+		{name: "multiple", value: "402, 409", want: []int{402, 409}},
+		{name: "empty entries", value: " ,402,, ", want: []int{402}},
+		{name: "empty", value: "", want: nil},
+		{name: "invalid", value: "402,nope", wantErr: `invalid status "nope"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseResponseRetryStatuses(tc.value)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSplitCommaSeparated(t *testing.T) {
+	require.Equal(t, []string{"Payment-Receipt", "X-Receipt"}, splitCommaSeparated(" Payment-Receipt, ,X-Receipt "))
+}
+
+func TestResponseRetryHandlerFromEnv(t *testing.T) {
+	base := map[string]string{
+		"IRON_RESPONSE_RETRY_HANDLER_URL":        "http://127.0.0.1/authorize",
+		"IRON_RESPONSE_RETRY_COMPLETE_URL":       "http://127.0.0.1/complete",
+		"IRON_RESPONSE_RETRY_HANDLER_TOKEN":      "handler-token",
+		"IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID": "sandbox-1",
+		"IRON_RESPONSE_RETRY_STATUSES":           "402,409",
+		"IRON_RESPONSE_RETRY_COMPLETION_HEADERS": "X-Receipt",
+	}
+
+	handler, statuses, err := responseRetryHandlerFromEnv(mapEnv(base), time.Second)
+
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	require.Equal(t, []int{402, 409}, statuses)
+}
+
+func TestResponseRetryHandlerFromEnvDisabled(t *testing.T) {
+	handler, statuses, err := responseRetryHandlerFromEnv(mapEnv(nil), time.Second)
+
+	require.NoError(t, err)
+	require.Nil(t, handler)
+	require.Nil(t, statuses)
+}
+
+func TestResponseRetryHandlerFromEnvRequiresDedicatedToken(t *testing.T) {
+	env := map[string]string{
+		"IRON_RESPONSE_RETRY_HANDLER_URL":        "http://127.0.0.1/authorize",
+		"IRON_RESPONSE_RETRY_COMPLETE_URL":       "http://127.0.0.1/complete",
+		"IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID": "sandbox-1",
+		"IRON_RESPONSE_RETRY_STATUSES":           "402",
+		"IRON_PROXY_TOKEN":                       "control-plane-token",
+	}
+
+	handler, _, err := responseRetryHandlerFromEnv(mapEnv(env), time.Second)
+
+	require.Nil(t, handler)
+	require.ErrorContains(t, err, "handler token is required")
 }
 
 // localListener builds a single-upstream local listener (with its own shared

--- a/integration_test/aws_sm_test.go
+++ b/integration_test/aws_sm_test.go
@@ -10,6 +10,9 @@ import (
 // TestAWSSecretsManager boots the proxy with real AWS Secrets Manager secrets
 // and verifies that proxy tokens in request headers are swapped for real values.
 func TestAWSSecretsManager(t *testing.T) {
+	requireEnv(t, "AWS_ACCESS_KEY_ID")
+	requireEnv(t, "AWS_SECRET_ACCESS_KEY")
+
 	cases := []struct {
 		name, header, sent, want string
 	}{

--- a/integration_test/aws_ssm_test.go
+++ b/integration_test/aws_ssm_test.go
@@ -10,6 +10,9 @@ import (
 // TestAWSSystemsManagerParameterStore boots the proxy with real AWS SSM
 // Parameter Store parameters and verifies proxy token replacement.
 func TestAWSSystemsManagerParameterStore(t *testing.T) {
+	requireEnv(t, "AWS_ACCESS_KEY_ID")
+	requireEnv(t, "AWS_SECRET_ACCESS_KEY")
+
 	cases := []struct {
 		name, header, sent, want string
 	}{

--- a/integration_test/onepassword_connect_test.go
+++ b/integration_test/onepassword_connect_test.go
@@ -11,6 +11,8 @@ import (
 // server and verifies that proxy tokens in request headers are swapped for the
 // resolved value. Reuses the same vault and item as TestOnePassword.
 func TestOnePasswordConnect(t *testing.T) {
+	requireEnv(t, "OP_CONNECT_TOKEN")
+
 	upstreamHost := echoHeadersUpstream(t, "X-OP-Connect-Secret")
 
 	cfgPath := renderConfig(t, t.TempDir(), "onepassword_connect.yaml", nil)

--- a/integration_test/onepassword_test.go
+++ b/integration_test/onepassword_test.go
@@ -10,6 +10,8 @@ import (
 // TestOnePassword boots the proxy with a real 1Password secret and verifies
 // that proxy tokens in request headers are swapped for the resolved value.
 func TestOnePassword(t *testing.T) {
+	requireEnv(t, "OP_SERVICE_ACCOUNT_TOKEN")
+
 	upstreamHost := echoHeadersUpstream(t, "X-OP-Secret")
 
 	cfgPath := renderConfig(t, t.TempDir(), "onepassword.yaml", nil)

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -150,6 +150,59 @@ func TestIntegration_ResponseHandlerReturnsOriginalChallengeForOversizedRequest(
 	require.Equal(t, 1, authorizeCalls)
 }
 
+func TestIntegration_ResponseHandlerBypassesStreamingRequests(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		unknownSize bool
+	}{
+		{name: "gRPC", contentType: "application/grpc+proto"},
+		{name: "unknown length", contentType: "application/octet-stream", unknownSize: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const body = "streamed request body"
+			upstreamCalls := 0
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamCalls++
+				gotBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				require.Equal(t, body, string(gotBody))
+				w.WriteHeader(http.StatusPaymentRequired)
+				_, err = io.WriteString(w, "original challenge")
+				require.NoError(t, err)
+			}))
+			defer upstream.Close()
+
+			authorizeCalls := 0
+			authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				authorizeCalls++
+				http.Error(w, "unexpected", http.StatusInternalServerError)
+			}))
+			defer authorizer.Close()
+			p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 1<<20)
+			var requestBody io.Reader = strings.NewReader(body)
+			if tc.unknownSize {
+				requestBody = struct{ io.Reader }{Reader: requestBody}
+			}
+			req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", requestBody)
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.unknownSize {
+				require.Equal(t, int64(-1), req.ContentLength)
+			}
+			recorder := httptest.NewRecorder()
+
+			p.handleDirectHTTP(recorder, req)
+
+			require.Equal(t, http.StatusPaymentRequired, recorder.Code)
+			require.Equal(t, "original challenge", recorder.Body.String())
+			require.Equal(t, 1, upstreamCalls)
+			require.Zero(t, authorizeCalls)
+		})
+	}
+}
+
 func TestIntegration_ResponseHandlerFailureReturnsOriginalChallenge(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusPaymentRequired)

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testing.T) {
 	const body = "same request body"
+	const chargeTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 	calls := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -35,6 +36,7 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 		require.NoError(t, err)
 		require.Equal(t, body, string(gotBody))
 		if r.Header.Get("X-Retry-Token") == "retry-token" {
+			require.Equal(t, chargeTraceparent, r.Header.Get("Traceparent"))
 			_, err := w.Write([]byte("paid"))
 			require.NoError(t, err)
 			return
@@ -49,11 +51,14 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
 		if r.URL.Path == "/complete" {
 			completions++
+			var payload responseretry.CompletionRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+			require.Equal(t, chargeTraceparent, payload.Traceparent)
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","headers":{"X-Retry-Token":"retry-token"}}`))
+		_, err := fmt.Fprintf(w, `{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","traceparent":%q,"headers":{"X-Retry-Token":"retry-token"}}`, chargeTraceparent)
 		require.NoError(t, err)
 	}))
 	defer authorizer.Close()

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -43,14 +44,28 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 	}))
 	defer upstream.Close()
 
+	completions := 0
 	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		if r.URL.Path == "/complete" {
+			completions++
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"retry":true,"headers":{"X-Retry-Token":"retry-token"}}`))
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","headers":{"X-Retry-Token":"retry-token"}}`))
 		require.NoError(t, err)
 	}))
 	defer authorizer.Close()
-	handler, err := responseretry.New(authorizer.URL, "proxy-token", []int{http.StatusConflict}, authorizer.Client())
+	handler, err := responseretry.New(
+		authorizer.URL+"/authorize",
+		authorizer.URL+"/complete",
+		"proxy-token",
+		"sandbox-1",
+		[]int{http.StatusConflict},
+		false,
+		authorizer.Client(),
+	)
 	require.NoError(t, err)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -59,8 +74,8 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 		MaxResponseBodyBytes: 1 << 20,
 	}, logger)
 	p := New(Options{
-		Pipeline:   transform.NewPipelineHolder(pipeline),
-		Logger:     logger,
+		Pipeline:             transform.NewPipelineHolder(pipeline),
+		Logger:               logger,
 		ResponseRetryHandler: handler,
 	})
 	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
@@ -71,6 +86,102 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, "paid", recorder.Body.String())
 	require.Equal(t, 2, calls)
+	require.Equal(t, 1, completions)
+}
+
+func TestIntegration_ResponseHandlerReturnsOriginalChallengeForOversizedRequest(t *testing.T) {
+	const body = "request is larger than the replay limit"
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		gotBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, string(gotBody))
+		w.Header().Set("Www-Authenticate", "Payment challenge")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte("original challenge"))
+	}))
+	defer upstream.Close()
+
+	authorizeCalls := 0
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizeCalls++
+		var payload responseretry.DecisionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		require.False(t, payload.Replayable)
+		_, _ = w.Write([]byte(`{"retry":false,"headers":{}}`))
+	}))
+	defer authorizer.Close()
+	handler, err := responseretry.New(
+		authorizer.URL,
+		authorizer.URL,
+		"proxy-token",
+		"sandbox-1",
+		[]int{http.StatusPaymentRequired},
+		false,
+		authorizer.Client(),
+	)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
+		MaxRequestBodyBytes:  8,
+		MaxResponseBodyBytes: 1 << 20,
+	}, logger)
+	p := New(Options{
+		Pipeline:             transform.NewPipelineHolder(pipeline),
+		Logger:               logger,
+		ResponseRetryHandler: handler,
+	})
+	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusPaymentRequired, recorder.Code)
+	require.Equal(t, "original challenge", recorder.Body.String())
+	require.Equal(t, 1, upstreamCalls)
+	require.Equal(t, 1, authorizeCalls)
+}
+
+func TestIntegration_ResponseHandlerFailureReturnsOriginalChallenge(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte("original challenge"))
+	}))
+	defer upstream.Close()
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer authorizer.Close()
+	handler, err := responseretry.New(
+		authorizer.URL,
+		authorizer.URL,
+		"proxy-token",
+		"sandbox-1",
+		[]int{http.StatusPaymentRequired},
+		false,
+		authorizer.Client(),
+	)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
+		MaxRequestBodyBytes:  1 << 20,
+		MaxResponseBodyBytes: 1 << 20,
+	}, logger)
+	p := New(Options{
+		Pipeline:             transform.NewPipelineHolder(pipeline),
+		Logger:               logger,
+		ResponseRetryHandler: handler,
+	})
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/paid", nil)
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusPaymentRequired, recorder.Code)
+	require.Equal(t, "original challenge", recorder.Body.String())
 }
 
 // integrationCA bundles the test CA certificate, cert cache, and trust pool.

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +20,58 @@ import (
 	"golang.org/x/net/http2"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
+
+func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testing.T) {
+	const body = "same request body"
+	calls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		gotBody, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, body, string(gotBody))
+		if r.Header.Get("X-Retry-Token") == "retry-token" {
+			_, err := w.Write([]byte("paid"))
+			require.NoError(t, err)
+			return
+		}
+		w.Header().Set("X-Retry-Challenge", "challenge")
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer upstream.Close()
+
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"X-Retry-Token":"retry-token"}}`))
+		require.NoError(t, err)
+	}))
+	defer authorizer.Close()
+	handler, err := responseretry.New(authorizer.URL, "proxy-token", []int{http.StatusConflict}, authorizer.Client())
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
+		MaxRequestBodyBytes:  1 << 20,
+		MaxResponseBodyBytes: 1 << 20,
+	}, logger)
+	p := New(Options{
+		Pipeline:   transform.NewPipelineHolder(pipeline),
+		Logger:     logger,
+		ResponseRetryHandler: handler,
+	})
+	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "paid", recorder.Body.String())
+	require.Equal(t, 2, calls)
+}
 
 // integrationCA bundles the test CA certificate, cert cache, and trust pool.
 type integrationCA struct {

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -26,15 +26,47 @@ import (
 	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
 )
 
+func newResponseRetryTestProxy(
+	t *testing.T,
+	authorizer *httptest.Server,
+	status int,
+	transforms []transform.Transformer,
+	maxRequestBodyBytes int64,
+) *Proxy {
+	t.Helper()
+	handler, err := responseretry.New(responseretry.Options{
+		AuthorizeEndpoint: authorizer.URL + "/authorize",
+		CompleteEndpoint:  authorizer.URL + "/complete",
+		Token:             "proxy-token",
+		SandboxID:         "sandbox-1",
+		Statuses:          []int{status},
+		CompletionHeaders: []string{"Payment-Receipt"},
+		Client:            authorizer.Client(),
+	})
+	require.NoError(t, err)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{
+		MaxRequestBodyBytes:  maxRequestBodyBytes,
+		MaxResponseBodyBytes: 1 << 20,
+	}, logger)
+	return New(Options{
+		Pipeline:             transform.NewPipelineHolder(pipeline),
+		Logger:               logger,
+		ResponseRetryHandler: handler,
+	})
+}
+
 func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testing.T) {
-	const body = "same request body"
+	const originalBody = "original request body"
+	const transformedBody = "transformed request body"
 	const chargeTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
 	calls := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		gotBody, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, body, string(gotBody))
+		require.Equal(t, transformedBody, string(gotBody))
+		require.Equal(t, "transformed", r.Header.Get("X-Transformed"))
 		if r.Header.Get("X-Retry-Token") == "retry-token" {
 			require.Equal(t, chargeTraceparent, r.Header.Get("Traceparent"))
 			_, err := w.Write([]byte("paid"))
@@ -62,28 +94,17 @@ func TestIntegration_ResponseHandlerReplaysExactTransformedRequestOnce(t *testin
 		require.NoError(t, err)
 	}))
 	defer authorizer.Close()
-	handler, err := responseretry.New(
-		authorizer.URL+"/authorize",
-		authorizer.URL+"/complete",
-		"proxy-token",
-		"sandbox-1",
-		[]int{http.StatusConflict},
-		false,
-		authorizer.Client(),
+	p := newResponseRetryTestProxy(
+		t,
+		authorizer,
+		http.StatusConflict,
+		[]transform.Transformer{&replacerTransform{
+			reqBody:    []byte(transformedBody),
+			reqHeaders: http.Header{"X-Transformed": {"transformed"}},
+		}},
+		1<<20,
 	)
-	require.NoError(t, err)
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
-		MaxRequestBodyBytes:  1 << 20,
-		MaxResponseBodyBytes: 1 << 20,
-	}, logger)
-	p := New(Options{
-		Pipeline:             transform.NewPipelineHolder(pipeline),
-		Logger:               logger,
-		ResponseRetryHandler: handler,
-	})
-	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(originalBody))
 	recorder := httptest.NewRecorder()
 
 	p.handleDirectHTTP(recorder, req)
@@ -117,27 +138,7 @@ func TestIntegration_ResponseHandlerReturnsOriginalChallengeForOversizedRequest(
 		_, _ = w.Write([]byte(`{"retry":false,"headers":{}}`))
 	}))
 	defer authorizer.Close()
-	handler, err := responseretry.New(
-		authorizer.URL,
-		authorizer.URL,
-		"proxy-token",
-		"sandbox-1",
-		[]int{http.StatusPaymentRequired},
-		false,
-		authorizer.Client(),
-	)
-	require.NoError(t, err)
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
-		MaxRequestBodyBytes:  8,
-		MaxResponseBodyBytes: 1 << 20,
-	}, logger)
-	p := New(Options{
-		Pipeline:             transform.NewPipelineHolder(pipeline),
-		Logger:               logger,
-		ResponseRetryHandler: handler,
-	})
+	p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 8)
 	req := httptest.NewRequest(http.MethodPost, upstream.URL+"/paid", strings.NewReader(body))
 	recorder := httptest.NewRecorder()
 
@@ -159,27 +160,7 @@ func TestIntegration_ResponseHandlerFailureReturnsOriginalChallenge(t *testing.T
 		http.Error(w, "unavailable", http.StatusServiceUnavailable)
 	}))
 	defer authorizer.Close()
-	handler, err := responseretry.New(
-		authorizer.URL,
-		authorizer.URL,
-		"proxy-token",
-		"sandbox-1",
-		[]int{http.StatusPaymentRequired},
-		false,
-		authorizer.Client(),
-	)
-	require.NoError(t, err)
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	pipeline := transform.NewPipeline(nil, transform.BodyLimits{
-		MaxRequestBodyBytes:  1 << 20,
-		MaxResponseBodyBytes: 1 << 20,
-	}, logger)
-	p := New(Options{
-		Pipeline:             transform.NewPipelineHolder(pipeline),
-		Logger:               logger,
-		ResponseRetryHandler: handler,
-	})
+	p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 1<<20)
 	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/paid", nil)
 	recorder := httptest.NewRecorder()
 
@@ -187,6 +168,121 @@ func TestIntegration_ResponseHandlerFailureReturnsOriginalChallenge(t *testing.T
 
 	require.Equal(t, http.StatusPaymentRequired, recorder.Code)
 	require.Equal(t, "original challenge", recorder.Body.String())
+}
+
+func TestIntegration_ResponseHandlerNeverRetriesAReplay(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, err := fmt.Fprintf(w, "challenge %d", upstreamCalls)
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	authorizeCalls := 0
+	completionCalls := 0
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorize":
+			authorizeCalls++
+			_, err := io.WriteString(w, `{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","headers":{"X-Retry-Token":"retry-token"}}`)
+			require.NoError(t, err)
+		case "/complete":
+			completionCalls++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authorizer.Close()
+	p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 1<<20)
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/paid", nil)
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusPaymentRequired, recorder.Code)
+	require.Equal(t, "challenge 2", recorder.Body.String())
+	require.Equal(t, 2, upstreamCalls)
+	require.Equal(t, 1, authorizeCalls)
+	require.Equal(t, 1, completionCalls)
+}
+
+func TestIntegration_ResponseHandlerReportsReplayTransportFailure(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		if upstreamCalls == 1 {
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		conn, _, err := w.(http.Hijacker).Hijack()
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+	}))
+	defer upstream.Close()
+
+	completionCalls := 0
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/complete" {
+			completionCalls++
+			var payload responseretry.CompletionRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+			require.Nil(t, payload.ReplayStatus)
+			require.Equal(t, "upstream_transport_error", payload.TransportError)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, err := io.WriteString(w, `{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","headers":{"X-Retry-Token":"retry-token"}}`)
+		require.NoError(t, err)
+	}))
+	defer authorizer.Close()
+	p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 1<<20)
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/paid", nil)
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+	require.Equal(t, 2, upstreamCalls)
+	require.Equal(t, 1, completionCalls)
+}
+
+func TestIntegration_ResponseHandlerCompletionFailureDoesNotHideReplay(t *testing.T) {
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls++
+		if upstreamCalls == 1 {
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		_, err := io.WriteString(w, "paid")
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	completionCalls := 0
+	authorizer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/complete" {
+			completionCalls++
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_, err := io.WriteString(w, `{"retry":true,"attempt_id":"8ace71a1-4e12-47e5-9df4-f2f660db6a82","headers":{"X-Retry-Token":"retry-token"}}`)
+		require.NoError(t, err)
+	}))
+	defer authorizer.Close()
+	p := newResponseRetryTestProxy(t, authorizer, http.StatusPaymentRequired, nil, 1<<20)
+	req := httptest.NewRequest(http.MethodGet, upstream.URL+"/paid", nil)
+	recorder := httptest.NewRecorder()
+
+	p.handleDirectHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "paid", recorder.Body.String())
+	require.Equal(t, 2, upstreamCalls)
+	require.Equal(t, 2, completionCalls)
 }
 
 // integrationCA bundles the test CA certificate, cert cache, and trust pool.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -504,7 +504,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	var replayBody []byte
 	replayable := false
-	if p.responseRetryHandler != nil {
+	responseRetryEnabled := p.responseRetryHandler != nil && responseRetryEligible(upstreamReq)
+	if responseRetryEnabled {
 		upstreamReq.Body, replayBody, replayable, err = prepareReplayBody(
 			upstreamReq.Body,
 			upstreamReq.ContentLength,
@@ -535,7 +536,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 	defer resp.Body.Close()
 
-	if p.responseRetryHandler != nil {
+	if responseRetryEnabled {
 		chargeStarted := time.Now()
 		decision, replay, retryErr := p.responseRetryHandler.Decide(r.Context(), upstreamReq, resp, replayable)
 		if retryErr != nil {
@@ -662,6 +663,14 @@ func prepareReplayBody(body io.ReadCloser, contentLength, limit int64) (io.ReadC
 		return nil, nil, false, err
 	}
 	return io.NopCloser(bytes.NewReader(replayBody)), replayBody, true, nil
+}
+
+func responseRetryEligible(req *http.Request) bool {
+	if req.ContentLength < 0 || isWebSocketUpgrade(req) {
+		return false
+	}
+	contentType := strings.ToLower(strings.TrimSpace(strings.SplitN(req.Header.Get("Content-Type"), ";", 2)[0]))
+	return !strings.HasPrefix(contentType, "application/grpc")
 }
 
 func (p *Proxy) completeResponseRetry(ctx context.Context, attemptID string, resp *http.Response, transportError, traceparent string, replayDuration, chargeDuration time.Duration) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -561,15 +561,22 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 					replayReq.Header.Add(name, value)
 				}
 			}
+			if decision.Traceparent != "" {
+				replayReq.Header.Set("Traceparent", decision.Traceparent)
+			}
 			replayStarted := time.Now()
 			resp, err = p.doUpstream(replayReq)
+			completionTraceparent := decision.Traceparent
+			if completionTraceparent == "" {
+				completionTraceparent = upstreamReq.Header.Get("Traceparent")
+			}
 			if err != nil {
 				p.completeResponseRetry(
 					r.Context(),
 					decision.AttemptID,
 					nil,
 					"upstream_transport_error",
-					upstreamReq.Header.Get("Traceparent"),
+					completionTraceparent,
 					time.Since(replayStarted),
 					time.Since(chargeStarted),
 				)
@@ -588,7 +595,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 				decision.AttemptID,
 				resp,
 				"",
-				upstreamReq.Header.Get("Traceparent"),
+				completionTraceparent,
 				time.Since(replayStarted),
 				time.Since(chargeStarted),
 			)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -505,28 +505,20 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	var replayBody []byte
 	replayable := false
 	if p.responseRetryHandler != nil {
-		limit := bodyLimits.MaxRequestBodyBytes
-		if limit > 0 && (upstreamReq.ContentLength < 0 || upstreamReq.ContentLength <= limit) {
-			originalBody := upstreamReq.Body
-			replayBody, err = io.ReadAll(io.LimitReader(originalBody, limit+1))
-			if err != nil {
-				result.Action = transform.ActionContinue
-				result.StatusCode = http.StatusBadGateway
-				result.Err = err
-				http.Error(w, "bad gateway", http.StatusBadGateway)
-				return
-			}
-			if int64(len(replayBody)) <= limit {
-				replayable = true
-				_ = originalBody.Close()
-				upstreamReq.Body = io.NopCloser(bytes.NewReader(replayBody))
-				upstreamReq.ContentLength = int64(len(replayBody))
-			} else {
-				upstreamReq.Body = &multiReadCloser{
-					Reader: io.MultiReader(bytes.NewReader(replayBody), originalBody),
-					Closer: originalBody,
-				}
-			}
+		upstreamReq.Body, replayBody, replayable, err = prepareReplayBody(
+			upstreamReq.Body,
+			upstreamReq.ContentLength,
+			bodyLimits.MaxRequestBodyBytes,
+		)
+		if err != nil {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusBadGateway
+			result.Err = err
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		if replayable {
+			upstreamReq.ContentLength = int64(len(replayBody))
 		}
 	}
 
@@ -647,6 +639,29 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 type multiReadCloser struct {
 	io.Reader
 	io.Closer
+}
+
+func prepareReplayBody(body io.ReadCloser, contentLength, limit int64) (io.ReadCloser, []byte, bool, error) {
+	if limit <= 0 || contentLength > limit {
+		return body, nil, false, nil
+	}
+	replayBody, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		if closeErr := body.Close(); closeErr != nil {
+			return nil, nil, false, errors.Join(err, closeErr)
+		}
+		return nil, nil, false, err
+	}
+	if int64(len(replayBody)) > limit {
+		return &multiReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(replayBody), body),
+			Closer: body,
+		}, nil, false, nil
+	}
+	if err := body.Close(); err != nil {
+		return nil, nil, false, err
+	}
+	return io.NopCloser(bytes.NewReader(replayBody)), replayBody, true, nil
 }
 
 func (p *Proxy) completeResponseRetry(ctx context.Context, attemptID string, resp *http.Response, transportError, traceparent string, replayDuration, chargeDuration time.Duration) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -24,6 +25,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/mcpgateway"
+	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"golang.org/x/net/http2"
 )
@@ -48,6 +50,7 @@ type Proxy struct {
 	guard          *dnsguard.Guard
 	mcpPolicy      *mcp.PolicyHolder
 	mcpGateway     *mcpgateway.Holder
+	responseRetryHandler *responseretry.Handler
 	logger         *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
@@ -76,6 +79,9 @@ type Options struct {
 	Guard      *dnsguard.Guard   // nil is treated as an empty (no-op) guard
 	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
 	MCPGateway *mcpgateway.Holder
+	// ResponseRetryHandler may add headers and replay the exact transformed
+	// request once after selected upstream response statuses.
+	ResponseRetryHandler *responseretry.Handler
 	Logger     *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
@@ -117,6 +123,7 @@ func New(opts Options) *Proxy {
 		guard:          guard,
 		mcpPolicy:      opts.MCPPolicy,
 		mcpGateway:     opts.MCPGateway,
+		responseRetryHandler: opts.ResponseRetryHandler,
 		logger:         opts.Logger,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -495,6 +502,27 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		upstreamReq.ContentLength = r.ContentLength
 	}
 
+	var replayBody []byte
+	if p.responseRetryHandler != nil {
+		if bodyLimits.MaxRequestBodyBytes <= 0 {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusBadGateway
+			result.Err = fmt.Errorf("response retry requires a positive request body limit")
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		replayBody, err = io.ReadAll(io.LimitReader(upstreamReq.Body, bodyLimits.MaxRequestBodyBytes+1))
+		if err != nil || int64(len(replayBody)) > bodyLimits.MaxRequestBodyBytes {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusRequestEntityTooLarge
+			result.Err = fmt.Errorf("request body exceeds response retry limit")
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		upstreamReq.Body = io.NopCloser(bytes.NewReader(replayBody))
+		upstreamReq.ContentLength = int64(len(replayBody))
+	}
+
 	resp, err := p.doUpstream(upstreamReq)
 	if err != nil {
 		if markIfClientCancel(r, err, result) {
@@ -507,6 +535,42 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		return
 	}
 	defer resp.Body.Close()
+
+	if p.responseRetryHandler != nil {
+		retryHeaders, replay, retryErr := p.responseRetryHandler.Decide(r.Context(), upstreamReq, resp)
+		if retryErr != nil {
+			result.Action = transform.ActionContinue
+			result.StatusCode = http.StatusBadGateway
+			result.Err = retryErr
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		if replay {
+			_ = resp.Body.Close() // The 402 body is never returned after authorization.
+			replayReq := upstreamReq.Clone(r.Context())
+			replayReq.Body = io.NopCloser(bytes.NewReader(replayBody))
+			replayReq.ContentLength = int64(len(replayBody))
+			replayReq.Header = upstreamReq.Header.Clone()
+			for name, values := range retryHeaders {
+				replayReq.Header.Del(name)
+				for _, value := range values {
+					replayReq.Header.Add(name, value)
+				}
+			}
+			resp, err = p.doUpstream(replayReq)
+			if err != nil {
+				if markIfClientCancel(r, err, result) {
+					return
+				}
+				result.Action = transform.ActionContinue
+				result.StatusCode = http.StatusBadGateway
+				result.Err = err
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+		}
+	}
 
 	// Wrap response body for lazy buffering by transforms.
 	resp.Body = transform.NewBufferedBody(resp.Body, bodyLimits.MaxResponseBodyBytes)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -35,23 +35,23 @@ import (
 // listener peeks the SNI from the ClientHello and TCP-passthroughs to the
 // upstream without terminating TLS.
 type Proxy struct {
-	httpServer     *http.Server
-	httpsServer    *http.Server
-	httpsAddr      string
-	tlsMode        string
-	tlsListener    net.Listener
-	tunnelAddr     string
-	tunnelListener net.Listener
-	tunnelDone     chan struct{}
-	certCache      *certcache.Cache
-	pipeline       *transform.PipelineHolder
-	transport      *http.Transport
-	resolver       *net.Resolver
-	guard          *dnsguard.Guard
-	mcpPolicy      *mcp.PolicyHolder
-	mcpGateway     *mcpgateway.Holder
+	httpServer           *http.Server
+	httpsServer          *http.Server
+	httpsAddr            string
+	tlsMode              string
+	tlsListener          net.Listener
+	tunnelAddr           string
+	tunnelListener       net.Listener
+	tunnelDone           chan struct{}
+	certCache            *certcache.Cache
+	pipeline             *transform.PipelineHolder
+	transport            *http.Transport
+	resolver             *net.Resolver
+	guard                *dnsguard.Guard
+	mcpPolicy            *mcp.PolicyHolder
+	mcpGateway           *mcpgateway.Holder
 	responseRetryHandler *responseretry.Handler
-	logger         *slog.Logger
+	logger               *slog.Logger
 
 	// shutdownCtx is canceled by Shutdown to unblock in-flight TCP-passthrough
 	// connections that would otherwise sit on blocking Reads.
@@ -82,7 +82,7 @@ type Options struct {
 	// ResponseRetryHandler may add headers and replay the exact transformed
 	// request once after selected upstream response statuses.
 	ResponseRetryHandler *responseretry.Handler
-	Logger     *slog.Logger
+	Logger               *slog.Logger
 	// UpstreamResponseHeaderTimeout overrides the upstream HTTP transport's
 	// ResponseHeaderTimeout. Zero falls back to
 	// config.DefaultUpstreamResponseHeaderTimeout.
@@ -111,22 +111,22 @@ func New(opts Options) *Proxy {
 		guard, _ = dnsguard.New(nil)
 	}
 	p := &Proxy{
-		ready:          opts.Ready,
-		httpsAddr:      opts.HTTPSAddr,
-		tlsMode:        opts.TLSMode,
-		tunnelAddr:     opts.TunnelAddr,
-		tunnelDone:     make(chan struct{}),
-		certCache:      opts.CertCache,
-		pipeline:       opts.Pipeline,
-		transport:      buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout, opts.UpstreamProxy),
-		resolver:       opts.Resolver,
-		guard:          guard,
-		mcpPolicy:      opts.MCPPolicy,
-		mcpGateway:     opts.MCPGateway,
+		ready:                opts.Ready,
+		httpsAddr:            opts.HTTPSAddr,
+		tlsMode:              opts.TLSMode,
+		tunnelAddr:           opts.TunnelAddr,
+		tunnelDone:           make(chan struct{}),
+		certCache:            opts.CertCache,
+		pipeline:             opts.Pipeline,
+		transport:            buildTransport(opts.Resolver, guard, opts.UpstreamResponseHeaderTimeout, opts.UpstreamProxy),
+		resolver:             opts.Resolver,
+		guard:                guard,
+		mcpPolicy:            opts.MCPPolicy,
+		mcpGateway:           opts.MCPGateway,
 		responseRetryHandler: opts.ResponseRetryHandler,
-		logger:         opts.Logger,
-		shutdownCtx:    shutdownCtx,
-		shutdownCancel: shutdownCancel,
+		logger:               opts.Logger,
+		shutdownCtx:          shutdownCtx,
+		shutdownCancel:       shutdownCancel,
 	}
 
 	p.httpServer = &http.Server{
@@ -503,24 +503,31 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 
 	var replayBody []byte
+	replayable := false
 	if p.responseRetryHandler != nil {
-		if bodyLimits.MaxRequestBodyBytes <= 0 {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusBadGateway
-			result.Err = fmt.Errorf("response retry requires a positive request body limit")
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
+		limit := bodyLimits.MaxRequestBodyBytes
+		if limit > 0 && (upstreamReq.ContentLength < 0 || upstreamReq.ContentLength <= limit) {
+			originalBody := upstreamReq.Body
+			replayBody, err = io.ReadAll(io.LimitReader(originalBody, limit+1))
+			if err != nil {
+				result.Action = transform.ActionContinue
+				result.StatusCode = http.StatusBadGateway
+				result.Err = err
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			if int64(len(replayBody)) <= limit {
+				replayable = true
+				_ = originalBody.Close()
+				upstreamReq.Body = io.NopCloser(bytes.NewReader(replayBody))
+				upstreamReq.ContentLength = int64(len(replayBody))
+			} else {
+				upstreamReq.Body = &multiReadCloser{
+					Reader: io.MultiReader(bytes.NewReader(replayBody), originalBody),
+					Closer: originalBody,
+				}
+			}
 		}
-		replayBody, err = io.ReadAll(io.LimitReader(upstreamReq.Body, bodyLimits.MaxRequestBodyBytes+1))
-		if err != nil || int64(len(replayBody)) > bodyLimits.MaxRequestBodyBytes {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusRequestEntityTooLarge
-			result.Err = fmt.Errorf("request body exceeds response retry limit")
-			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
-			return
-		}
-		upstreamReq.Body = io.NopCloser(bytes.NewReader(replayBody))
-		upstreamReq.ContentLength = int64(len(replayBody))
 	}
 
 	resp, err := p.doUpstream(upstreamReq)
@@ -537,13 +544,10 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	defer resp.Body.Close()
 
 	if p.responseRetryHandler != nil {
-		retryHeaders, replay, retryErr := p.responseRetryHandler.Decide(r.Context(), upstreamReq, resp)
+		chargeStarted := time.Now()
+		decision, replay, retryErr := p.responseRetryHandler.Decide(r.Context(), upstreamReq, resp, replayable)
 		if retryErr != nil {
-			result.Action = transform.ActionContinue
-			result.StatusCode = http.StatusBadGateway
-			result.Err = retryErr
-			http.Error(w, "bad gateway", http.StatusBadGateway)
-			return
+			p.logger.Warn("response retry authorization failed", slog.String("error", retryErr.Error()))
 		}
 		if replay {
 			_ = resp.Body.Close() // The 402 body is never returned after authorization.
@@ -551,14 +555,24 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 			replayReq.Body = io.NopCloser(bytes.NewReader(replayBody))
 			replayReq.ContentLength = int64(len(replayBody))
 			replayReq.Header = upstreamReq.Header.Clone()
-			for name, values := range retryHeaders {
+			for name, values := range decision.Headers {
 				replayReq.Header.Del(name)
 				for _, value := range values {
 					replayReq.Header.Add(name, value)
 				}
 			}
+			replayStarted := time.Now()
 			resp, err = p.doUpstream(replayReq)
 			if err != nil {
+				p.completeResponseRetry(
+					r.Context(),
+					decision.AttemptID,
+					nil,
+					"upstream_transport_error",
+					upstreamReq.Header.Get("Traceparent"),
+					time.Since(replayStarted),
+					time.Since(chargeStarted),
+				)
 				if markIfClientCancel(r, err, result) {
 					return
 				}
@@ -569,6 +583,15 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 				return
 			}
 			defer resp.Body.Close()
+			p.completeResponseRetry(
+				r.Context(),
+				decision.AttemptID,
+				resp,
+				"",
+				upstreamReq.Header.Get("Traceparent"),
+				time.Since(replayStarted),
+				time.Since(chargeStarted),
+			)
 		}
 	}
 
@@ -612,6 +635,19 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 
 	p.writeResponse(w, finalResp)
+}
+
+type multiReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func (p *Proxy) completeResponseRetry(ctx context.Context, attemptID string, resp *http.Response, transportError, traceparent string, replayDuration, chargeDuration time.Duration) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	if err := p.responseRetryHandler.Complete(ctx, attemptID, resp, transportError, traceparent, replayDuration, chargeDuration); err != nil {
+		p.logger.Warn("response retry completion failed", slog.String("error", err.Error()))
+	}
 }
 
 // isWebSocketUpgrade detects a WebSocket upgrade request. Connection is

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1019,29 +1019,44 @@ func TestPrepareReplayBodyBoundaries(t *testing.T) {
 func TestResponseRetryEligible(t *testing.T) {
 	cases := []struct {
 		name          string
+		method        string
 		contentType   string
 		contentLength int64
-		websocket     bool
+		connection    string
+		upgrade       string
 		want          bool
 	}{
-		{name: "ordinary GET", contentLength: 0, want: true},
-		{name: "ordinary known body", contentType: "application/json", contentLength: 4, want: true},
-		{name: "unknown length", contentType: "application/json", contentLength: -1, want: false},
-		{name: "gRPC", contentType: "application/grpc", contentLength: 4, want: false},
-		{name: "gRPC proto", contentType: "application/grpc+proto", contentLength: 4, want: false},
-		{name: "gRPC web parameters", contentType: "Application/GRPC-Web+Proto; charset=utf-8", contentLength: 4, want: false},
-		{name: "WebSocket", contentLength: 0, websocket: true, want: false},
+		{name: "ordinary GET", method: http.MethodGet, contentLength: 0, want: true},
+		{name: "ordinary HEAD", method: http.MethodHead, contentLength: 0, want: true},
+		{name: "ordinary known body", method: http.MethodPost, contentType: "application/json", contentLength: 4, want: true},
+		{name: "known body with content type parameters", method: http.MethodPost, contentType: "application/json; charset=utf-8", contentLength: 4, want: true},
+		{name: "known body without content type", method: http.MethodPost, contentLength: 4, want: true},
+		{name: "unknown length with content type", method: http.MethodPost, contentType: "application/json", contentLength: -1, want: false},
+		{name: "unknown length without content type", method: http.MethodPost, contentLength: -1, want: false},
+		{name: "gRPC", method: http.MethodPost, contentType: "application/grpc", contentLength: 4, want: false},
+		{name: "gRPC proto", method: http.MethodPost, contentType: "application/grpc+proto", contentLength: 4, want: false},
+		{name: "gRPC JSON", method: http.MethodPost, contentType: "application/grpc+json", contentLength: 4, want: false},
+		{name: "gRPC web", method: http.MethodPost, contentType: "application/grpc-web", contentLength: 4, want: false},
+		{name: "gRPC web text", method: http.MethodPost, contentType: "application/grpc-web-text", contentLength: 4, want: false},
+		{name: "gRPC web mixed case and parameters", method: http.MethodPost, contentType: " Application/GRPC-Web+Proto ; charset=utf-8", contentLength: 4, want: false},
+		{name: "gRPC prefix is conservative", method: http.MethodPost, contentType: "application/grpcish", contentLength: 4, want: false},
+		{name: "WebSocket", method: http.MethodGet, contentLength: 0, connection: "Upgrade", upgrade: "websocket", want: false},
+		{name: "WebSocket mixed case and connection tokens", method: http.MethodGet, contentLength: 0, connection: "keep-alive, UpGrAdE", upgrade: "WebSocket", want: false},
+		{name: "upgrade without connection header", method: http.MethodGet, contentLength: 0, upgrade: "websocket", want: true},
+		{name: "connection upgrade without protocol", method: http.MethodGet, contentLength: 0, connection: "Upgrade", want: true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "https://service.example/", strings.NewReader("body"))
+			var body io.Reader
+			if tc.contentLength != 0 {
+				body = strings.NewReader("body")
+			}
+			req := httptest.NewRequest(tc.method, "https://service.example/", body)
 			req.ContentLength = tc.contentLength
 			req.Header.Set("Content-Type", tc.contentType)
-			if tc.websocket {
-				req.Header.Set("Connection", "Upgrade")
-				req.Header.Set("Upgrade", "websocket")
-			}
+			req.Header.Set("Connection", tc.connection)
+			req.Header.Set("Upgrade", tc.upgrade)
 
 			require.Equal(t, tc.want, responseRetryEligible(req))
 		})

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1016,6 +1016,38 @@ func TestPrepareReplayBodyBoundaries(t *testing.T) {
 	}
 }
 
+func TestResponseRetryEligible(t *testing.T) {
+	cases := []struct {
+		name          string
+		contentType   string
+		contentLength int64
+		websocket     bool
+		want          bool
+	}{
+		{name: "ordinary GET", contentLength: 0, want: true},
+		{name: "ordinary known body", contentType: "application/json", contentLength: 4, want: true},
+		{name: "unknown length", contentType: "application/json", contentLength: -1, want: false},
+		{name: "gRPC", contentType: "application/grpc", contentLength: 4, want: false},
+		{name: "gRPC proto", contentType: "application/grpc+proto", contentLength: 4, want: false},
+		{name: "gRPC web parameters", contentType: "Application/GRPC-Web+Proto; charset=utf-8", contentLength: 4, want: false},
+		{name: "WebSocket", contentLength: 0, websocket: true, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "https://service.example/", strings.NewReader("body"))
+			req.ContentLength = tc.contentLength
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.websocket {
+				req.Header.Set("Connection", "Upgrade")
+				req.Header.Set("Upgrade", "websocket")
+			}
+
+			require.Equal(t, tc.want, responseRetryEligible(req))
+		})
+	}
+}
+
 func TestHTTPProxy_FailsClosedUntilReady(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -69,8 +69,9 @@ func startProxy(t *testing.T) (*Proxy, string, string, *x509.CertPool) {
 
 // replacerTransform replaces request and response bodies with fixed-size padding.
 type replacerTransform struct {
-	reqBody  []byte
-	respBody []byte
+	reqBody    []byte
+	reqHeaders http.Header
+	respBody   []byte
 }
 
 func (r *replacerTransform) Name() string { return "replacer" }
@@ -84,6 +85,7 @@ func (r *replacerTransform) TransformRequest(_ context.Context, _ *transform.Tra
 		req.Body = transform.NewBufferedBodyFromBytes(r.reqBody)
 		req.ContentLength = int64(len(r.reqBody))
 	}
+	copyHeaders(req.Header, r.reqHeaders)
 	return &transform.TransformResult{Action: transform.ActionContinue}, nil
 }
 
@@ -972,6 +974,44 @@ func TestContainsDotSegments(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {
 			require.Equal(t, tc.want, containsDotSegments(tc.path))
+		})
+	}
+}
+
+func TestPrepareReplayBodyBoundaries(t *testing.T) {
+	cases := []struct {
+		name          string
+		body          string
+		contentLength int64
+		limit         int64
+		wantReplay    bool
+	}{
+		{name: "below limit", body: "1234", contentLength: 4, limit: 5, wantReplay: true},
+		{name: "at limit", body: "12345", contentLength: 5, limit: 5, wantReplay: true},
+		{name: "known over limit", body: "123456", contentLength: 6, limit: 5, wantReplay: false},
+		{name: "unknown at limit", body: "12345", contentLength: -1, limit: 5, wantReplay: true},
+		{name: "unknown over limit", body: "123456", contentLength: -1, limit: 5, wantReplay: false},
+		{name: "disabled", body: "12345", contentLength: 5, limit: 0, wantReplay: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, replayBody, replayable, err := prepareReplayBody(
+				io.NopCloser(strings.NewReader(tc.body)),
+				tc.contentLength,
+				tc.limit,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantReplay, replayable)
+			if tc.wantReplay {
+				require.Equal(t, []byte(tc.body), replayBody)
+			} else {
+				require.Nil(t, replayBody)
+			}
+			got, err := io.ReadAll(prepared)
+			require.NoError(t, err)
+			require.NoError(t, prepared.Close())
+			require.Equal(t, tc.body, string(got))
 		})
 	}
 }

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var forbiddenRetryHeaders = map[string]struct{}{
@@ -23,42 +24,69 @@ var forbiddenRetryHeaders = map[string]struct{}{
 }
 
 // Handler asks a trusted service whether a bounded upstream response should
-// be retried and which request headers to add. It does not interpret response
-// protocols or credentials.
+// be retried and reports the result of the one permitted replay.
 type Handler struct {
-	endpoint *url.URL
-	token    string
-	statuses map[int]struct{}
-	client   *http.Client
+	authorizeEndpoint *url.URL
+	completeEndpoint  *url.URL
+	token             string
+	sandboxID         string
+	statuses          map[int]struct{}
+	client            *http.Client
 }
 
-// DecisionRequest describes the completed request and response. Response
-// bodies are deliberately excluded.
+// DecisionRequest describes the completed request and response. Request and
+// response bodies are deliberately excluded.
 type DecisionRequest struct {
 	Host            string              `json:"host"`
 	Method          string              `json:"method"`
 	Path            string              `json:"path"`
+	Replayable      bool                `json:"replayable"`
 	Status          int                 `json:"status"`
 	ResponseHeaders map[string][]string `json:"response_headers"`
+	SandboxID       string              `json:"sandbox_id"`
+	Traceparent     string              `json:"traceparent,omitempty"`
 }
 
 // DecisionResponse authorizes at most one replay with additional headers.
 type DecisionResponse struct {
-	Retry   bool              `json:"retry"`
-	Headers map[string]string `json:"headers"`
+	Retry     bool              `json:"retry"`
+	Headers   map[string]string `json:"headers"`
+	AttemptID string            `json:"attempt_id"`
+}
+
+// CompletionRequest reports the replay result without any request or response
+// body and includes only the payment receipt response header.
+type CompletionRequest struct {
+	AttemptID        string              `json:"attempt_id"`
+	ReplayStatus     *int                `json:"replay_status"`
+	ResponseHeaders  map[string][]string `json:"response_headers"`
+	TransportError   string              `json:"transport_error,omitempty"`
+	Traceparent      string              `json:"traceparent,omitempty"`
+	ReplayDurationMS int64               `json:"replay_duration_ms,omitempty"`
+	ChargeDurationMS int64               `json:"charge_duration_ms,omitempty"`
+}
+
+// Decision contains the validated result of an authorization call.
+type Decision struct {
+	Headers   http.Header
+	AttemptID string
 }
 
 // New creates a Handler for the configured response status codes.
-func New(endpoint, token string, statuses []int, client *http.Client) (*Handler, error) {
-	u, err := url.Parse(endpoint)
-	if err != nil || !u.IsAbs() || u.Host == "" {
-		return nil, fmt.Errorf("response retry handler URL must be absolute")
+func New(authorizeEndpoint, completeEndpoint, token, sandboxID string, statuses []int, allowHTTP bool, client *http.Client) (*Handler, error) {
+	authorizeURL, err := parseEndpoint(authorizeEndpoint, allowHTTP)
+	if err != nil {
+		return nil, fmt.Errorf("authorize endpoint: %w", err)
 	}
-	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopback(u.Hostname())) {
-		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless it is loopback")
+	completeURL, err := parseEndpoint(completeEndpoint, allowHTTP)
+	if err != nil {
+		return nil, fmt.Errorf("complete endpoint: %w", err)
 	}
 	if token == "" {
 		return nil, fmt.Errorf("response retry handler token is required")
+	}
+	if sandboxID == "" {
+		return nil, fmt.Errorf("response retry handler sandbox identity is required")
 	}
 	statusSet := make(map[int]struct{}, len(statuses))
 	for _, status := range statuses {
@@ -73,31 +101,43 @@ func New(endpoint, token string, statuses []int, client *http.Client) (*Handler,
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &Handler{endpoint: u, token: token, statuses: statusSet, client: client}, nil
+	return &Handler{
+		authorizeEndpoint: authorizeURL,
+		completeEndpoint:  completeURL,
+		token:             token,
+		sandboxID:         sandboxID,
+		statuses:          statusSet,
+		client:            client,
+	}, nil
 }
 
-// Decide returns request headers for one replay. retry is false when the
-// response status is outside the configured set or the handler declines.
-func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Response) (headers http.Header, retry bool, err error) {
+// Decide returns authorization metadata for one replay. The caller passes
+// replayable=false when the exact request body cannot be replayed safely.
+func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Response, replayable bool) (*Decision, bool, error) {
 	if _, ok := h.statuses[resp.StatusCode]; !ok {
 		return nil, false, nil
+	}
+	path := req.URL.EscapedPath()
+	if req.URL.RawQuery != "" {
+		path += "?" + req.URL.RawQuery
 	}
 	payload, err := json.Marshal(DecisionRequest{
 		Host:            req.URL.Host,
 		Method:          req.Method,
-		Path:            req.URL.EscapedPath(),
+		Path:            path,
+		Replayable:      replayable,
 		Status:          resp.StatusCode,
 		ResponseHeaders: resp.Header,
+		SandboxID:       h.sandboxID,
+		Traceparent:     req.Header.Get("Traceparent"),
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("encode response retry decision request: %w", err)
 	}
-	decisionReq, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint.String(), bytes.NewReader(payload))
+	decisionReq, err := h.newRequest(ctx, h.authorizeEndpoint, payload)
 	if err != nil {
 		return nil, false, fmt.Errorf("create response retry decision request: %w", err)
 	}
-	decisionReq.Header.Set("Authorization", "Bearer "+h.token)
-	decisionReq.Header.Set("Content-Type", "application/json")
 	decisionResp, err := h.client.Do(decisionReq)
 	if err != nil {
 		return nil, false, fmt.Errorf("request response retry decision: %w", err)
@@ -114,7 +154,13 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 	if !decision.Retry {
 		return nil, false, nil
 	}
-	headers = make(http.Header, len(decision.Headers))
+	if !replayable {
+		return nil, false, fmt.Errorf("response retry handler authorized a non-replayable request")
+	}
+	if decision.AttemptID == "" {
+		return nil, false, fmt.Errorf("response retry handler omitted attempt id")
+	}
+	headers := make(http.Header, len(decision.Headers))
 	for name, value := range decision.Headers {
 		canonical := http.CanonicalHeaderKey(name)
 		if canonical == "" {
@@ -125,7 +171,75 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 		}
 		headers.Set(canonical, value)
 	}
-	return headers, true, nil
+	return &Decision{Headers: headers, AttemptID: decision.AttemptID}, true, nil
+}
+
+// Complete reports the replay outcome. It is idempotent at the handler.
+func (h *Handler) Complete(ctx context.Context, attemptID string, resp *http.Response, transportError, traceparent string, replayDuration, chargeDuration time.Duration) error {
+	var status *int
+	headers := make(http.Header)
+	if resp != nil {
+		value := resp.StatusCode
+		status = &value
+		headers = receiptHeaders(resp.Header)
+	}
+	payload, err := json.Marshal(CompletionRequest{
+		AttemptID:        attemptID,
+		ReplayStatus:     status,
+		ResponseHeaders:  headers,
+		TransportError:   transportError,
+		Traceparent:      traceparent,
+		ReplayDurationMS: replayDuration.Milliseconds(),
+		ChargeDurationMS: chargeDuration.Milliseconds(),
+	})
+	if err != nil {
+		return fmt.Errorf("encode response retry completion request: %w", err)
+	}
+	req, err := h.newRequest(ctx, h.completeEndpoint, payload)
+	if err != nil {
+		return fmt.Errorf("create response retry completion request: %w", err)
+	}
+	completionResp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request response retry completion: %w", err)
+	}
+	defer completionResp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(completionResp.Body, 64<<10))
+	if completionResp.StatusCode < 200 || completionResp.StatusCode >= 300 {
+		return fmt.Errorf("response retry completion returned status %d", completionResp.StatusCode)
+	}
+	return nil
+}
+
+func (h *Handler) newRequest(ctx context.Context, endpoint *url.URL, payload []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+h.token)
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+func parseEndpoint(endpoint string, allowHTTP bool) (*url.URL, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || !u.IsAbs() || u.Host == "" || u.User != nil {
+		return nil, fmt.Errorf("response retry handler URL must be absolute without credentials")
+	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && (allowHTTP || isLoopback(u.Hostname()))) {
+		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless HTTP is explicitly allowed")
+	}
+	return u, nil
+}
+
+func receiptHeaders(headers http.Header) http.Header {
+	result := make(http.Header)
+	for name, values := range headers {
+		if strings.EqualFold(name, "Payment-Receipt") {
+			result[name] = append([]string(nil), values...)
+		}
+	}
+	return result
 }
 
 func isLoopback(host string) bool {

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -5,6 +5,7 @@ package responseretry
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,9 +50,10 @@ type DecisionRequest struct {
 
 // DecisionResponse authorizes at most one replay with additional headers.
 type DecisionResponse struct {
-	Retry     bool              `json:"retry"`
-	Headers   map[string]string `json:"headers"`
-	AttemptID string            `json:"attempt_id"`
+	Retry       bool              `json:"retry"`
+	Headers     map[string]string `json:"headers"`
+	AttemptID   string            `json:"attempt_id"`
+	Traceparent string            `json:"traceparent,omitempty"`
 }
 
 // CompletionRequest reports the replay result without any request or response
@@ -68,8 +70,9 @@ type CompletionRequest struct {
 
 // Decision contains the validated result of an authorization call.
 type Decision struct {
-	Headers   http.Header
-	AttemptID string
+	Headers     http.Header
+	AttemptID   string
+	Traceparent string
 }
 
 // New creates a Handler for the configured response status codes.
@@ -160,6 +163,9 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 	if decision.AttemptID == "" {
 		return nil, false, fmt.Errorf("response retry handler omitted attempt id")
 	}
+	if decision.Traceparent != "" && !validTraceparent(decision.Traceparent) {
+		return nil, false, fmt.Errorf("response retry handler returned invalid traceparent")
+	}
 	headers := make(http.Header, len(decision.Headers))
 	for name, value := range decision.Headers {
 		canonical := http.CanonicalHeaderKey(name)
@@ -171,7 +177,11 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 		}
 		headers.Set(canonical, value)
 	}
-	return &Decision{Headers: headers, AttemptID: decision.AttemptID}, true, nil
+	return &Decision{
+		Headers:     headers,
+		AttemptID:   decision.AttemptID,
+		Traceparent: decision.Traceparent,
+	}, true, nil
 }
 
 // Complete reports the replay outcome. It is idempotent at the handler.
@@ -244,4 +254,25 @@ func receiptHeaders(headers http.Header) http.Header {
 
 func isLoopback(host string) bool {
 	return host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1"
+}
+
+func validTraceparent(value string) bool {
+	parts := strings.Split(value, "-")
+	if len(parts) != 4 || parts[0] != "00" || len(parts[1]) != 32 || len(parts[2]) != 16 || len(parts[3]) != 2 {
+		return false
+	}
+	traceID, traceErr := hex.DecodeString(parts[1])
+	spanID, spanErr := hex.DecodeString(parts[2])
+	_, flagsErr := hex.DecodeString(parts[3])
+	return traceErr == nil && spanErr == nil && flagsErr == nil &&
+		!allZero(traceID) && !allZero(spanID)
+}
+
+func allZero(value []byte) bool {
+	for _, current := range value {
+		if current != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -285,7 +285,7 @@ func parseEndpoint(endpoint string, allowHTTP bool) (*url.URL, error) {
 	if err != nil || !u.IsAbs() || u.Host == "" || u.User != nil {
 		return nil, fmt.Errorf("response retry handler URL must be absolute without credentials")
 	}
-	if u.Scheme != "https" && !(u.Scheme == "http" && (allowHTTP || isLoopback(u.Hostname()))) {
+	if u.Scheme != "https" && (u.Scheme != "http" || (!allowHTTP && !isLoopback(u.Hostname()))) {
 		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless HTTP is explicitly allowed")
 	}
 	return u, nil

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -1,0 +1,133 @@
+// Package responseretry implements a protocol-neutral, externally decided
+// response retry hook.
+package responseretry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+var forbiddenRetryHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Content-Length":      {},
+	"Host":                {},
+	"Proxy-Authorization": {},
+	"Transfer-Encoding":   {},
+}
+
+// Handler asks a trusted service whether a bounded upstream response should
+// be retried and which request headers to add. It does not interpret response
+// protocols or credentials.
+type Handler struct {
+	endpoint *url.URL
+	token    string
+	statuses map[int]struct{}
+	client   *http.Client
+}
+
+// DecisionRequest describes the completed request and response. Response
+// bodies are deliberately excluded.
+type DecisionRequest struct {
+	Host            string              `json:"host"`
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	Status          int                 `json:"status"`
+	ResponseHeaders map[string][]string `json:"response_headers"`
+}
+
+// DecisionResponse authorizes at most one replay with additional headers.
+type DecisionResponse struct {
+	Retry   bool              `json:"retry"`
+	Headers map[string]string `json:"headers"`
+}
+
+// New creates a Handler for the configured response status codes.
+func New(endpoint, token string, statuses []int, client *http.Client) (*Handler, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return nil, fmt.Errorf("response retry handler URL must be absolute")
+	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && isLoopback(u.Hostname())) {
+		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless it is loopback")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("response retry handler token is required")
+	}
+	statusSet := make(map[int]struct{}, len(statuses))
+	for _, status := range statuses {
+		if status < 100 || status > 599 {
+			return nil, fmt.Errorf("invalid response retry status %s", strconv.Itoa(status))
+		}
+		statusSet[status] = struct{}{}
+	}
+	if len(statusSet) == 0 {
+		return nil, fmt.Errorf("at least one response retry status is required")
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Handler{endpoint: u, token: token, statuses: statusSet, client: client}, nil
+}
+
+// Decide returns request headers for one replay. retry is false when the
+// response status is outside the configured set or the handler declines.
+func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Response) (headers http.Header, retry bool, err error) {
+	if _, ok := h.statuses[resp.StatusCode]; !ok {
+		return nil, false, nil
+	}
+	payload, err := json.Marshal(DecisionRequest{
+		Host:            req.URL.Host,
+		Method:          req.Method,
+		Path:            req.URL.EscapedPath(),
+		Status:          resp.StatusCode,
+		ResponseHeaders: resp.Header,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("encode response retry decision request: %w", err)
+	}
+	decisionReq, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, false, fmt.Errorf("create response retry decision request: %w", err)
+	}
+	decisionReq.Header.Set("Authorization", "Bearer "+h.token)
+	decisionReq.Header.Set("Content-Type", "application/json")
+	decisionResp, err := h.client.Do(decisionReq)
+	if err != nil {
+		return nil, false, fmt.Errorf("request response retry decision: %w", err)
+	}
+	defer decisionResp.Body.Close()
+	if decisionResp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(decisionResp.Body, 64<<10))
+		return nil, false, fmt.Errorf("response retry handler rejected request with status %d", decisionResp.StatusCode)
+	}
+	var decision DecisionResponse
+	if err := json.NewDecoder(io.LimitReader(decisionResp.Body, 64<<10)).Decode(&decision); err != nil {
+		return nil, false, fmt.Errorf("decode response retry decision: %w", err)
+	}
+	if !decision.Retry {
+		return nil, false, nil
+	}
+	headers = make(http.Header, len(decision.Headers))
+	for name, value := range decision.Headers {
+		canonical := http.CanonicalHeaderKey(name)
+		if canonical == "" {
+			return nil, false, fmt.Errorf("response retry handler returned an invalid header name")
+		}
+		if _, forbidden := forbiddenRetryHeaders[canonical]; forbidden {
+			return nil, false, fmt.Errorf("response retry handler returned forbidden header %s", canonical)
+		}
+		headers.Set(canonical, value)
+	}
+	return headers, true, nil
+}
+
+func isLoopback(host string) bool {
+	return host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1"
+}

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -10,19 +10,30 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/http/httpguts"
 )
 
 var forbiddenRetryHeaders = map[string]struct{}{
 	"Connection":          {},
 	"Content-Length":      {},
 	"Host":                {},
+	"Keep-Alive":          {},
 	"Proxy-Authorization": {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Connection":    {},
+	"Te":                  {},
+	"Trailer":             {},
 	"Transfer-Encoding":   {},
+	"Upgrade":             {},
 }
+
+const defaultClientTimeout = 10 * time.Second
 
 // Handler asks a trusted service whether a bounded upstream response should
 // be retried and reports the result of the one permitted replay.
@@ -32,7 +43,20 @@ type Handler struct {
 	token             string
 	sandboxID         string
 	statuses          map[int]struct{}
+	completionHeaders map[string]struct{}
 	client            *http.Client
+}
+
+// Options configures a response retry handler.
+type Options struct {
+	AuthorizeEndpoint string
+	CompleteEndpoint  string
+	Token             string
+	SandboxID         string
+	Statuses          []int
+	AllowHTTP         bool
+	CompletionHeaders []string
+	Client            *http.Client
 }
 
 // DecisionRequest describes the completed request and response. Request and
@@ -57,7 +81,7 @@ type DecisionResponse struct {
 }
 
 // CompletionRequest reports the replay result without any request or response
-// body and includes only the payment receipt response header.
+// body and includes only explicitly selected response headers.
 type CompletionRequest struct {
 	AttemptID        string              `json:"attempt_id"`
 	ReplayStatus     *int                `json:"replay_status"`
@@ -76,23 +100,23 @@ type Decision struct {
 }
 
 // New creates a Handler for the configured response status codes.
-func New(authorizeEndpoint, completeEndpoint, token, sandboxID string, statuses []int, allowHTTP bool, client *http.Client) (*Handler, error) {
-	authorizeURL, err := parseEndpoint(authorizeEndpoint, allowHTTP)
+func New(opts Options) (*Handler, error) {
+	authorizeURL, err := parseEndpoint(opts.AuthorizeEndpoint, opts.AllowHTTP)
 	if err != nil {
 		return nil, fmt.Errorf("authorize endpoint: %w", err)
 	}
-	completeURL, err := parseEndpoint(completeEndpoint, allowHTTP)
+	completeURL, err := parseEndpoint(opts.CompleteEndpoint, opts.AllowHTTP)
 	if err != nil {
 		return nil, fmt.Errorf("complete endpoint: %w", err)
 	}
-	if token == "" {
+	if opts.Token == "" {
 		return nil, fmt.Errorf("response retry handler token is required")
 	}
-	if sandboxID == "" {
+	if opts.SandboxID == "" {
 		return nil, fmt.Errorf("response retry handler sandbox identity is required")
 	}
-	statusSet := make(map[int]struct{}, len(statuses))
-	for _, status := range statuses {
+	statusSet := make(map[int]struct{}, len(opts.Statuses))
+	for _, status := range opts.Statuses {
 		if status < 100 || status > 599 {
 			return nil, fmt.Errorf("invalid response retry status %s", strconv.Itoa(status))
 		}
@@ -101,16 +125,21 @@ func New(authorizeEndpoint, completeEndpoint, token, sandboxID string, statuses 
 	if len(statusSet) == 0 {
 		return nil, fmt.Errorf("at least one response retry status is required")
 	}
-	if client == nil {
-		client = http.DefaultClient
+	completionHeaders := make(map[string]struct{}, len(opts.CompletionHeaders))
+	for _, name := range opts.CompletionHeaders {
+		if !httpguts.ValidHeaderFieldName(name) {
+			return nil, fmt.Errorf("invalid completion response header %q", name)
+		}
+		completionHeaders[http.CanonicalHeaderKey(name)] = struct{}{}
 	}
 	return &Handler{
 		authorizeEndpoint: authorizeURL,
 		completeEndpoint:  completeURL,
-		token:             token,
-		sandboxID:         sandboxID,
+		token:             opts.Token,
+		sandboxID:         opts.SandboxID,
 		statuses:          statusSet,
-		client:            client,
+		completionHeaders: completionHeaders,
+		client:            hardenedClient(opts.Client),
 	}, nil
 }
 
@@ -168,12 +197,18 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 	}
 	headers := make(http.Header, len(decision.Headers))
 	for name, value := range decision.Headers {
-		canonical := http.CanonicalHeaderKey(name)
-		if canonical == "" {
+		if !httpguts.ValidHeaderFieldName(name) {
 			return nil, false, fmt.Errorf("response retry handler returned an invalid header name")
 		}
+		if !httpguts.ValidHeaderFieldValue(value) {
+			return nil, false, fmt.Errorf("response retry handler returned an invalid value for header %s", name)
+		}
+		canonical := http.CanonicalHeaderKey(name)
 		if _, forbidden := forbiddenRetryHeaders[canonical]; forbidden {
 			return nil, false, fmt.Errorf("response retry handler returned forbidden header %s", canonical)
+		}
+		if _, duplicate := headers[canonical]; duplicate {
+			return nil, false, fmt.Errorf("response retry handler returned duplicate header %s", canonical)
 		}
 		headers.Set(canonical, value)
 	}
@@ -191,7 +226,7 @@ func (h *Handler) Complete(ctx context.Context, attemptID string, resp *http.Res
 	if resp != nil {
 		value := resp.StatusCode
 		status = &value
-		headers = receiptHeaders(resp.Header)
+		headers = selectedHeaders(resp.Header, h.completionHeaders)
 	}
 	payload, err := json.Marshal(CompletionRequest{
 		AttemptID:        attemptID,
@@ -205,20 +240,34 @@ func (h *Handler) Complete(ctx context.Context, attemptID string, resp *http.Res
 	if err != nil {
 		return fmt.Errorf("encode response retry completion request: %w", err)
 	}
-	req, err := h.newRequest(ctx, h.completeEndpoint, payload)
-	if err != nil {
-		return fmt.Errorf("create response retry completion request: %w", err)
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := h.newRequest(ctx, h.completeEndpoint, payload)
+		if err != nil {
+			return fmt.Errorf("create response retry completion request: %w", err)
+		}
+		completionResp, err := h.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request response retry completion: %w", err)
+			continue
+		}
+		_, copyErr := io.Copy(io.Discard, io.LimitReader(completionResp.Body, 64<<10))
+		closeErr := completionResp.Body.Close()
+		if copyErr != nil {
+			return fmt.Errorf("read response retry completion: %w", copyErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close response retry completion: %w", closeErr)
+		}
+		if completionResp.StatusCode >= 200 && completionResp.StatusCode < 300 {
+			return nil
+		}
+		lastErr = fmt.Errorf("response retry completion returned status %d", completionResp.StatusCode)
+		if completionResp.StatusCode < 500 {
+			break
+		}
 	}
-	completionResp, err := h.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("request response retry completion: %w", err)
-	}
-	defer completionResp.Body.Close()
-	_, _ = io.Copy(io.Discard, io.LimitReader(completionResp.Body, 64<<10))
-	if completionResp.StatusCode < 200 || completionResp.StatusCode >= 300 {
-		return fmt.Errorf("response retry completion returned status %d", completionResp.StatusCode)
-	}
-	return nil
+	return lastErr
 }
 
 func (h *Handler) newRequest(ctx context.Context, endpoint *url.URL, payload []byte) (*http.Request, error) {
@@ -242,10 +291,24 @@ func parseEndpoint(endpoint string, allowHTTP bool) (*url.URL, error) {
 	return u, nil
 }
 
-func receiptHeaders(headers http.Header) http.Header {
+func hardenedClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = &http.Client{Timeout: defaultClientTimeout}
+	}
+	result := *client
+	if result.Timeout <= 0 {
+		result.Timeout = defaultClientTimeout
+	}
+	result.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &result
+}
+
+func selectedHeaders(headers http.Header, allowed map[string]struct{}) http.Header {
 	result := make(http.Header)
-	for name, values := range headers {
-		if strings.EqualFold(name, "Payment-Receipt") {
+	for name := range allowed {
+		if values := headers.Values(name); len(values) > 0 {
 			result[name] = append([]string(nil), values...)
 		}
 	}
@@ -253,7 +316,11 @@ func receiptHeaders(headers http.Header) http.Header {
 }
 
 func isLoopback(host string) bool {
-	return host == "localhost" || strings.HasPrefix(host, "127.") || host == "::1"
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	address, err := netip.ParseAddr(host)
+	return err == nil && address.Unmap().IsLoopback()
 }
 
 func validTraceparent(value string) bool {

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -25,7 +25,7 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 		require.Equal(t, "00-trace-span-01", request.Traceparent)
 		require.True(t, request.Replayable)
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","headers":{"Authorization":"credential"}}`))
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01","headers":{"Authorization":"credential"}}`))
 		require.NoError(t, err)
 	})
 	mux.HandleFunc("/complete", func(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +60,7 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 	require.True(t, retry)
 	require.Equal(t, "credential", decision.Headers.Get("Authorization"))
 	require.Equal(t, testAttemptID, decision.AttemptID)
+	require.Equal(t, "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", decision.Traceparent)
 
 	replayResp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -130,4 +131,20 @@ func TestHandlerRejectsAuthorizedNonReplayableRequest(t *testing.T) {
 	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, false)
 
 	require.ErrorContains(t, err, "non-replayable")
+}
+
+func TestHandlerRejectsInvalidReturnedTraceparent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","traceparent":"invalid","headers":{"Authorization":"credential"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
+
+	require.ErrorContains(t, err, "invalid traceparent")
 }

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -3,8 +3,12 @@ package responseretry
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +16,18 @@ import (
 )
 
 const testAttemptID = "8ace71a1-4e12-47e5-9df4-f2f660db6a82"
+
+func testOptions(endpoint string, client *http.Client) Options {
+	return Options{
+		AuthorizeEndpoint: endpoint,
+		CompleteEndpoint:  endpoint,
+		Token:             "proxy-token",
+		SandboxID:         "sandbox-1",
+		Statuses:          []int{http.StatusPaymentRequired},
+		CompletionHeaders: []string{"Payment-Receipt"},
+		Client:            client,
+	}
+}
 
 func TestHandlerAuthorizeAndComplete(t *testing.T) {
 	mux := http.NewServeMux()
@@ -44,7 +60,9 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
-	handler, err := New(server.URL+"/authorize", server.URL+"/complete", "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	opts := testOptions(server.URL+"/authorize", server.Client())
+	opts.CompleteEndpoint = server.URL + "/complete"
+	handler, err := New(opts)
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/v1/search?q=one", nil)
 	require.NoError(t, err)
@@ -81,15 +99,9 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 }
 
 func TestHandlerSkipsUnconfiguredStatus(t *testing.T) {
-	handler, err := New(
-		"http://127.0.0.1/authorize",
-		"http://127.0.0.1/complete",
-		"proxy-token",
-		"sandbox-1",
-		[]int{http.StatusPaymentRequired},
-		false,
-		nil,
-	)
+	opts := testOptions("http://127.0.0.1/authorize", nil)
+	opts.CompleteEndpoint = "http://127.0.0.1/complete"
+	handler, err := New(opts)
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
@@ -107,7 +119,7 @@ func TestHandlerRejectsForbiddenReplayHeader(t *testing.T) {
 		require.NoError(t, err)
 	}))
 	defer server.Close()
-	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	handler, err := New(testOptions(server.URL, server.Client()))
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
@@ -123,7 +135,7 @@ func TestHandlerRejectsAuthorizedNonReplayableRequest(t *testing.T) {
 		require.NoError(t, err)
 	}))
 	defer server.Close()
-	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	handler, err := New(testOptions(server.URL, server.Client()))
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
@@ -139,7 +151,7 @@ func TestHandlerRejectsInvalidReturnedTraceparent(t *testing.T) {
 		require.NoError(t, err)
 	}))
 	defer server.Close()
-	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	handler, err := New(testOptions(server.URL, server.Client()))
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
@@ -147,4 +159,277 @@ func TestHandlerRejectsInvalidReturnedTraceparent(t *testing.T) {
 	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
 
 	require.ErrorContains(t, err, "invalid traceparent")
+}
+
+func TestNewValidatesConfiguration(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Options)
+		want   string
+	}{
+		{
+			name: "plaintext non-loopback",
+			mutate: func(opts *Options) {
+				opts.AuthorizeEndpoint = "http://127.attacker.example/authorize"
+			},
+			want: "must use HTTPS",
+		},
+		{
+			name: "URL credentials",
+			mutate: func(opts *Options) {
+				opts.AuthorizeEndpoint = "https://user:password@handler.example/authorize"
+			},
+			want: "without credentials",
+		},
+		{
+			name: "missing token",
+			mutate: func(opts *Options) {
+				opts.Token = ""
+			},
+			want: "token is required",
+		},
+		{
+			name: "missing sandbox",
+			mutate: func(opts *Options) {
+				opts.SandboxID = ""
+			},
+			want: "sandbox identity is required",
+		},
+		{
+			name: "missing statuses",
+			mutate: func(opts *Options) {
+				opts.Statuses = nil
+			},
+			want: "at least one",
+		},
+		{
+			name: "invalid status",
+			mutate: func(opts *Options) {
+				opts.Statuses = []int{99}
+			},
+			want: "invalid response retry status",
+		},
+		{
+			name: "invalid completion header",
+			mutate: func(opts *Options) {
+				opts.CompletionHeaders = []string{"Bad Header"}
+			},
+			want: "invalid completion response header",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := testOptions("https://handler.example/authorize", nil)
+			opts.CompleteEndpoint = "https://handler.example/complete"
+			tc.mutate(&opts)
+			_, err := New(opts)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestNewAllowsOnlyActualLoopbackHTTP(t *testing.T) {
+	for _, endpoint := range []string{
+		"http://localhost/authorize",
+		"http://127.0.0.1/authorize",
+		"http://127.255.255.255/authorize",
+		"http://[::1]/authorize",
+		"http://[::ffff:127.0.0.1]/authorize",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			opts := testOptions(endpoint, nil)
+			opts.CompleteEndpoint = endpoint
+			_, err := New(opts)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestHandlerRejectsRedirectsWithoutForwardingAuthorization(t *testing.T) {
+	var redirectedCalls atomic.Int64
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		redirectedCalls.Add(1)
+		require.Empty(t, r.Header.Get("Authorization"))
+	}))
+	defer target.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	handler, err := New(testOptions(redirector.URL, redirector.Client()))
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
+
+	require.ErrorContains(t, err, "status 302")
+	require.Zero(t, redirectedCalls.Load())
+}
+
+func TestHandlerValidatesAllReturnedHeaders(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{name: "invalid name", headers: map[string]string{"Bad Header": "value"}, want: "invalid header name"},
+		{name: "invalid value", headers: map[string]string{"X-Test": "bad\nvalue"}, want: "invalid value"},
+		{name: "duplicate canonical name", headers: map[string]string{"X-Test": "one", "x-test": "two"}, want: "duplicate header"},
+	}
+	for name := range forbiddenRetryHeaders {
+		cases = append(cases, struct {
+			name    string
+			headers map[string]string
+			want    string
+		}{name: "forbidden " + name, headers: map[string]string{name: "value"}, want: "forbidden header"})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := json.Marshal(DecisionResponse{
+				Retry:     true,
+				AttemptID: testAttemptID,
+				Headers:   tc.headers,
+			})
+			require.NoError(t, err)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, writeErr := w.Write(payload)
+				require.NoError(t, writeErr)
+			}))
+			defer server.Close()
+			handler, err := New(testOptions(server.URL, server.Client()))
+			require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+			require.NoError(t, err)
+
+			_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
+
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestHandlerDecisionFailureModes(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		body      string
+		wantRetry bool
+		wantErr   string
+	}{
+		{name: "declined", status: http.StatusOK, body: `{"retry":false}`, wantRetry: false},
+		{name: "handler rejection", status: http.StatusUnauthorized, body: `{}`, wantErr: "status 401"},
+		{name: "malformed JSON", status: http.StatusOK, body: `{`, wantErr: "decode response retry decision"},
+		{name: "missing attempt", status: http.StatusOK, body: `{"retry":true}`, wantErr: "omitted attempt id"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, err := io.WriteString(w, tc.body)
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+			handler, err := New(testOptions(server.URL, server.Client()))
+			require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+			require.NoError(t, err)
+
+			decision, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
+
+			require.Equal(t, tc.wantRetry, retry)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.Nil(t, decision)
+			} else {
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandlerCompleteRetriesServerFailureAndSelectsConfiguredHeaders(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		var request CompletionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, []string{"selected"}, request.ResponseHeaders["X-Selected"])
+		require.Empty(t, request.ResponseHeaders["Payment-Receipt"])
+		if call == 1 {
+			http.Error(w, "retry", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	opts := testOptions(server.URL, server.Client())
+	opts.CompletionHeaders = []string{"X-Selected"}
+	handler, err := New(opts)
+	require.NoError(t, err)
+
+	err = handler.Complete(
+		context.Background(),
+		testAttemptID,
+		&http.Response{StatusCode: http.StatusOK, Header: http.Header{
+			"X-Selected":      {"selected"},
+			"Payment-Receipt": {"not-selected"},
+		}},
+		"",
+		"",
+		0,
+		0,
+	)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 2, calls.Load())
+}
+
+func TestHandlerCompleteDoesNotRetryClientFailure(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		http.Error(w, "invalid", http.StatusBadRequest)
+	}))
+	defer server.Close()
+	handler, err := New(testOptions(server.URL, server.Client()))
+	require.NoError(t, err)
+
+	err = handler.Complete(context.Background(), testAttemptID, nil, "upstream_transport_error", "", 0, 0)
+
+	require.ErrorContains(t, err, "status 400")
+	require.EqualValues(t, 1, calls.Load())
+}
+
+func TestHardenedClientDoesNotMutateInputClient(t *testing.T) {
+	originalRedirect := func(_ *http.Request, _ []*http.Request) error { return fmt.Errorf("original") }
+	client := &http.Client{CheckRedirect: originalRedirect}
+	hardened := hardenedClient(client)
+
+	require.NotSame(t, client, hardened)
+	require.Zero(t, client.Timeout)
+	require.Equal(t, defaultClientTimeout, hardened.Timeout)
+	require.ErrorContains(t, client.CheckRedirect(nil, nil), "original")
+	require.ErrorIs(t, hardened.CheckRedirect(nil, nil), http.ErrUseLastResponse)
+}
+
+func TestSelectedHeadersIsCaseInsensitive(t *testing.T) {
+	headers := make(http.Header)
+	headers.Add("x-receipt", "one")
+	headers.Add("X-Receipt", "two")
+	headers.Add("Set-Cookie", "secret")
+
+	selected := selectedHeaders(headers, map[string]struct{}{"X-Receipt": {}})
+
+	require.Equal(t, []string{"one", "two"}, selected.Values("X-Receipt"))
+	require.Empty(t, selected.Values("Set-Cookie"))
+}
+
+func TestValidTraceparentRejectsAllZeroFlagsShape(t *testing.T) {
+	require.False(t, validTraceparent(strings.Repeat("0", 55)))
 }

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -1,0 +1,60 @@
+package responseretry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerDecide(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"Authorization":"credential"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "https://service.example/v1/search", nil)
+	require.NoError(t, err)
+	resp := &http.Response{StatusCode: 409, Header: http.Header{"Www-Authenticate": {"challenge"}}}
+
+	headers, retry, err := handler.Decide(context.Background(), req, resp)
+
+	require.NoError(t, err)
+	require.True(t, retry)
+	require.Equal(t, "credential", headers.Get("Authorization"))
+}
+
+func TestHandlerSkipsUnconfiguredStatus(t *testing.T) {
+	handler, err := New("http://127.0.0.1/decide", "proxy-token", []int{409}, nil)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	headers, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: 429})
+
+	require.NoError(t, err)
+	require.False(t, retry)
+	require.Nil(t, headers)
+}
+
+func TestHandlerRejectsForbiddenReplayHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"retry":true,"headers":{"Host":"other.example"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: 409})
+
+	require.ErrorContains(t, err, "forbidden header Host")
+}

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -2,59 +2,132 @@ package responseretry
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestHandlerDecide(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"retry":true,"headers":{"Authorization":"credential"}}`))
-		require.NoError(t, err)
-	}))
-	defer server.Close()
-	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
-	require.NoError(t, err)
-	req, err := http.NewRequest(http.MethodPost, "https://service.example/v1/search", nil)
-	require.NoError(t, err)
-	resp := &http.Response{StatusCode: 409, Header: http.Header{"Www-Authenticate": {"challenge"}}}
+const testAttemptID = "8ace71a1-4e12-47e5-9df4-f2f660db6a82"
 
-	headers, retry, err := handler.Decide(context.Background(), req, resp)
+func TestHandlerAuthorizeAndComplete(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		var request DecisionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, "service.example", request.Host)
+		require.Equal(t, "/v1/search?q=one", request.Path)
+		require.Equal(t, "sandbox-1", request.SandboxID)
+		require.Equal(t, "00-trace-span-01", request.Traceparent)
+		require.True(t, request.Replayable)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","headers":{"Authorization":"credential"}}`))
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("/complete", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
+		var request CompletionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, testAttemptID, request.AttemptID)
+		require.NotNil(t, request.ReplayStatus)
+		require.Equal(t, http.StatusOK, *request.ReplayStatus)
+		require.Equal(t, []string{"receipt"}, request.ResponseHeaders["Payment-Receipt"])
+		require.Empty(t, request.ResponseHeaders["Set-Cookie"])
+		require.Equal(t, "00-trace-span-01", request.Traceparent)
+		require.EqualValues(t, 25, request.ReplayDurationMS)
+		require.EqualValues(t, 50, request.ChargeDurationMS)
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	handler, err := New(server.URL+"/authorize", server.URL+"/complete", "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/v1/search?q=one", nil)
+	require.NoError(t, err)
+	req.Header.Set("Traceparent", "00-trace-span-01")
+	resp := &http.Response{
+		StatusCode: http.StatusPaymentRequired,
+		Header:     http.Header{"Www-Authenticate": {"Payment challenge"}},
+	}
+
+	decision, retry, err := handler.Decide(context.Background(), req, resp, true)
 
 	require.NoError(t, err)
 	require.True(t, retry)
-	require.Equal(t, "credential", headers.Get("Authorization"))
+	require.Equal(t, "credential", decision.Headers.Get("Authorization"))
+	require.Equal(t, testAttemptID, decision.AttemptID)
+
+	replayResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Payment-Receipt": {"receipt"},
+			"Set-Cookie":      {"secret"},
+		},
+	}
+	require.NoError(t, handler.Complete(
+		context.Background(),
+		decision.AttemptID,
+		replayResp,
+		"",
+		"00-trace-span-01",
+		25*time.Millisecond,
+		50*time.Millisecond,
+	))
 }
 
 func TestHandlerSkipsUnconfiguredStatus(t *testing.T) {
-	handler, err := New("http://127.0.0.1/decide", "proxy-token", []int{409}, nil)
+	handler, err := New(
+		"http://127.0.0.1/authorize",
+		"http://127.0.0.1/complete",
+		"proxy-token",
+		"sandbox-1",
+		[]int{http.StatusPaymentRequired},
+		false,
+		nil,
+	)
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
 
-	headers, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: 429})
+	decision, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusTooManyRequests}, true)
 
 	require.NoError(t, err)
 	require.False(t, retry)
-	require.Nil(t, headers)
+	require.Nil(t, decision)
 }
 
 func TestHandlerRejectsForbiddenReplayHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(`{"retry":true,"headers":{"Host":"other.example"}}`))
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","headers":{"Host":"other.example"}}`))
 		require.NoError(t, err)
 	}))
 	defer server.Close()
-	handler, err := New(server.URL, "proxy-token", []int{409}, server.Client())
+	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
 	require.NoError(t, err)
 
-	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: 409})
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
 
 	require.ErrorContains(t, err, "forbidden header Host")
+}
+
+func TestHandlerRejectsAuthorizedNonReplayableRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"retry":true,"attempt_id":"` + testAttemptID + `","headers":{"Authorization":"credential"}}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	handler, err := New(server.URL, server.URL, "proxy-token", "sandbox-1", []int{http.StatusPaymentRequired}, false, server.Client())
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "https://service.example/", nil)
+	require.NoError(t, err)
+
+	_, _, err = handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, false)
+
+	require.ErrorContains(t, err, "non-replayable")
 }


### PR DESCRIPTION
## Motivation

Some upstreams answer a request with a challenge that an out-of-band system can satisfy: a `402` payment challenge, a `401` that needs a fresh token from a credential broker, a `409`/`428` requiring a signed confirmation header. Today every workload behind the proxy must speak each of those protocols and hold the credentials to answer them.

This adds a protocol-neutral hook: when an upstream responds with a configured status code, iron-proxy consults an authenticated external decision service, which may authorize **exactly one replay** of the same request with additional headers. All protocol logic and credentials stay outside the proxy.

## How it works

```
┌──────────┐            ┌────────────┐              ┌──────────┐
│ workload │            │ iron-proxy │              │ upstream │
└────┬─────┘            └─────┬──────┘              └────┬─────┘
     │ 1. request             │                          │
     │───────────────────────▶│ 2. forward               │
     │                        │─────────────────────────▶│
     │                        │ 3. challenge             │
     │                        │    (status ∈ retry set)  │
     │                        │◀─────────────────────────│
     │                        │                          │
     │                        │ 4. authorize: authority, method,
     │                        │    path/query, response status +
     │                        │    headers, replayable, trace
     │                        │    context, sandbox id — no bodies
     │                        │──────────────┐           │
     │                        │              ▼           │
     │                        │   ┌─────────────────────┐│
     │                        │   │  decision service   ││
     │                        │   │  (HTTPS + bearer)   ││
     │                        │   └──────────┬──────────┘│
     │                        │◀─────────────┘           │
     │                        │ 5. {retry, headers,      │
     │                        │     attempt_id}          │
     │                        │                          │
     │                        │ 6. exact replay ×1       │
     │                        │    (+ handler headers)   │
     │                        │─────────────────────────▶│
     │                        │ 7. response              │
     │                        │◀─────────────────────────│
     │                        │                          │
     │                        │ 8. completion report:    │
     │                        │    status, receipt hdr ──┼──▶ decision service
     │ 9. final response      │                          │
     │◀───────────────────────│                          │
```

If the handler declines (`retry: false`), fails, or the request cannot be safely replayed, the original challenge response passes through unchanged (steps 5–8 skipped).

## Summary

- Enabled via `IRON_RESPONSE_RETRY_*` env vars: authorize URL, completion URL, bearer token (defaults to the proxy token), sandbox identity, and a comma-separated status list — any status codes, not just `402`.
- The decision request carries the exact request authority, method, path/query, replayability, response status and headers, trace context, and sandbox identity. Response bodies are never sent to the handler.
- The handler may authorize one exact replay with extra headers; the destination cannot change and connection/framing headers are rejected.
- Replay outcome (transport status, receipt header, trace context) is reported to the completion endpoint.
- Fail-safe posture: requests over `proxy.max_request_body_bytes` proceed normally but are marked non-replayable — if challenged, the workload gets the original response. Handler failures likewise preserve the original response.
- Handler endpoints require HTTPS unless loopback, or `IRON_RESPONSE_RETRY_HANDLER_ALLOW_HTTP=true` is explicitly set for a trusted internal network.

## Example uses

- **Payments:** a `402` + `WWW-Authenticate: Payment` challenge answered by an external payment signer, keeping payment keys out of the proxy.
- **Credential brokering:** a `401` answered with a freshly minted token from a broker service.
- **Custom challenge/response:** any protocol keyed on a status code, without teaching the proxy the protocol.