### PR TITLE
fix: allow configured retry handlers in denied private CIDRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ trusted internal network. Redirects are rejected, and the response retry token
 must be configured independently from the control-plane token. WebSocket,
 gRPC, and unknown-length streaming requests bypass response retry handling.
 
+When a trusted handler resolves inside `proxy.upstream_deny_cidrs`, set
+`IRON_RESPONSE_RETRY_HANDLER_ALLOW_CIDRS` to a comma-separated list of the
+narrow private CIDRs it may use. This exception applies only to the exact
+configured authorize and complete endpoints; ordinary proxied traffic remains
+subject to the full upstream deny list. Public, loopback, link-local, and cloud
+metadata ranges cannot be added through this setting.
+
 ### Allowlist
 
 Default-deny. Requests must match at least one domain glob or CIDR to proceed.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -775,6 +775,7 @@ func responseRetryHandlerFromEnv(getenv func(string) string, timeout time.Durati
 		Statuses:          statuses,
 		AllowHTTP:         allowHTTP,
 		CompletionHeaders: splitCommaSeparated(completionHeaders),
+		AllowCIDRs:        splitCommaSeparated(getenv("IRON_RESPONSE_RETRY_HANDLER_ALLOW_CIDRS")),
 		Resolver:          resolver,
 		Guard:             guard,
 		ClientTimeout:     timeout,

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -65,12 +65,13 @@ func TestSplitCommaSeparated(t *testing.T) {
 
 func TestResponseRetryHandlerFromEnv(t *testing.T) {
 	base := map[string]string{
-		"IRON_RESPONSE_RETRY_HANDLER_URL":        "http://127.0.0.1/authorize",
-		"IRON_RESPONSE_RETRY_COMPLETE_URL":       "http://127.0.0.1/complete",
-		"IRON_RESPONSE_RETRY_HANDLER_TOKEN":      "handler-token",
-		"IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID": "sandbox-1",
-		"IRON_RESPONSE_RETRY_STATUSES":           "402,409",
-		"IRON_RESPONSE_RETRY_COMPLETION_HEADERS": "X-Receipt",
+		"IRON_RESPONSE_RETRY_HANDLER_URL":         "http://127.0.0.1/authorize",
+		"IRON_RESPONSE_RETRY_COMPLETE_URL":        "http://127.0.0.1/complete",
+		"IRON_RESPONSE_RETRY_HANDLER_TOKEN":       "handler-token",
+		"IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID":  "sandbox-1",
+		"IRON_RESPONSE_RETRY_STATUSES":            "402,409",
+		"IRON_RESPONSE_RETRY_COMPLETION_HEADERS":  "X-Receipt",
+		"IRON_RESPONSE_RETRY_HANDLER_ALLOW_CIDRS": "10.43.0.0/16",
 	}
 
 	handler, statuses, err := responseRetryHandlerFromEnv(mapEnv(base), time.Second, nil, nil)
@@ -78,6 +79,37 @@ func TestResponseRetryHandlerFromEnv(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, handler)
 	require.Equal(t, []int{402, 409}, statuses)
+}
+
+func TestResponseRetryHandlerFromEnvRejectsUnsafeAllowCIDRs(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "missing prefix", value: "10.43.0.1", want: "must use CIDR notation"},
+		{name: "public range", value: "203.0.113.0/24", want: "private address range"},
+		{name: "link local", value: "169.254.0.0/16", want: "private address range"},
+		{name: "IPv6 metadata", value: "fd00::/8", want: "metadata address"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := map[string]string{
+				"IRON_RESPONSE_RETRY_HANDLER_URL":         "http://127.0.0.1/authorize",
+				"IRON_RESPONSE_RETRY_COMPLETE_URL":        "http://127.0.0.1/complete",
+				"IRON_RESPONSE_RETRY_HANDLER_TOKEN":       "handler-token",
+				"IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID":  "sandbox-1",
+				"IRON_RESPONSE_RETRY_STATUSES":            "402",
+				"IRON_RESPONSE_RETRY_HANDLER_ALLOW_CIDRS": tc.value,
+			}
+
+			handler, _, err := responseRetryHandlerFromEnv(mapEnv(env), time.Second, nil, nil)
+
+			require.Nil(t, handler)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
 }
 
 func TestResponseRetryHandlerFromEnvDisabled(t *testing.T) {

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -39,6 +39,16 @@ var forbiddenRetryHeaders = map[string]struct{}{
 
 const defaultClientTimeout = 10 * time.Second
 
+var (
+	privateNetworks = []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("fc00::/7"),
+	}
+	ipv6MetadataAddress = netip.MustParseAddr("fd00:ec2::254")
+)
+
 // Handler asks a trusted service whether a bounded upstream response should
 // be retried and reports the result of the one permitted replay.
 type Handler struct {
@@ -60,6 +70,7 @@ type Options struct {
 	Statuses          []int
 	AllowHTTP         bool
 	CompletionHeaders []string
+	AllowCIDRs        []string
 	Resolver          *net.Resolver
 	Guard             *dnsguard.Guard
 	ClientTimeout     time.Duration
@@ -132,6 +143,10 @@ func New(opts Options) (*Handler, error) {
 	if len(statusSet) == 0 {
 		return nil, fmt.Errorf("at least one response retry status is required")
 	}
+	allowCIDRs, err := parsePrivateCIDRs(opts.AllowCIDRs)
+	if err != nil {
+		return nil, fmt.Errorf("response retry handler allow CIDRs: %w", err)
+	}
 	completionHeaders := make(map[string]struct{}, len(opts.CompletionHeaders))
 	for _, name := range opts.CompletionHeaders {
 		if !httpguts.ValidHeaderFieldName(name) {
@@ -146,7 +161,14 @@ func New(opts Options) (*Handler, error) {
 		sandboxID:         opts.SandboxID,
 		statuses:          statusSet,
 		completionHeaders: completionHeaders,
-		client:            hardenedClient(opts.Client, opts.Resolver, opts.Guard, opts.ClientTimeout),
+		client: hardenedClient(
+			opts.Client,
+			opts.Resolver,
+			opts.Guard,
+			opts.ClientTimeout,
+			allowCIDRs,
+			[]*url.URL{authorizeURL, completeURL},
+		),
 	}, nil
 }
 
@@ -292,6 +314,9 @@ func parseEndpoint(endpoint string, allowHTTP bool) (*url.URL, error) {
 	if err != nil || !u.IsAbs() || u.Host == "" || u.User != nil {
 		return nil, fmt.Errorf("response retry handler URL must be absolute without credentials")
 	}
+	if u.Fragment != "" {
+		return nil, fmt.Errorf("response retry handler URL must not contain a fragment")
+	}
 	httpAllowed := u.Scheme == "http" && (allowHTTP || isLoopback(u.Hostname()))
 	if u.Scheme != "https" && !httpAllowed {
 		return nil, fmt.Errorf("response retry handler URL must use HTTPS unless HTTP is explicitly allowed")
@@ -299,9 +324,16 @@ func parseEndpoint(endpoint string, allowHTTP bool) (*url.URL, error) {
 	return u, nil
 }
 
-func hardenedClient(client *http.Client, resolver *net.Resolver, guard *dnsguard.Guard, timeout time.Duration) *http.Client {
+func hardenedClient(
+	client *http.Client,
+	resolver *net.Resolver,
+	guard *dnsguard.Guard,
+	timeout time.Duration,
+	allowCIDRs []netip.Prefix,
+	endpoints []*url.URL,
+) *http.Client {
 	if client == nil {
-		client = &http.Client{Transport: newHandlerTransport(resolver, guard)}
+		client = &http.Client{Transport: newHandlerTransport(resolver, guard, allowCIDRs, endpoints)}
 	}
 	result := *client
 	if result.Timeout <= 0 {
@@ -317,33 +349,123 @@ func hardenedClient(client *http.Client, resolver *net.Resolver, guard *dnsguard
 }
 
 type handlerTransport struct {
-	guarded  http.RoundTripper
-	loopback http.RoundTripper
+	guarded          http.RoundTripper
+	loopback         http.RoundTripper
+	allowedEndpoints map[string]struct{}
 }
 
-func newHandlerTransport(resolver *net.Resolver, guard *dnsguard.Guard) http.RoundTripper {
+func newHandlerTransport(
+	resolver *net.Resolver,
+	guard *dnsguard.Guard,
+	allowCIDRs []netip.Prefix,
+	endpoints []*url.URL,
+) http.RoundTripper {
 	guardedDialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Resolver:  resolver,
-		Control:   guard.DialControl,
+		Control:   handlerDialControl(guard, allowCIDRs),
 	}
 	loopbackDialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Control:   loopbackOnlyDialControl,
 	}
+	allowedEndpoints := make(map[string]struct{}, len(endpoints))
+	for _, endpoint := range endpoints {
+		allowedEndpoints[handlerEndpointKey(endpoint)] = struct{}{}
+	}
 	return &handlerTransport{
-		guarded:  newHTTPTransport(guardedDialer),
-		loopback: newHTTPTransport(loopbackDialer),
+		guarded:          newHTTPTransport(guardedDialer),
+		loopback:         newHTTPTransport(loopbackDialer),
+		allowedEndpoints: allowedEndpoints,
 	}
 }
 
 func (t *handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, allowed := t.allowedEndpoints[handlerEndpointKey(req.URL)]; !allowed || req.Method != http.MethodPost {
+		return nil, fmt.Errorf("response retry transport rejected unconfigured request")
+	}
 	if isLoopback(req.URL.Hostname()) {
 		return t.loopback.RoundTrip(req)
 	}
 	return t.guarded.RoundTrip(req)
+}
+
+func handlerEndpointKey(endpoint *url.URL) string {
+	port := endpoint.Port()
+	if port == "" {
+		if strings.EqualFold(endpoint.Scheme, "https") {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	path := endpoint.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	return strings.ToLower(endpoint.Scheme) + "\x00" +
+		net.JoinHostPort(strings.ToLower(endpoint.Hostname()), port) + "\x00" +
+		path + "\x00" + endpoint.RawQuery
+}
+
+func handlerDialControl(guard *dnsguard.Guard, allowCIDRs []netip.Prefix) func(string, string, syscall.RawConn) error {
+	return func(network string, address string, connection syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		addr, err := netip.ParseAddr(host)
+		if err == nil {
+			addr = addr.Unmap()
+			if guard.IsDenied(addr) && prefixContains(allowCIDRs, addr) {
+				return nil
+			}
+		}
+		return guard.DialControl(network, address, connection)
+	}
+}
+
+func parsePrivateCIDRs(cidrs []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(cidrs))
+	for _, raw := range cidrs {
+		value := strings.TrimSpace(raw)
+		if value == "" || !strings.Contains(value, "/") {
+			return nil, fmt.Errorf("invalid CIDR %q: must use CIDR notation", raw)
+		}
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q: %w", raw, err)
+		}
+		prefix = prefix.Masked()
+		if !prefixWithin(prefix, privateNetworks) {
+			return nil, fmt.Errorf("CIDR %q must be within a private address range", raw)
+		}
+		if prefix.Contains(ipv6MetadataAddress) {
+			return nil, fmt.Errorf("CIDR %q includes a metadata address", raw)
+		}
+		prefixes = append(prefixes, prefix)
+	}
+	return prefixes, nil
+}
+
+func prefixWithin(prefix netip.Prefix, networks []netip.Prefix) bool {
+	for _, network := range networks {
+		if prefix.Bits() >= network.Bits() && network.Contains(prefix.Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+func prefixContains(prefixes []netip.Prefix, addr netip.Addr) bool {
+	for _, prefix := range prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 func newHTTPTransport(dialer *net.Dialer) *http.Transport {

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,6 +21,12 @@ import (
 )
 
 const testAttemptID = "8ace71a1-4e12-47e5-9df4-f2f660db6a82"
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func testOptions(endpoint string, client *http.Client) Options {
 	return Options{
@@ -185,6 +193,13 @@ func TestNewValidatesConfiguration(t *testing.T) {
 			want: "without credentials",
 		},
 		{
+			name: "URL fragment",
+			mutate: func(opts *Options) {
+				opts.AuthorizeEndpoint = "https://handler.example/authorize#fragment"
+			},
+			want: "must not contain a fragment",
+		},
+		{
 			name: "missing token",
 			mutate: func(opts *Options) {
 				opts.Token = ""
@@ -218,6 +233,41 @@ func TestNewValidatesConfiguration(t *testing.T) {
 				opts.CompletionHeaders = []string{"Bad Header"}
 			},
 			want: "invalid completion response header",
+		},
+		{
+			name: "allow address without prefix",
+			mutate: func(opts *Options) {
+				opts.AllowCIDRs = []string{"10.43.0.1"}
+			},
+			want: "must use CIDR notation",
+		},
+		{
+			name: "malformed allow CIDR",
+			mutate: func(opts *Options) {
+				opts.AllowCIDRs = []string{"10.43.0.0/99"}
+			},
+			want: "invalid CIDR",
+		},
+		{
+			name: "public allow CIDR",
+			mutate: func(opts *Options) {
+				opts.AllowCIDRs = []string{"203.0.113.0/24"}
+			},
+			want: "must be within a private address range",
+		},
+		{
+			name: "link-local allow CIDR",
+			mutate: func(opts *Options) {
+				opts.AllowCIDRs = []string{"169.254.0.0/16"}
+			},
+			want: "must be within a private address range",
+		},
+		{
+			name: "IPv6 metadata allow CIDR",
+			mutate: func(opts *Options) {
+				opts.AllowCIDRs = []string{"fd00::/8"}
+			},
+			want: "includes a metadata address",
 		},
 	}
 
@@ -412,7 +462,7 @@ func TestHandlerCompleteDoesNotRetryClientFailure(t *testing.T) {
 func TestHardenedClientDoesNotMutateInputClient(t *testing.T) {
 	originalRedirect := func(_ *http.Request, _ []*http.Request) error { return fmt.Errorf("original") }
 	client := &http.Client{CheckRedirect: originalRedirect}
-	hardened := hardenedClient(client, nil, nil, 0)
+	hardened := hardenedClient(client, nil, nil, 0, nil, nil)
 
 	require.NotSame(t, client, hardened)
 	require.Zero(t, client.Timeout)
@@ -479,6 +529,137 @@ func TestHandlerClientAllowsExplicitLoopbackDespiteGuard(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, retry)
 	require.Nil(t, decision)
+}
+
+func TestParsePrivateCIDRs(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  netip.Prefix
+	}{
+		{name: "ten", value: "10.43.0.1/16", want: netip.MustParsePrefix("10.43.0.0/16")},
+		{name: "172", value: "172.20.0.0/16", want: netip.MustParsePrefix("172.20.0.0/16")},
+		{name: "192", value: "192.168.10.0/24", want: netip.MustParsePrefix("192.168.10.0/24")},
+		{name: "IPv6 ULA", value: "fd12:3456::/48", want: netip.MustParsePrefix("fd12:3456::/48")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefixes, err := parsePrivateCIDRs([]string{tc.value})
+			require.NoError(t, err)
+			require.Equal(t, []netip.Prefix{tc.want}, prefixes)
+		})
+	}
+}
+
+func TestHandlerDialControlAllowsOnlyConfiguredPrivateCIDRs(t *testing.T) {
+	guard, err := dnsguard.New([]string{
+		"10.42.0.0/16",
+		"10.43.0.0/16",
+		"169.254.0.0/16",
+		"203.0.113.0/24",
+		"fd00::/8",
+	})
+	require.NoError(t, err)
+	allowCIDRs, err := parsePrivateCIDRs([]string{"10.43.0.0/16", "fd12:3456::/48"})
+	require.NoError(t, err)
+	control := handlerDialControl(guard, allowCIDRs)
+
+	cases := []struct {
+		name    string
+		address string
+		allowed bool
+	}{
+		{name: "configured service CIDR", address: "10.43.5.10:8090", allowed: true},
+		{name: "mapped configured service CIDR", address: "[::ffff:10.43.5.10]:8090", allowed: true},
+		{name: "configured IPv6 ULA", address: "[fd12:3456::10]:8090", allowed: true},
+		{name: "ordinary allowed address", address: "8.8.8.8:443", allowed: true},
+		{name: "malformed address deferred to dialer", address: "not-an-address", allowed: true},
+		{name: "different private CIDR", address: "10.42.5.10:8090", allowed: false},
+		{name: "IPv4 metadata", address: "169.254.169.254:80", allowed: false},
+		{name: "IPv6 metadata", address: "[fd00:ec2::254]:80", allowed: false},
+		{name: "denied public CIDR", address: "203.0.113.10:443", allowed: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := control("tcp", tc.address, nil)
+			if tc.allowed {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.True(t, dnsguard.IsDenyError(err))
+			}
+		})
+	}
+
+	err = guard.DialControl("tcp", "10.43.5.10:8090", nil)
+	require.Error(t, err)
+	require.True(t, dnsguard.IsDenyError(err), "the handler exception must not modify the shared guard")
+}
+
+func TestHandlerTransportAllowsOnlyConfiguredEndpoints(t *testing.T) {
+	authorizeEndpoint, err := url.Parse("https://handler.internal/authorize?realm=payments")
+	require.NoError(t, err)
+	completeEndpoint, err := url.Parse("https://handler.internal/complete")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name    string
+		method  string
+		request string
+		allowed bool
+	}{
+		{name: "authorize", request: "https://handler.internal/authorize?realm=payments", allowed: true},
+		{name: "complete", request: "https://handler.internal/complete", allowed: true},
+		{name: "explicit default port", request: "https://handler.internal:443/complete", allowed: true},
+		{name: "different authority", request: "https://other.internal/authorize?realm=payments", allowed: false},
+		{name: "different port", request: "https://handler.internal:8443/complete", allowed: false},
+		{name: "downgraded scheme", request: "http://handler.internal/complete", allowed: false},
+		{name: "different path", request: "https://handler.internal/admin", allowed: false},
+		{name: "missing query", request: "https://handler.internal/authorize", allowed: false},
+		{name: "different query", request: "https://handler.internal/authorize?realm=other", allowed: false},
+		{name: "different method", method: http.MethodGet, request: "https://handler.internal/complete", allowed: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int64
+			roundTripper := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			})
+			transport := &handlerTransport{
+				guarded:  roundTripper,
+				loopback: roundTripper,
+				allowedEndpoints: map[string]struct{}{
+					handlerEndpointKey(authorizeEndpoint): {},
+					handlerEndpointKey(completeEndpoint):  {},
+				},
+			}
+			method := tc.method
+			if method == "" {
+				method = http.MethodPost
+			}
+			req, err := http.NewRequest(method, tc.request, nil)
+			require.NoError(t, err)
+
+			resp, err := transport.RoundTrip(req)
+			if tc.allowed {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.NoError(t, resp.Body.Close())
+				require.EqualValues(t, 1, calls.Load())
+			} else {
+				require.ErrorContains(t, err, "unconfigured request")
+				require.Nil(t, resp)
+				require.Zero(t, calls.Load())
+			}
+		})
+	}
 }
 
 func TestSelectedHeadersIsCaseInsensitive(t *testing.T) {


### PR DESCRIPTION
## Motivation

Response retry handlers may be trusted cluster-internal services whose addresses are intentionally covered by the proxy's global upstream deny list. Those handlers currently cannot be reached without weakening ordinary proxy egress protections.

## Summary

- Add `IRON_RESPONSE_RETRY_HANDLER_ALLOW_CIDRS` for narrow private handler ranges.
- Bind the dedicated handler transport to the exact configured POST endpoints.
- Reject public, loopback, link-local, and metadata CIDR exceptions.
- Preserve dial-time DNS validation, redirect rejection, and the unchanged shared upstream guard.
- Document the configuration and security boundary.

## Key design considerations

- The exception exists only in the response retry transport; sandbox-originated proxy traffic continues using the full deny list.
- An exception applies only when the resolved address is both globally denied and inside an explicitly configured private CIDR.
- Scheme, authority, port, path, query, and method substitutions are rejected before dialing.
- Dial validation still occurs in `net.Dialer.Control` after resolution and on the address used by the socket.
