### PR TITLE
fix: include upstream scheme in retry decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Set `IRON_RESPONSE_RETRY_HANDLER_URL`,
 `IRON_RESPONSE_RETRY_COMPLETE_URL`, `IRON_RESPONSE_RETRY_HANDLER_TOKEN`,
 `IRON_RESPONSE_RETRY_HANDLER_SANDBOX_ID`, and a comma-separated
 `IRON_RESPONSE_RETRY_STATUSES` list to enable externally authorized response
-retries. The authorization handler receives the exact authority, method,
+retries. The authorization handler receives the exact upstream scheme, authority, method,
 path/query, replayability, response status and headers, trace context, and
 sandbox identity. It may return request headers plus an attempt ID for one
 exact replay. The completion handler then receives the replay status and

--- a/internal/proxy/integration_test.go
+++ b/internal/proxy/integration_test.go
@@ -134,6 +134,7 @@ func TestIntegration_ResponseHandlerReturnsOriginalChallengeForOversizedRequest(
 		authorizeCalls++
 		var payload responseretry.DecisionRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		require.Equal(t, "http", payload.Scheme)
 		require.False(t, payload.Replayable)
 		_, _ = w.Write([]byte(`{"retry":false,"headers":{}}`))
 	}))

--- a/internal/responseretry/handler.go
+++ b/internal/responseretry/handler.go
@@ -79,6 +79,7 @@ type Options struct {
 // DecisionRequest describes the completed request and response. Request and
 // response bodies are deliberately excluded.
 type DecisionRequest struct {
+	Scheme          string              `json:"scheme"`
 	Host            string              `json:"host"`
 	Method          string              `json:"method"`
 	Path            string              `json:"path"`
@@ -182,6 +183,7 @@ func (h *Handler) Decide(ctx context.Context, req *http.Request, resp *http.Resp
 		path += "?" + req.URL.RawQuery
 	}
 	payload, err := json.Marshal(DecisionRequest{
+		Scheme:          req.URL.Scheme,
 		Host:            req.URL.Host,
 		Method:          req.Method,
 		Path:            path,

--- a/internal/responseretry/handler_test.go
+++ b/internal/responseretry/handler_test.go
@@ -46,6 +46,7 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 		require.Equal(t, "Bearer proxy-token", r.Header.Get("Authorization"))
 		var request DecisionRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, "https", request.Scheme)
 		require.Equal(t, "service.example", request.Host)
 		require.Equal(t, "/v1/search?q=one", request.Path)
 		require.Equal(t, "sandbox-1", request.SandboxID)
@@ -107,6 +108,40 @@ func TestHandlerAuthorizeAndComplete(t *testing.T) {
 		25*time.Millisecond,
 		50*time.Millisecond,
 	))
+}
+
+func TestHandlerReportsExactUpstreamScheme(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "HTTPS", target: "https://service.example/paid", want: "https"},
+		{name: "HTTP", target: "http://service.example/paid", want: "http"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request DecisionRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+				require.Equal(t, tc.want, request.Scheme)
+				_, err := w.Write([]byte(`{"retry":false,"headers":{}}`))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+			handler, err := New(testOptions(server.URL, server.Client()))
+			require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodGet, tc.target, nil)
+			require.NoError(t, err)
+
+			decision, retry, err := handler.Decide(context.Background(), req, &http.Response{StatusCode: http.StatusPaymentRequired}, true)
+
+			require.NoError(t, err)
+			require.False(t, retry)
+			require.Nil(t, decision)
+		})
+	}
 }
 
 func TestHandlerSkipsUnconfiguredStatus(t *testing.T) {


### PR DESCRIPTION
## Motivation

Response retry authorizers need the original upstream scheme to distinguish encrypted HTTPS requests from plaintext HTTP requests before returning sensitive replay headers.

## Summary

- include the exact upstream URL scheme in authorization decision payloads
- cover HTTP and HTTPS scheme propagation in handler tests
- assert the scheme across the proxy integration path
- document the expanded retry-handler contract

## Key design considerations

- the wire change is additive and keeps iron-proxy protocol-neutral
- the scheme comes directly from the immutable upstream request URL
- request and response bodies remain excluded from handler payloads