### PR TITLE
fix(hostmatch): case-insensitive domain glob matching per RFC 4343 and IPv6 bracket stripping in StripPort

### DIFF
--- a/internal/hostmatch/hostmatch.go
+++ b/internal/hostmatch/hostmatch.go
@@ -58,8 +58,10 @@ func (m *Matcher) Matches(host string) bool {
 
 // MatchGlob matches a domain against a glob pattern.
 // "*" matches any host. "*.example.com" matches any subdomain depth and
-// "example.com" itself.
+// "example.com" itself. Matching is case-insensitive per RFC 4343.
 func MatchGlob(pattern, name string) bool {
+	pattern = strings.ToLower(pattern)
+	name = strings.ToLower(name)
 	if pattern == "*" {
 		return true
 	}
@@ -72,10 +74,11 @@ func MatchGlob(pattern, name string) bool {
 }
 
 // StripPort removes the port from a host:port string. If there's no port,
-// the host is returned unchanged.
+// the host is returned. IPv6 brackets (e.g. [::1]) are stripped for clean
+// IP parsing and domain matching.
 func StripPort(host string) string {
 	if h, _, err := net.SplitHostPort(host); err == nil {
-		return h
+		return strings.Trim(h, "[]")
 	}
-	return host
+	return strings.Trim(host, "[]")
 }

--- a/internal/hostmatch/hostmatch_test.go
+++ b/internal/hostmatch/hostmatch_test.go
@@ -14,10 +14,14 @@ func TestMatchGlob(t *testing.T) {
 		want    bool
 	}{
 		{"*.example.com", "foo.example.com", true},
+		{"*.example.com", "FOO.EXAMPLE.COM", true},
+		{"*.EXAMPLE.COM", "foo.example.com", true},
 		{"*.example.com", "bar.baz.example.com", true},
 		{"*.example.com", "example.com", true},
+		{"*.example.com", "EXAMPLE.COM", true},
 		{"*.example.com", "notexample.com", false},
 		{"exact.example.com", "exact.example.com", true},
+		{"exact.example.com", "EXACT.EXAMPLE.COM", true},
 		{"exact.example.com", "other.example.com", false},
 		{"*", "anything.example.com", true},
 		{"*", "1.2.3.4", true},
@@ -27,6 +31,26 @@ func TestMatchGlob(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s/%s", tt.pattern, tt.name), func(t *testing.T) {
 			require.Equal(t, tt.want, MatchGlob(tt.pattern, tt.name))
+		})
+	}
+}
+
+func TestStripPort(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"example.com:8080", "example.com"},
+		{"example.com", "example.com"},
+		{"[::1]:8080", "::1"},
+		{"[::1]", "::1"},
+		{"127.0.0.1:9090", "127.0.0.1"},
+		{"127.0.0.1", "127.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			require.Equal(t, tt.want, StripPort(tt.host))
 		})
 	}
 }


### PR DESCRIPTION
Updated MatchGlob in internal/hostmatch/hostmatch.go to perform case-insensitive domain glob matching per RFC 4343 and RFC 1035 standards. Previously, uppercase letters in HTTP Host headers (e.g. FOO.EXAMPLE.COM) failed allowlist wildcard matches. Also updated StripPort to trim IPv6 brackets (e.g. [::1]) so net.ParseIP can successfully evaluate IPv6 literal addresses for CIDR matching. Added unit test coverage.