### PR TITLE
feat: route Postgres policies by startup selector

### DIFF
--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -598,7 +598,7 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 	synced := make([]*postgres.Upstream, 0, len(entries))
 	seen := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		u, err := postgres.NewManagedUpstream(e.Database, e.DSN, e.Role, e.Settings)
+		u, err := postgres.NewManagedRoute(e.Database, e.ForeignID, e.DSN, e.Role, e.Settings)
 		if err != nil {
 			logger.Error("skipping synced postgres upstream: invalid upstream",
 				slog.String("foreign_id", e.ForeignID),
@@ -606,14 +606,15 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 			)
 			continue
 		}
-		if seen[u.Database()] {
-			logger.Warn("skipping synced postgres upstream: duplicate database",
+		key := u.Database() + "\x00" + u.Route()
+		if seen[key] {
+			logger.Warn("skipping synced postgres upstream: duplicate route",
 				slog.String("foreign_id", e.ForeignID),
 				slog.String("database", u.Database()),
 			)
 			continue
 		}
-		seen[u.Database()] = true
+		seen[key] = true
 		synced = append(synced, u)
 	}
 
@@ -621,9 +622,9 @@ func postgresListenerFromSync(local *postgres.Listener, getenv func(string) stri
 	// address and client credential. Local wins on a database collision.
 	if local != nil {
 		merged, dropped := local.WithUpstreams(synced)
-		for _, db := range dropped {
-			logger.Warn("skipping synced postgres upstream: duplicate database",
-				slog.String("database", db))
+		for _, route := range dropped {
+			logger.Warn("skipping synced postgres upstream: duplicate route",
+				slog.String("route", route))
 		}
 		return merged, true
 	}

--- a/cmd/iron-proxy/main_test.go
+++ b/cmd/iron-proxy/main_test.go
@@ -232,10 +232,10 @@ func TestPostgresListenerFromSync_LocalWinsOnCollision(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, listener)
 	require.Len(t, listener.Upstreams(), 1, "the synced upstream colliding with the local one is dropped")
-	require.Contains(t, logBuf.String(), "duplicate database")
+	require.Contains(t, logBuf.String(), "duplicate route")
 }
 
-func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
+func TestPostgresListenerFromSync_SameDatabaseRoutesRetained(t *testing.T) {
 	raw := json.RawMessage(`[
 		{"id":"pgs_1","foreign_id":"a","database":"shared","dsn":{"type":"env","var":"PG_DSN"}},
 		{"id":"pgs_2","foreign_id":"b","database":"shared","dsn":{"type":"env","var":"PG_DSN"}}
@@ -246,9 +246,14 @@ func TestPostgresListenerFromSync_DuplicateSyncedDatabaseDropped(t *testing.T) {
 	listener, ok := postgresListenerFromSync(nil, mapEnv(pgListenerEnv()), logger, raw)
 	require.True(t, ok)
 	require.NotNil(t, listener)
-	require.Len(t, listener.Upstreams(), 1)
-	require.NotNil(t, listener.Upstream("shared"))
-	require.Contains(t, logBuf.String(), "duplicate database")
+	require.Len(t, listener.Upstreams(), 2)
+	require.Nil(t, listener.Upstream("shared"), "multiple routes require an explicit selector")
+	a, err := listener.SelectUpstream("shared", "a")
+	require.NoError(t, err)
+	require.Equal(t, "a", a.Route())
+	b, err := listener.SelectUpstream("shared", "b")
+	require.NoError(t, err)
+	require.Equal(t, "b", b.Route())
 }
 
 func TestPostgresListenerFromSync_InvalidPayload(t *testing.T) {

--- a/integration_test/postgres_test.go
+++ b/integration_test/postgres_test.go
@@ -459,19 +459,23 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 
 	pgAddr := proxy.AddrFor(t, "postgres proxy starting")
 
-	// connStrTo selects an upstream by the database name the client requests.
-	// Every upstream lives on the same listener; only the database differs.
-	connStrTo := func(database string) string {
+	connConfigTo := func(t *testing.T, database, route string) *pgconn.Config {
+		t.Helper()
 		host, port, _ := net.SplitHostPort(pgAddr)
-		return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
-			pgClientUser, pgClientPassword, host, port, database)
+		config, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+			pgClientUser, pgClientPassword, host, port, database))
+		require.NoError(t, err)
+		if route != "" {
+			config.RuntimeParams["iron.route"] = route
+		}
+		return config
 	}
 
-	queryScalar := func(t *testing.T, database, sql string) string {
+	queryScalar := func(t *testing.T, database, route, sql string) string {
 		t.Helper()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		conn, err := pgconn.Connect(ctx, connStrTo(database))
+		conn, err := pgconn.ConnectConfig(ctx, connConfigTo(t, database, route))
 		require.NoError(t, err)
 		defer func() { _ = conn.Close(context.Background()) }()
 		results, err := conn.Exec(ctx, sql).ReadAll()
@@ -482,11 +486,13 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 	}
 
 	t.Run("each upstream routes to its own database and role", func(t *testing.T) {
-		require.Equal(t, "appdb", queryScalar(t, "appdb", "SELECT current_database()"))
-		require.Equal(t, "tenant_role", queryScalar(t, "appdb", "SELECT current_role"))
+		require.Equal(t, "appdb", queryScalar(t, "appdb", "tenant", "SELECT current_database()"))
+		require.Equal(t, "tenant_role", queryScalar(t, "appdb", "tenant", "SELECT current_role"))
+		require.Equal(t, "appdb", queryScalar(t, "appdb", "other-role", "SELECT current_database()"))
+		require.Equal(t, "other_role", queryScalar(t, "appdb", "other-role", "SELECT current_role"))
 
-		require.Equal(t, "otherdb", queryScalar(t, "otherdb", "SELECT current_database()"))
-		require.Equal(t, "other_role", queryScalar(t, "otherdb", "SELECT current_role"))
+		require.Equal(t, "otherdb", queryScalar(t, "otherdb", "", "SELECT current_database()"))
+		require.Equal(t, "other_role", queryScalar(t, "otherdb", "", "SELECT current_role"))
 	})
 
 	t.Run("role scopes rows via rls on the appdb upstream", func(t *testing.T) {
@@ -495,12 +501,38 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 
 		// The appdb upstream injects tenant_role, so RLS scopes the client to
 		// tenant_role's rows.
-		client, err := pgx.Connect(ctx, connStrTo("appdb"))
+		host, port, _ := net.SplitHostPort(pgAddr)
+		config, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+			pgClientUser, pgClientPassword, host, port, "appdb"))
+		require.NoError(t, err)
+		config.RuntimeParams["iron.route"] = "tenant"
+		client, err := pgx.ConnectConfig(ctx, config)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = client.Close(ctx) })
 		var count int
 		require.NoError(t, client.QueryRow(ctx, "SELECT count(*) FROM items").Scan(&count))
 		require.Equal(t, 2, count, "appdb upstream should see only tenant_role's rows")
+	})
+
+	t.Run("ambiguous database without route is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := pgconn.ConnectConfig(ctx, connConfigTo(t, "appdb", ""))
+		require.Error(t, err)
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
+		require.Equal(t, "3D000", pgErr.Code)
+		require.Contains(t, pgErr.Message, "iron.route")
+	})
+
+	t.Run("unknown route is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := pgconn.ConnectConfig(ctx, connConfigTo(t, "appdb", "unknown"))
+		require.Error(t, err)
+		var pgErr *pgconn.PgError
+		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
+		require.Equal(t, "3D000", pgErr.Code)
 	})
 
 	t.Run("database not matching the dsn is rejected", func(t *testing.T) {
@@ -509,7 +541,7 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 		// the client on appdb.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_, err := pgconn.Connect(ctx, connStrTo("mismatch"))
+		_, err := pgconn.ConnectConfig(ctx, connConfigTo(t, "mismatch", ""))
 		require.Error(t, err, "an upstream whose DSN database differs from its route database must be rejected")
 		var pgErr *pgconn.PgError
 		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)
@@ -520,7 +552,7 @@ func TestPostgresMultipleUpstreams(t *testing.T) {
 	t.Run("unknown database is rejected", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_, err := pgconn.Connect(ctx, connStrTo("nonexistent"))
+		_, err := pgconn.ConnectConfig(ctx, connConfigTo(t, "nonexistent", ""))
 		require.Error(t, err, "a database with no matching upstream must be rejected")
 		var pgErr *pgconn.PgError
 		require.True(t, errors.As(err, &pgErr), "want PgError, got %T: %v", err, err)

--- a/integration_test/testdata/postgres_multi_pipeline.yaml
+++ b/integration_test/testdata/postgres_multi_pipeline.yaml
@@ -20,10 +20,18 @@ postgres:
     # Two upstreams routing to two distinct databases, each injecting its own
     # role. Each upstream's database must match the database its DSN connects to.
     - database: appdb
+      route: tenant
       dsn:
         type: env
         var: PG_UPSTREAM_DSN
       role: tenant_role
+
+    - database: appdb
+      route: other-role
+      dsn:
+        type: env
+        var: PG_UPSTREAM_DSN
+      role: other_role
 
     - database: otherdb
       dsn:

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -121,14 +121,12 @@ func MCPFromSync(raw json.RawMessage) (node yaml.Node, present bool, err error) 
 }
 
 // PostgresSyncEntry is one control-plane-synced postgres upstream, mapped to a
-// single route under the managed listener. The DSN, optional role, and routing
-// database come from the control plane; the per-route client credentials are
-// supplied separately via environment variables keyed off ForeignID (see the
-// managed-mode env convention in cmd/iron-proxy).
+// single route under the managed listener. ForeignID is the logical route
+// selector while Database remains the physical database the DSN must name.
 type PostgresSyncEntry struct {
 	ForeignID string
-	// Database is the routing key clients use to reach this upstream. Required:
-	// it must equal the database the DSN connects to, so the control plane must
+	// Database is the physical database clients request in StartupMessage. It
+	// must equal the database the DSN connects to, so the control plane must
 	// supply it explicitly.
 	Database string
 	DSN      secrets.Source

--- a/internal/postgres/config.go
+++ b/internal/postgres/config.go
@@ -24,16 +24,15 @@
 // as every statement passes; a batch is rejected if any statement is rejected.
 // Extended Query, COPY, and prepared statements pass through unchanged.
 //
-// The proxy runs a single postgres listener fronting multiple upstream
-// databases: the top-level postgres: block is one object with a listen address
-// and a list of upstreams. An upstream is selected by the database name the
-// client supplies in its startup message; each upstream has its own DSN, client
-// credentials, and optional injected role. One listen address therefore serves
-// many databases.
+// The proxy runs a single postgres listener fronting multiple upstream routes.
+// A route is selected by the database name and optional iron.route value the
+// client supplies in its startup message. The selector allows multiple policy
+// routes to share one physical database without weakening role isolation.
 package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -54,7 +53,7 @@ type SourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
 const listenerName = "postgres"
 
 // ListenerConfig is the top-level postgres: block — a single bind address and
-// one shared client credential fronting a set of database-keyed upstreams.
+// one shared client credential fronting a set of database-and-route upstreams.
 type ListenerConfig struct {
 	// Listen is the proxy's bind address for client connections, e.g. ":5432".
 	Listen string `yaml:"listen"`
@@ -71,9 +70,9 @@ type ListenerConfig struct {
 	Upstreams []UpstreamConfig `yaml:"upstreams"`
 }
 
-// UpstreamConfig describes one upstream database reachable through the listener.
+// UpstreamConfig describes one upstream route reachable through the listener.
 // The client selects it by sending its Database value as the startup "database"
-// parameter.
+// parameter and, when needed, its Route as the startup "iron.route" parameter.
 type UpstreamConfig struct {
 	// Database is the routing key: the database name a client must request to
 	// reach this upstream. Required and must be unique across upstreams. It must
@@ -81,6 +80,11 @@ type UpstreamConfig struct {
 	// proxy rejects a connection whose upstream session would land on a
 	// different database than the client named.
 	Database string `yaml:"database"`
+
+	// Route distinguishes policy routes that share one physical database. It is
+	// optional while Database has only one upstream, and required when multiple
+	// upstreams use the same Database.
+	Route string `yaml:"route,omitempty"`
 
 	// DSN is the upstream connection string, loaded from any registered secret
 	// source (env, aws_sm, aws_ssm, 1password, 1password_connect) and passed
@@ -131,7 +135,12 @@ type Listener struct {
 	clientUser     string
 	clientPassword string
 
-	upstreams map[string]*Upstream
+	upstreams map[upstreamKey]*Upstream
+}
+
+type upstreamKey struct {
+	database string
+	route    string
 }
 
 // Name returns the listener's name (a fixed identifier surfaced in logs).
@@ -140,9 +149,46 @@ func (l *Listener) Name() string { return l.name }
 // Listen returns the bind address.
 func (l *Listener) Listen() string { return l.listen }
 
-// Upstream returns the upstream for the given database name, or nil if no
-// upstream on this listener serves it.
-func (l *Listener) Upstream(database string) *Upstream { return l.upstreams[database] }
+// Upstream returns the sole upstream for a database. It returns nil when the
+// database is missing or has multiple routes.
+func (l *Listener) Upstream(database string) *Upstream {
+	upstream, _ := l.SelectUpstream(database, "")
+	return upstream
+}
+
+var (
+	ErrNoUpstream    = errors.New("no postgres upstream")
+	ErrRouteRequired = errors.New("postgres route selector required")
+	ErrUnknownRoute  = errors.New("unknown postgres route selector")
+)
+
+// SelectUpstream resolves a physical database and optional logical route. A
+// database with one route remains backward compatible when iron.route is
+// absent. A database with multiple routes fails closed without a selector.
+func (l *Listener) SelectUpstream(database, route string) (*Upstream, error) {
+	if route != "" {
+		upstream := l.upstreams[upstreamKey{database: database, route: route}]
+		if upstream == nil {
+			return nil, ErrUnknownRoute
+		}
+		return upstream, nil
+	}
+
+	var selected *Upstream
+	for key, upstream := range l.upstreams {
+		if key.database != database {
+			continue
+		}
+		if selected != nil {
+			return nil, ErrRouteRequired
+		}
+		selected = upstream
+	}
+	if selected == nil {
+		return nil, ErrNoUpstream
+	}
+	return selected, nil
+}
 
 // Upstreams returns all of the listener's upstreams. The order is unspecified.
 func (l *Listener) Upstreams() []*Upstream {
@@ -163,20 +209,25 @@ func (l *Listener) VerifyClient(user, password string) bool {
 }
 
 // WithUpstreams returns a copy of the listener with extra upstreams added,
-// keeping the listener's address and client credential. An extra upstream whose
-// database already exists is skipped (the existing one wins); its database is
-// returned in dropped so the caller can log it.
+// keeping the listener's address and client credential. A local legacy route
+// without a selector wins any same-database collision; otherwise only an exact
+// database-and-route collision is dropped.
 func (l *Listener) WithUpstreams(extra []*Upstream) (listener *Listener, dropped []string) {
-	m := make(map[string]*Upstream, len(l.upstreams)+len(extra))
-	for db, u := range l.upstreams {
-		m[db] = u
+	m := make(map[upstreamKey]*Upstream, len(l.upstreams)+len(extra))
+	for key, upstream := range l.upstreams {
+		m[key] = upstream
 	}
-	for _, u := range extra {
-		if _, ok := m[u.database]; ok {
-			dropped = append(dropped, u.database)
+	for _, upstream := range extra {
+		if _, ok := m[upstreamKey{database: upstream.database, route: ""}]; ok {
+			dropped = append(dropped, routeLabel(upstream.database, upstream.route))
 			continue
 		}
-		m[u.database] = u
+		key := upstreamKey{database: upstream.database, route: upstream.route}
+		if _, ok := m[key]; ok {
+			dropped = append(dropped, routeLabel(upstream.database, upstream.route))
+			continue
+		}
+		m[key] = upstream
 	}
 	return &Listener{
 		name:           l.name,
@@ -192,6 +243,7 @@ func (l *Listener) WithUpstreams(extra []*Upstream) (listener *Listener, dropped
 // session settings.
 type Upstream struct {
 	database string
+	route    string
 	role     string
 	settings []Setting
 
@@ -206,6 +258,9 @@ type Upstream struct {
 // Database returns the upstream's routing key — the database name a client
 // requests to reach it.
 func (u *Upstream) Database() string { return u.database }
+
+// Route returns the logical selector for this policy route.
+func (u *Upstream) Route() string { return u.route }
 
 // Role returns the role the proxy SETs upstream at session start. Empty
 // means no role is set (the upstream session runs as the connecting user).
@@ -267,7 +322,7 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 		return nil, fmt.Errorf("postgres: client.password_env %q is not set in the environment", c.Client.PasswordEnv)
 	}
 
-	upstreams := make(map[string]*Upstream, len(c.Upstreams))
+	upstreams := make(map[upstreamKey]*Upstream, len(c.Upstreams))
 	for j, uc := range c.Upstreams {
 		uctx := fmt.Sprintf("postgres.upstreams[%d]", j)
 		if uc.Database != "" {
@@ -280,8 +335,9 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 		if uc.DSN.Kind == 0 {
 			return nil, fmt.Errorf("%s: dsn is required", uctx)
 		}
-		if _, ok := upstreams[uc.Database]; ok {
-			return nil, fmt.Errorf("postgres: duplicate upstream database %q", uc.Database)
+		key := upstreamKey{database: uc.Database, route: uc.Route}
+		if _, ok := upstreams[key]; ok {
+			return nil, fmt.Errorf("postgres: duplicate upstream route %q", routeLabel(uc.Database, uc.Route))
 		}
 
 		dsnSource, err := buildSource(uc.DSN, logger)
@@ -294,13 +350,17 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 			return nil, err
 		}
 
-		upstreams[uc.Database] = &Upstream{
+		upstreams[key] = &Upstream{
 			database:   uc.Database,
+			route:      uc.Route,
 			role:       uc.Role,
 			settings:   settings,
 			pinnedGUCs: pinned,
 			dsn:        dsnSource,
 		}
+	}
+	if err := validateRoutes(upstreams); err != nil {
+		return nil, err
 	}
 
 	return &Listener{
@@ -316,8 +376,8 @@ func Compile(c ListenerConfig, logger *slog.Logger, buildSource SourceBuilder) (
 // client credential, and a set of upstreams. It is the construction path for
 // control-plane-synced listeners, whose upstreams are built one at a time via
 // NewManagedUpstream. The listen address and client credential are required,
-// and at least one upstream must be supplied; an upstream whose Database
-// collides with an earlier one is an error.
+// and at least one upstream must be supplied; an upstream whose database and
+// route collide with an earlier one is an error.
 func NewListener(listen, clientUser, clientPassword string, upstreams []*Upstream) (*Listener, error) {
 	if listen == "" {
 		return nil, fmt.Errorf("postgres: listen is required")
@@ -331,12 +391,16 @@ func NewListener(listen, clientUser, clientPassword string, upstreams []*Upstrea
 	if len(upstreams) == 0 {
 		return nil, fmt.Errorf("postgres: at least one upstream is required")
 	}
-	m := make(map[string]*Upstream, len(upstreams))
+	m := make(map[upstreamKey]*Upstream, len(upstreams))
 	for _, u := range upstreams {
-		if _, ok := m[u.database]; ok {
-			return nil, fmt.Errorf("postgres: duplicate upstream database %q", u.database)
+		key := upstreamKey{database: u.database, route: u.route}
+		if _, ok := m[key]; ok {
+			return nil, fmt.Errorf("postgres: duplicate upstream route %q", routeLabel(u.database, u.route))
 		}
-		m[u.database] = u
+		m[key] = u
+	}
+	if err := validateRoutes(m); err != nil {
+		return nil, err
 	}
 	return &Listener{
 		name:           listenerName,
@@ -348,10 +412,16 @@ func NewListener(listen, clientUser, clientPassword string, upstreams []*Upstrea
 }
 
 // NewManagedUpstream builds an Upstream for a control-plane-synced listener. The
-// DSN source, optional role, and optional pinned session settings come from the
-// control plane. Database is the routing key and is required; role and settings
-// are optional. Settings are validated identically to the YAML path.
+// DSN source, route selector, optional role, and optional pinned session
+// settings come from the control plane. Database is required; route, role, and
+// settings are otherwise optional. Settings are validated identically to YAML.
 func NewManagedUpstream(database string, dsn secrets.Source, role string, settings []Setting) (*Upstream, error) {
+	return NewManagedRoute(database, "", dsn, role, settings)
+}
+
+// NewManagedRoute builds a control-plane upstream with an explicit logical
+// selector. Distinct routes may share one physical database.
+func NewManagedRoute(database, route string, dsn secrets.Source, role string, settings []Setting) (*Upstream, error) {
 	if database == "" {
 		return nil, fmt.Errorf("postgres: managed upstream database is required")
 	}
@@ -364,11 +434,34 @@ func NewManagedUpstream(database string, dsn secrets.Source, role string, settin
 	}
 	return &Upstream{
 		database:   database,
+		route:      route,
 		role:       role,
 		settings:   compiled,
 		pinnedGUCs: pinned,
 		dsn:        dsn,
 	}, nil
+}
+
+func validateRoutes(upstreams map[upstreamKey]*Upstream) error {
+	counts := make(map[string]int)
+	unnamed := make(map[string]bool)
+	for key := range upstreams {
+		counts[key.database]++
+		unnamed[key.database] = unnamed[key.database] || key.route == ""
+	}
+	for database, count := range counts {
+		if count > 1 && unnamed[database] {
+			return fmt.Errorf("postgres: database %q has multiple upstreams; every upstream must set route", database)
+		}
+	}
+	return nil
+}
+
+func routeLabel(database, route string) string {
+	if route == "" {
+		return database
+	}
+	return database + "/" + route
 }
 
 // gucNameRe matches a Postgres GUC name: a bare identifier, or a dotted

--- a/internal/postgres/config_test.go
+++ b/internal/postgres/config_test.go
@@ -90,9 +90,17 @@ func TestCompile(t *testing.T) {
 		require.ErrorContains(t, err, "at least one upstream is required")
 	})
 
-	t.Run("duplicate upstream database rejected", func(t *testing.T) {
+	t.Run("duplicate upstream route rejected", func(t *testing.T) {
 		_, err := Compile(cfg(upstream("dup"), upstream("dup")), logger, stubSource)
-		require.ErrorContains(t, err, `duplicate upstream database "dup"`)
+		require.ErrorContains(t, err, `duplicate upstream route "dup"`)
+	})
+
+	t.Run("multiple routes require selectors", func(t *testing.T) {
+		legacy := upstream("shared")
+		named := upstream("shared")
+		named.Route = "reader"
+		_, err := Compile(cfg(legacy, named), logger, stubSource)
+		require.ErrorContains(t, err, `database "shared" has multiple upstreams`)
 	})
 
 	t.Run("upstream database is required", func(t *testing.T) {
@@ -151,4 +159,44 @@ func TestCompile(t *testing.T) {
 		_, err := Compile(cfg(u), logger, stubSource)
 		require.ErrorContains(t, err, "duplicate setting")
 	})
+}
+
+func TestLoadFromNodeAllowsDistinctRoutesForOneDatabase(t *testing.T) {
+	t.Setenv("PG_PW", "secret")
+	t.Setenv("PG_DSN", "host=127.0.0.1 port=1 dbname=appdb")
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`
+listen: "127.0.0.1:0"
+client:
+  user: app
+  password_env: PG_PW
+upstreams:
+  - database: appdb
+    route: audit
+    dsn:
+      type: env
+      var: PG_DSN
+  - database: appdb
+    route: company-context
+    dsn:
+      type: env
+      var: PG_DSN
+    role: company_context_reader
+`), &node))
+
+	listener, err := LoadFromNode(*node.Content[0], slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+	require.Len(t, listener.Upstreams(), 2)
+	require.Nil(t, listener.Upstream("appdb"))
+	audit, err := listener.SelectUpstream("appdb", "audit")
+	require.NoError(t, err)
+	require.Empty(t, audit.Role())
+	companyContext, err := listener.SelectUpstream("appdb", "company-context")
+	require.NoError(t, err)
+	require.Equal(t, "company_context_reader", companyContext.Role())
+	_, err = listener.SelectUpstream("appdb", "")
+	require.ErrorIs(t, err, ErrRouteRequired)
+	_, err = listener.SelectUpstream("appdb", "unknown")
+	require.ErrorIs(t, err, ErrUnknownRoute)
 }

--- a/internal/postgres/manager_test.go
+++ b/internal/postgres/manager_test.go
@@ -25,8 +25,8 @@ func testListener(listen string) *Listener {
 		listen:         listen,
 		clientUser:     "u",
 		clientPassword: "p",
-		upstreams: map[string]*Upstream{
-			"appdb": {
+		upstreams: map[upstreamKey]*Upstream{
+			{database: "appdb"}: {
 				database: "appdb",
 				dsn:      staticDSN{name: "test", value: "host=127.0.0.1"},
 			},

--- a/internal/postgres/policy_test.go
+++ b/internal/postgres/policy_test.go
@@ -103,9 +103,10 @@ func TestNewManagedUpstream(t *testing.T) {
 	require.Empty(t, u.Role())
 
 	// Settings are carried through and pinned.
-	u, err = NewManagedUpstream("centaur", dsn, "reader", []Setting{{Name: "centaur.slack_channel_id", Value: "C123"}})
+	u, err = NewManagedRoute("centaur", "company-context", dsn, "reader", []Setting{{Name: "centaur.slack_channel_id", Value: "C123"}})
 	require.NoError(t, err)
 	require.Equal(t, []Setting{{Name: "centaur.slack_channel_id", Value: "C123"}}, u.Settings())
+	require.Equal(t, "company-context", u.Route())
 	require.Contains(t, u.PinnedGUCs(), "centaur.slack_channel_id")
 
 	// Settings are validated identically to the YAML path.
@@ -147,13 +148,13 @@ func TestNewListener(t *testing.T) {
 	_, err = NewListener("127.0.0.1:0", "app", "pw", nil)
 	require.ErrorContains(t, err, "at least one upstream is required")
 	_, err = NewListener("127.0.0.1:0", "app", "pw", []*Upstream{mustUpstream("a"), mustUpstream("a")})
-	require.ErrorContains(t, err, `duplicate upstream database "a"`)
+	require.ErrorContains(t, err, `duplicate upstream route "a"`)
 }
 
 func TestListenerWithUpstreams(t *testing.T) {
 	dsn := staticDSN{name: "dsn", value: "host=db"}
 	mustUpstream := func(database string) *Upstream {
-		u, err := NewManagedUpstream(database, dsn, "", nil)
+		u, err := NewManagedRoute(database, database+"-route", dsn, "", nil)
 		require.NoError(t, err)
 		return u
 	}
@@ -162,7 +163,7 @@ func TestListenerWithUpstreams(t *testing.T) {
 	require.NoError(t, err)
 
 	merged, dropped := base.WithUpstreams([]*Upstream{mustUpstream("b"), mustUpstream("a")})
-	require.Equal(t, []string{"a"}, dropped, "existing database wins")
+	require.Equal(t, []string{"a/a-route"}, dropped, "existing route wins")
 	require.Len(t, merged.Upstreams(), 2)
 	require.NotNil(t, merged.Upstream("a"))
 	require.NotNil(t, merged.Upstream("b"))

--- a/internal/postgres/session.go
+++ b/internal/postgres/session.go
@@ -47,11 +47,19 @@ func runSession(ctx context.Context, clientConn net.Conn, listener *Listener, lo
 		)
 		return
 	}
-	upstream := listener.Upstream(dbName)
-	if upstream == nil {
-		writeFatal(backend, "3D000", fmt.Sprintf("no upstream for database %q", dbName))
-		logger.Info("postgres: no upstream for database",
+	route := startup.Parameters["iron.route"]
+	upstream, selectErr := listener.SelectUpstream(dbName, route)
+	if selectErr != nil {
+		message := fmt.Sprintf("no upstream for database %q", dbName)
+		if errors.Is(selectErr, ErrRouteRequired) {
+			message = fmt.Sprintf("database %q has multiple policy routes; iron.route is required", dbName)
+		} else if errors.Is(selectErr, ErrUnknownRoute) {
+			message = fmt.Sprintf("no upstream for database %q and requested iron.route", dbName)
+		}
+		writeFatal(backend, "3D000", message)
+		logger.Info("postgres: upstream route selection failed",
 			slog.String("database", dbName),
+			slog.Bool("has_route", route != ""),
 			slog.String("listener", listener.Name()),
 			slog.String("remote", clientConn.RemoteAddr().String()),
 		)

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -715,26 +715,26 @@ transforms:
 # (no per-user).
 #
 # The proxy runs a single postgres listener: the postgres key is one object
-# with a bind address and a list of upstreams. A single listen address serves
-# many upstream databases. The client selects an upstream by the database name
-# it sends in its startup message (psql's `dbname=`), and the proxy
-# authenticates that connection against the upstream's own credentials before
-# dialing it. The client must name a database explicitly; a database with no
-# matching upstream is rejected. Each upstream's `database` must equal the
-# database its DSN connects to (the dbname in the DSN) — otherwise the client
-# would land on a different database than the one it named, and the proxy
-# rejects the connection.
+# with a bind address and a list of upstream routes. A single listen address
+# serves many physical databases and can expose multiple policy routes for one
+# database. The client selects an upstream by the database name it sends in its
+# startup message (psql's `dbname=`), and, when a database has multiple routes,
+# the `iron.route` startup parameter. A database with no matching upstream is
+# rejected, and an ambiguous database without `iron.route` fails closed. Each
+# upstream's `database` must equal the database its DSN connects to (the dbname
+# in the DSN) — the logical route selector never replaces this physical check.
 # postgres:
 #   listen: ":5432"
 #   # The single credential clients present to the proxy, shared across every
-#   # upstream below. Routing is by database, so per-database credentials add
-#   # nothing.
+#   # upstream below.
 #   client:
 #     user: app_user
 #     password_env: PG_PROXY_PASSWORD
 #   upstreams:
 #     # Clients connect with dbname=appdb to reach this upstream.
 #     - database: appdb
+#       # Optional logical selector. Required when appdb has multiple routes.
+#       route: readonly
 #       # The DSN is loaded from any registered secret source and passed
 #       # verbatim to pgconn. URL or keyword/value form both work.
 #       dsn:


### PR DESCRIPTION
## Summary
- allow multiple policy routes to share one physical Postgres database
- select routes with the `iron.route` StartupMessage parameter while preserving database/DSN equality checks
- fail closed when a database is ambiguous or the selector is unknown
- use control-plane `foreign_id` as the managed route selector

## Test plan
- `go test ./...`
- `TESTCONTAINERS_RYUK_DISABLED=true go test ./integration_test -run TestPostgresMultipleUpstreams -count=1 -v -integration`

## Root cause
The managed proxy keyed Postgres upstreams only by physical database, so one principal could not hold two isolated roles for the same database. Console grants therefore collapsed or the proxy dropped one route.