### PR TITLE
fix(proxy): flush Connect and gRPC streaming responses

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -628,9 +628,8 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		}
 	}
 
-	// SSE: stream with flushing
-	if isSSE(finalResp) {
-		p.streamSSE(w, finalResp)
+	if isStreamingResponse(finalResp) {
+		p.streamResponse(w, finalResp)
 		return
 	}
 
@@ -855,15 +854,19 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 	p.logger.Debug("websocket connection closed", slog.String("host", host))
 }
 
-// isSSE detects a Server-Sent Events response.
-func isSSE(resp *http.Response) bool {
-	ct := resp.Header.Get("Content-Type")
-	return strings.HasPrefix(ct, "text/event-stream")
+// isStreamingResponse detects response protocols that require incremental
+// delivery to the client.
+func isStreamingResponse(resp *http.Response) bool {
+	ct := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
+	return strings.HasPrefix(ct, "text/event-stream") ||
+		strings.HasPrefix(ct, "application/connect+") ||
+		strings.HasPrefix(ct, "application/grpc")
 }
 
-// streamSSE writes an SSE response with per-chunk flushing.
-func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
+// streamResponse writes a streaming response with per-chunk flushing.
+func (p *Proxy) streamResponse(w http.ResponseWriter, resp *http.Response) {
 	copyHeaders(w.Header(), resp.Header)
+	defer writeTrailers(w, resp)
 	w.WriteHeader(resp.StatusCode)
 
 	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
@@ -871,24 +874,25 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		if _, err := io.Copy(w, reader); err != nil {
-			p.logger.Warn("SSE copy error", slog.String("error", err.Error()))
+			p.logger.Warn("streaming response copy error", slog.String("error", err.Error()))
 		}
 		return
 	}
+	flusher.Flush()
 
 	buf := make([]byte, 32*1024)
 	for {
 		n, readErr := reader.Read(buf)
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
-				p.logger.Warn("SSE write error", slog.String("error", writeErr.Error()))
+				p.logger.Warn("streaming response write error", slog.String("error", writeErr.Error()))
 				break
 			}
 			flusher.Flush()
 		}
 		if readErr != nil {
 			if readErr != io.EOF {
-				p.logger.Warn("SSE read error", slog.String("error", readErr.Error()))
+				p.logger.Warn("streaming response read error", slog.String("error", readErr.Error()))
 			}
 			break
 		}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -37,6 +37,16 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
+type countingFlusher struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (w *countingFlusher) Flush() {
+	w.flushes++
+	w.ResponseRecorder.Flush()
+}
+
 func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	t.Helper()
 
@@ -647,6 +657,50 @@ func TestHTTPProxy_SSEStreaming(t *testing.T) {
 	require.Contains(t, string(body), "data: event1")
 	require.Contains(t, string(body), "data: event2")
 	require.Contains(t, string(body), "data: event3")
+}
+
+func TestIsStreamingResponse(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		want        bool
+	}{
+		{name: "SSE", contentType: "text/event-stream; charset=utf-8", want: true},
+		{name: "Connect proto", contentType: "application/connect+proto", want: true},
+		{name: "Connect JSON", contentType: "application/connect+json", want: true},
+		{name: "gRPC", contentType: "application/grpc", want: true},
+		{name: "gRPC proto", contentType: "application/grpc+proto", want: true},
+		{name: "JSON", contentType: "application/json", want: false},
+		{name: "protobuf unary", contentType: "application/proto", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{"Content-Type": []string{tc.contentType}}}
+			require.Equal(t, tc.want, isStreamingResponse(resp))
+		})
+	}
+}
+
+func TestStreamResponseFlushesEachChunk(t *testing.T) {
+	recorder := &countingFlusher{ResponseRecorder: httptest.NewRecorder()}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/connect+proto"}},
+		Body: transform.NewBufferedBody(io.NopCloser(io.MultiReader(
+			strings.NewReader("first"),
+			strings.NewReader("second"),
+		)), 0),
+		Trailer: http.Header{"Grpc-Status": []string{"0"}},
+	}
+
+	p := &Proxy{logger: testLogger()}
+	p.streamResponse(recorder, resp)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "firstsecond", recorder.Body.String())
+	require.Equal(t, 3, recorder.flushes, "headers and each upstream chunk must be flushed")
+	require.Equal(t, "0", recorder.Header().Get(http.TrailerPrefix+"Grpc-Status"))
 }
 
 func TestHTTPProxy_RequestContentLengthPreserved(t *testing.T) {


### PR DESCRIPTION
## Motivation

PR #212 enabled HTTP/2 in MITM mode and forwarded gRPC trailers, but long-lived Connect and gRPC responses still go through `writeResponse`, which copies the body without flushing incremental writes. Small streaming frames can remain buffered even though the upstream returned 200, leaving the client with no messages until it cancels the request.

This reproduces with Cursor's `AgentService/Run` RPC: unary Connect calls complete normally, while the `application/connect+proto` streaming response consistently disconnects after approximately 30 seconds.

## Summary

- treat SSE, Connect streaming, and gRPC response media types as streaming responses
- flush response headers and every chunk read from the upstream body
- preserve upstream trailers on the streaming path
- cover media-type detection, per-chunk flushing, and trailer forwarding

Non-streaming response handling and the transform pipeline are unchanged.

## Validation

- `go test -v -race -count=1 ./...`
- `go vet ./...`
- live MITM reproduction: a one-shot Cursor request completed in 5 seconds instead of reconnecting at 30 seconds
- live multi-tool flow: three sequential tool calls and the final response completed over a single 70-second stream
