### PR TITLE
fix: regenerate expired cached certificates

### DIFF
--- a/internal/certcache/cache.go
+++ b/internal/certcache/cache.go
@@ -68,7 +68,13 @@ func (c *Cache) GetOrCreate(domain string) (*tls.Certificate, error) {
 	defer c.mu.Unlock()
 
 	if cert, ok := c.cache.Get(domain); ok {
-		return cert, nil
+		// The LRU expiry uses Go's monotonic clock, which does not advance while
+		// the host is suspended. Certificate validity uses wall time, so reject a
+		// cached leaf that has expired even when its LRU entry is still alive.
+		if cert.Leaf != nil && time.Now().Before(cert.Leaf.NotAfter) {
+			return cert, nil
+		}
+		c.cache.Remove(domain)
 	}
 
 	cert, err := c.generate(domain)

--- a/internal/certcache/cache_test.go
+++ b/internal/certcache/cache_test.go
@@ -328,6 +328,22 @@ func TestGetOrCreate_CacheHit(t *testing.T) {
 	require.Equal(t, 1, c.Len())
 }
 
+func TestGetOrCreate_ExpiredLeaf(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	c := newTestCache(t, caCert, caKey, 10)
+
+	cert1, err := c.GetOrCreate("example.com")
+	require.NoError(t, err)
+	cert1.Leaf.NotAfter = time.Now().Add(-time.Minute)
+
+	cert2, err := c.GetOrCreate("example.com")
+	require.NoError(t, err)
+
+	require.NotSame(t, cert1, cert2)
+	require.True(t, cert2.Leaf.NotAfter.After(time.Now()))
+	require.Equal(t, 1, c.Len())
+}
+
 func TestGetOrCreate_DifferentDomains(t *testing.T) {
 	caCert, caKey := generateTestCA(t)
 	c := newTestCache(t, caCert, caKey, 10)


### PR DESCRIPTION
The expirable LRU uses Go monotonic time, which does not advance while the host is suspended. Certificate validity uses wall-clock time, so a cached leaf could remain in the LRU after its NotAfter timestamp had passed and be served to clients as expired.

Check the cached leaf NotAfter timestamp before reuse. Remove and regenerate the entry when its certificate has expired, and add a regression test for the stale-cache case.