### PR TITLE
Fail closed on invalid gRPC transform actions

### DIFF
--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 
@@ -30,6 +31,7 @@ func init() {
 type grpcConfig struct {
 	Name             string                 `yaml:"name"`
 	Target           string                 `yaml:"target"`
+	WorkloadIdentity string                 `yaml:"workload_identity"`
 	TLS              tlsConfig              `yaml:"tls"`
 	SendRequestBody  bool                   `yaml:"send_request_body"`
 	SendResponseBody bool                   `yaml:"send_response_body"`
@@ -46,6 +48,7 @@ type tlsConfig struct {
 // GRPCTransform delegates to a single external gRPC TransformService server.
 type GRPCTransform struct {
 	name             string
+	workloadIdentity string
 	sendRequestBody  bool
 	sendResponseBody bool
 	rules            []hostmatch.Rule
@@ -119,6 +122,7 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 
 	return &GRPCTransform{
 		name:             cfg.Name,
+		workloadIdentity: cfg.WorkloadIdentity,
 		sendRequestBody:  cfg.SendRequestBody,
 		sendResponseBody: cfg.SendResponseBody,
 		rules:            rules,
@@ -139,6 +143,7 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
 
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-iron-workload-identity", g.workloadIdentity)
 	resp, err := g.client.TransformRequest(ctx, &transformv1.TransformRequestRequest{
 		Context: transformContextToProto(tctx),
 		Request: pbReq,
@@ -151,12 +156,17 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 		tctx.Annotate(k, v)
 	}
 
-	if resp.GetAction() == transformv1.TransformAction_TRANSFORM_ACTION_REJECT {
+	switch resp.GetAction() {
+	case transformv1.TransformAction_TRANSFORM_ACTION_REJECT:
 		result := &transform.TransformResult{Action: transform.ActionReject}
 		if resp.GetResponse() != nil {
 			result.Response = protoToHTTPResponse(resp.GetResponse(), req)
 		}
 		return result, nil
+	case transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE:
+		// Continue below so a valid response may modify the request.
+	default:
+		return &transform.TransformResult{Action: transform.ActionReject}, nil
 	}
 
 	if resp.GetModifiedRequest() != nil {
@@ -180,6 +190,7 @@ func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.T
 		return nil, fmt.Errorf("grpc transform %q: marshaling response: %w", g.name, err)
 	}
 
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-iron-workload-identity", g.workloadIdentity)
 	grpcResp, err := g.client.TransformResponse(ctx, &transformv1.TransformResponseRequest{
 		Context:  transformContextToProto(tctx),
 		Request:  pbReq,
@@ -193,12 +204,17 @@ func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.T
 		tctx.Annotate(k, v)
 	}
 
-	if grpcResp.GetAction() == transformv1.TransformAction_TRANSFORM_ACTION_REJECT {
+	switch grpcResp.GetAction() {
+	case transformv1.TransformAction_TRANSFORM_ACTION_REJECT:
 		result := &transform.TransformResult{Action: transform.ActionReject}
 		if grpcResp.GetModifiedResponse() != nil {
 			result.Response = protoToHTTPResponse(grpcResp.GetModifiedResponse(), req)
 		}
 		return result, nil
+	case transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE:
+		// Continue below so a valid response may modify the response.
+	default:
+		return &transform.TransformResult{Action: transform.ActionReject}, nil
 	}
 
 	if grpcResp.GetModifiedResponse() != nil {

--- a/internal/transform/grpc/grpc_test.go
+++ b/internal/transform/grpc/grpc_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	"gopkg.in/yaml.v3"
 
 	transformv1 "github.com/ironsh/iron-proxy/gen/transform/v1"
@@ -28,6 +29,7 @@ type fakeServer struct {
 	reqModified  *transformv1.HttpRequest
 	reqAnnot     map[string]string
 	lastReqProto *transformv1.TransformRequestRequest
+	lastReqMeta  metadata.MD
 
 	respAction    transformv1.TransformAction
 	respModified  *transformv1.HttpResponse
@@ -35,8 +37,9 @@ type fakeServer struct {
 	lastRespProto *transformv1.TransformResponseRequest
 }
 
-func (f *fakeServer) TransformRequest(_ context.Context, in *transformv1.TransformRequestRequest) (*transformv1.TransformRequestResponse, error) {
+func (f *fakeServer) TransformRequest(ctx context.Context, in *transformv1.TransformRequestRequest) (*transformv1.TransformRequestResponse, error) {
 	f.lastReqProto = in
+	f.lastReqMeta, _ = metadata.FromIncomingContext(ctx)
 	return &transformv1.TransformRequestResponse{
 		Action:          f.reqAction,
 		Response:        f.reqResponse,
@@ -109,6 +112,35 @@ func TestTransformRequest_Continue(t *testing.T) {
 	require.Equal(t, "example.com", srv.lastReqProto.GetContext().GetSni())
 	require.Equal(t, "GET", srv.lastReqProto.GetRequest().GetMethod())
 	require.Equal(t, "hello", srv.lastReqProto.GetRequest().GetHeaders()["X-Test"].GetValues()[0])
+}
+
+func TestTransformRequest_ForwardsConfiguredIdentity(t *testing.T) {
+	srv := &fakeServer{reqAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE}
+	addr := startFakeServer(t, srv)
+	gt, err := newGRPCTransform(grpcConfig{Name: "test", Target: addr, WorkloadIdentity: "install/group/session"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gt.Close() })
+	req, _ := http.NewRequest("GET", "https://example.com/", nil)
+
+	_, err = gt.TransformRequest(context.Background(), testContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"install/group/session"}, srv.lastReqMeta.Get("x-iron-workload-identity"))
+}
+
+func TestTransformRequest_UnknownActionsReject(t *testing.T) {
+	for _, action := range []transformv1.TransformAction{
+		transformv1.TransformAction_TRANSFORM_ACTION_UNSPECIFIED,
+		transformv1.TransformAction(99),
+	} {
+		t.Run(action.String(), func(t *testing.T) {
+			srv := &fakeServer{reqAction: action}
+			gt := newTestTransform(t, "test", startFakeServer(t, srv), false, false)
+			req, _ := http.NewRequest("GET", "https://example.com/", nil)
+			result, err := gt.TransformRequest(context.Background(), testContext(), req)
+			require.NoError(t, err)
+			require.Equal(t, transform.ActionReject, result.Action)
+		})
+	}
 }
 
 func TestTransformRequest_TunnelInfoInContext(t *testing.T) {
@@ -287,6 +319,23 @@ func TestTransformResponse_Reject(t *testing.T) {
 	require.Equal(t, transform.ActionReject, result.Action)
 	require.NotNil(t, result.Response)
 	require.Equal(t, 502, result.Response.StatusCode)
+}
+
+func TestTransformResponse_UnknownActionsReject(t *testing.T) {
+	for _, action := range []transformv1.TransformAction{
+		transformv1.TransformAction_TRANSFORM_ACTION_UNSPECIFIED,
+		transformv1.TransformAction(99),
+	} {
+		t.Run(action.String(), func(t *testing.T) {
+			srv := &fakeServer{respAction: action}
+			gt := newTestTransform(t, "test", startFakeServer(t, srv), false, false)
+			req, _ := http.NewRequest("GET", "https://example.com/", nil)
+			resp := &http.Response{StatusCode: 200, Header: make(http.Header), Body: http.NoBody}
+			result, err := gt.TransformResponse(context.Background(), testContext(), req, resp)
+			require.NoError(t, err)
+			require.Equal(t, transform.ActionReject, result.Action)
+		})
+	}
 }
 
 // --- send body tests ---


### PR DESCRIPTION
The gRPC transform currently treats every action except REJECT as CONTINUE. This makes TRANSFORM_ACTION_UNSPECIFIED and future unknown enum values fail open.

This change:
- accepts only explicit CONTINUE or REJECT actions;
- rejects unspecified and unknown actions for both request and response transforms;
- adds optional operator-configured workload identity as gRPC metadata, so an external transform can use a stable identity that is not derived from request headers or remote address.

Validation: `go test ./...` on Go 1.26.