### PR TITLE
fix(proxy): bound HTTP/2 response buffering

### DIFF
--- a/internal/proxy/http2_memory_test.go
+++ b/internal/proxy/http2_memory_test.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
+)
+
+func TestBuildTransport_HTTP2ReceiveWindowsAreBounded(t *testing.T) {
+	guard, err := dnsguard.New(nil)
+	require.NoError(t, err)
+	transport := buildTransport(nil, guard, 0, nil)
+
+	require.NotNil(t, transport.HTTP2)
+	require.Equal(t, maxHTTP2ReceiveBufferPerConnection, transport.HTTP2.MaxReceiveBufferPerConnection)
+	require.Equal(t, maxHTTP2ReceiveBufferPerStream, transport.HTTP2.MaxReceiveBufferPerStream)
+}
+
+func TestBuildTransport_HTTP2ConcurrentResponsesStayWithinMemoryBudget(t *testing.T) {
+	const (
+		streams  = 40
+		bodySize = 8 << 20
+	)
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.CopyN(w, zeroReader{}, bodySize)
+	}))
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	defer upstream.Close()
+
+	guard, err := dnsguard.New(nil)
+	require.NoError(t, err)
+	transport := buildTransport(nil, guard, 0, nil)
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	defer transport.CloseIdleConnections()
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	ctx := context.Background()
+	responses := make([]*http.Response, streams)
+	errs := make(chan error, streams)
+	for i := range streams {
+		go func(i int) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstream.URL, nil)
+			if err != nil {
+				errs <- err
+				return
+			}
+			responses[i], err = transport.RoundTrip(req)
+			errs <- err
+		}(i)
+	}
+	for range streams {
+		require.NoError(t, <-errs)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	require.Less(t, after.HeapAlloc, before.HeapAlloc+uint64(64<<20))
+
+	drained := make(chan error, streams)
+	for _, resp := range responses {
+		require.Equal(t, 2, resp.ProtoMajor)
+		go func(resp *http.Response) {
+			got, err := io.Copy(io.Discard, resp.Body)
+			if err == nil && got != int64(bodySize) {
+				err = io.ErrUnexpectedEOF
+			}
+			if closeErr := resp.Body.Close(); err == nil {
+				err = closeErr
+			}
+			drained <- err
+		}(resp)
+	}
+	for range streams {
+		require.NoError(t, <-drained)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -65,7 +65,13 @@ type Proxy struct {
 	ready           func() bool
 }
 
-const notReadyMessage = "proxy is not ready: awaiting control-plane config"
+const (
+	notReadyMessage = "proxy is not ready: awaiting control-plane config"
+	// Keep HTTP/2 receive windows bounded because each unread response stream
+	// owns transport buffers; the default stream window is 4 MiB.
+	maxHTTP2ReceiveBufferPerConnection = 2 << 20
+	maxHTTP2ReceiveBufferPerStream     = 1 << 20
+)
 
 // Options configures Proxy construction.
 type Options struct {
@@ -950,7 +956,11 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 		DialContext: dialer.DialContext,
 		// A custom DialContext disables net/http's automatic HTTP/2; opt back in
 		// so gRPC upstreams negotiate h2 over the same (dnsguard-controlled) dialer.
-		ForceAttemptHTTP2:     true,
+		ForceAttemptHTTP2: true,
+		HTTP2: &http.HTTP2Config{
+			MaxReceiveBufferPerConnection: maxHTTP2ReceiveBufferPerConnection,
+			MaxReceiveBufferPerStream:     maxHTTP2ReceiveBufferPerStream,
+		},
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
## Summary

- bound the HTTP/2 receive window to 2 MiB per connection and 1 MiB per stream
- prevent many concurrent unread upstream response bodies from consuming the proxy memory limit
- preserve full response streaming without truncation
- add a regression test with 40 concurrent 8 MiB HTTP/2 responses

## Root cause

Go HTTP/2 can buffer up to 4 MiB for each unread response stream by default. A workload downloading 116 packages concurrently could therefore retain roughly 464 MiB in transport buffers alone. The affected proxy peaked at 511,700,992 bytes under a 512 MiB cgroup limit and was OOM-killed.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `go test -count=1 ./...`
- [x] `go vet ./...`
- [x] verify all concurrent response bodies are read completely