### PR TITLE
feat(bodycapture): capture streaming response bodies via a body tee

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Transforms run in order. Built-in transforms:
 | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `allowlist`    | Permits requests to matching domains/CIDRs; rejects everything else (403).                                              |
 | `secrets`      | Scans headers (and optionally query, path, or body) for proxy tokens and swaps in real secrets from environment variables. |
-| `body_capture` | Records decoded request bodies of matching hosts as `request_body` audit fields. Observation-only; never rejects.       |
+| `body_capture` | Records decoded request bodies of matching hosts as `request_body` audit fields, and optionally response bodies as `response_body`. Observation-only.        |
 
 ## Configuration
 
@@ -412,19 +412,44 @@ On a successful capture, the transform's entry in `request_transforms` is
 annotated with `captured_bytes` and `truncated` so the trace records that a
 body was captured without duplicating the body itself.
 
-Response bodies are not captured. Streaming responses (SSE) would have to be
-buffered end-to-end before forwarding, which would stall the client.
+#### Response bodies
 
-> **Warning:** Captured bodies are written to the audit log in plain text. When
-> `secrets` runs with `match_body: true`, place `body_capture` *before* `secrets`
-> so the audit log records the sandbox's proxy tokens rather than the real
-> credentials `secrets` swaps into the body.
+Response capture is **off by default**. Set `capture_response_body: true` to
+turn it on; `response_body` and `response_body_truncated` then join the same
+`body_capture` group, and `max_response_body_bytes` caps the copy (default
+64 KiB).
+
+The response half is *tee'd*, never buffered-then-forwarded. Installing the tee
+is O(1) and never reads the body; the client's own reads drive the copy, so a
+streaming reply (SSE from an LLM provider, say) is forwarded byte-for-byte as it
+arrives and the audit copy simply holds whatever went past by the time the audit
+record is emitted — which is after the body has been written to the client.
+Bytes past `max_response_body_bytes` are *dropped* as they stream by rather than
+queued, so a full audit buffer can never apply back-pressure to the client, and
+a failing sink can never surface as a read error on the client's stream.
+
+What lands in `response_body` is the raw reply as it went over the wire, only
+content-decoded when the upstream compressed it (`gzip`, `deflate`; a reply in
+an encoding the transform cannot decode is skipped and the gap is annotated on
+the trace). SSE frames are not merged and JSON is not parsed — that is the log
+consumer's job, and guessing at a provider's streaming shape does not belong on
+the hot path.
+
+> **Warning:** Captured bodies are written to the audit log in plain text, and
+> that goes for captured response bodies too — enable `capture_response_body`
+> only where an upstream's replies are safe to keep. When `secrets` runs with
+> `match_body: true`, place `body_capture` *before* `secrets` so the audit log
+> records the sandbox's proxy tokens rather than the real credentials `secrets`
+> swaps into the body.
 
 ```yaml
 transforms:
   - name: body_capture
     config:
       max_request_body_bytes: 16384
+      # Optional; off by default.
+      capture_response_body: true
+      max_response_body_bytes: 65536
       rules:
         - host: "api.anthropic.com"
           methods: ["POST"]

--- a/internal/proxy/bodycapture_response_test.go
+++ b/internal/proxy/bodycapture_response_test.go
@@ -1,0 +1,364 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+
+	// Registers the body_capture transform factory.
+	_ "github.com/ironsh/iron-proxy/internal/transform/bodycapture"
+)
+
+// newBodyCaptureTransform builds the real body_capture transform from YAML, the
+// way cmd/iron-proxy does, so these tests exercise the shipped config path
+// rather than a hand-built struct.
+func newBodyCaptureTransform(t *testing.T, doc string) transform.Transformer {
+	t.Helper()
+	factory, err := transform.Lookup("body_capture")
+	require.NoError(t, err)
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+	require.NotEmpty(t, node.Content)
+	tr, err := factory(*node.Content[0], testLogger())
+	require.NoError(t, err)
+	return tr
+}
+
+// startProxyWithAudit starts a plain-HTTP proxy whose pipeline runs transforms
+// and reports each completed PipelineResult on the returned channel.
+func startProxyWithAudit(t *testing.T, transforms []transform.Transformer) (string, <-chan *transform.PipelineResult) {
+	t.Helper()
+
+	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
+	results := make(chan *transform.PipelineResult, 4)
+	pipeline.SetAuditFunc(func(r *transform.PipelineResult) { results <- r })
+
+	p := New(Options{
+		HTTPAddr: "127.0.0.1:0",
+		Pipeline: transform.NewPipelineHolder(pipeline),
+		Logger:   testLogger(),
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = p.httpServer.Serve(ln) }()
+	t.Cleanup(func() { _ = p.httpServer.Close() })
+
+	return ln.Addr().String(), results
+}
+
+func awaitAudit(t *testing.T, results <-chan *transform.PipelineResult) *transform.PipelineResult {
+	t.Helper()
+	select {
+	case r := <-results:
+		return r
+	case <-time.After(5 * time.Second):
+		t.Fatal("audit record never emitted")
+		return nil
+	}
+}
+
+// TestHTTPProxy_BodyCapture_SSEResponseReachesTheAuditRecord is the end-to-end
+// case for the tee: a real streaming upstream, through the real proxy, with the
+// real body_capture transform, asserting that (a) the client receives each
+// frame as it is flushed — not after the reply completes — and (b) the raw,
+// unmerged body lands on the audit record the emitters render as
+// `body_capture.response_body`.
+//
+// This test is the argument for the tee. An implementation that buffered the
+// reply before forwarding it cannot pass it: the upstream refuses to flush
+// frame 2 until the client has actually read frame 1, so a buffering proxy
+// deadlocks until the deadline fires.
+func TestHTTPProxy_BodyCapture_SSEResponseReachesTheAuditRecord(t *testing.T) {
+	sawFirst := make(chan struct{})
+	var releaseUpstream sync.Once
+	release := func() { releaseUpstream.Do(func() { close(sawFirst) }) }
+
+	frames := []string{
+		"data: {\"delta\":{\"type\":\"text_delta\",\"text\":\"import \"}}\n\n",
+		"data: {\"delta\":{\"type\":\"text_delta\",\"text\":\"os\\n\"}}\n\n",
+		"data: [DONE]\n\n",
+	}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		_, _ = fmt.Fprint(w, frames[0])
+		flusher.Flush()
+		// Frame 2 is withheld until the client has actually read frame 1. This
+		// is what makes the test a regression test rather than a smoke test: a
+		// proxy that buffers the reply before forwarding it can never satisfy
+		// both sides of this handshake.
+		<-sawFirst
+		for _, f := range frames[1:] {
+			_, _ = fmt.Fprint(w, f)
+			flusher.Flush()
+		}
+	}))
+	// Cleanups run LIFO, so registering Close first and the release second means
+	// the handler is always released before Close waits on it — including on the
+	// failure path below, where the upstream is still holding frame 2.
+	t.Cleanup(upstream.Close)
+	t.Cleanup(release)
+
+	bc := newBodyCaptureTransform(t, `
+max_request_body_bytes: 16384
+capture_response_body: true
+max_response_body_bytes: 65536
+rules:
+  - host: "127.0.0.1"
+    methods: ["POST"]
+    paths: ["/v1/messages"]
+`)
+	proxyAddr, results := startProxyWithAudit(t, []transform.Transformer{bc})
+
+	reqBody := `{"model":"claude","messages":[{"role":"user","content":"write a script"}],"stream":true}`
+	req, err := http.NewRequest("POST", "http://"+proxyAddr+"/v1/messages", strings.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	// Send the request and read frame 1, both while the upstream is still
+	// holding frame 2. This is the assertion a buffering implementation cannot
+	// satisfy: it would be parked in the middle of draining the upstream body,
+	// which cannot advance until the client reads — so neither the response
+	// headers nor the first frame ever arrive. Both steps sit behind one
+	// deadline so that deadlock surfaces as a fast, legible failure instead of
+	// hanging the suite.
+	type firstFrame struct {
+		resp *http.Response
+		head string
+		err  error
+	}
+	arrived := make(chan firstFrame, 1)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			arrived <- firstFrame{err: err}
+			return
+		}
+		buf := make([]byte, 32*1024)
+		n, err := resp.Body.Read(buf)
+		arrived <- firstFrame{resp: resp, head: string(buf[:n]), err: err}
+	}()
+
+	var ff firstFrame
+	select {
+	case ff = <-arrived:
+		require.NoError(t, ff.err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first SSE frame never reached the client while the reply was " +
+			"still streaming - the response body is being buffered before it is forwarded")
+	}
+	resp := ff.resp
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, ff.head, "import ",
+		"the first frame must arrive before the reply is complete")
+	release()
+
+	rest, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	clientSaw := ff.head + string(rest)
+	require.Equal(t, strings.Join(frames, ""), clientSaw)
+
+	// The audit record is emitted after the body is written to the client, so by
+	// the time it fires the tee has the whole reply.
+	result := awaitAudit(t, results)
+	require.NotNil(t, result.BodyCapture, "body_capture should have attached a capture")
+	require.Equal(t, reqBody, result.BodyCapture.RequestBody())
+	require.Equal(t, clientSaw, result.BodyCapture.ResponseBody(),
+		"response_body must be the raw bytes the client received, frames unmerged")
+	require.False(t, result.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestHTTPProxy_BodyCapture_ResponseCapDoesNotTruncateTheClient(t *testing.T) {
+	// 200 KiB reply, 4 KiB audit cap. The client must get all of it; the audit
+	// record keeps the head and says it was truncated.
+	const total = 200 * 1024
+	const capBytes = 4 * 1024
+	payload := strings.Repeat("z", total)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, payload)
+	}))
+	defer upstream.Close()
+
+	bc := newBodyCaptureTransform(t, fmt.Sprintf(`
+capture_response_body: true
+max_response_body_bytes: %d
+rules:
+  - host: "127.0.0.1"
+`, capBytes))
+	proxyAddr, results := startProxyWithAudit(t, []transform.Transformer{bc})
+
+	req, err := http.NewRequest("POST", "http://"+proxyAddr+"/v1/messages", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, total, len(body), "the client must receive the whole reply")
+
+	result := awaitAudit(t, results)
+	require.NotNil(t, result.BodyCapture)
+	require.Equal(t, capBytes, len(result.BodyCapture.ResponseBody()))
+	require.True(t, result.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestHTTPProxy_BodyCapture_ResponseNotCapturedByDefault(t *testing.T) {
+	// The same config without `capture_response_body` must behave exactly as
+	// body_capture did before response capture existed.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"content":"reply"}`)
+	}))
+	defer upstream.Close()
+
+	bc := newBodyCaptureTransform(t, `
+rules:
+  - host: "127.0.0.1"
+`)
+	proxyAddr, results := startProxyWithAudit(t, []transform.Transformer{bc})
+
+	req, err := http.NewRequest("POST", "http://"+proxyAddr+"/v1/messages", strings.NewReader(`{"x":1}`))
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"content":"reply"}`, string(body))
+
+	result := awaitAudit(t, results)
+	require.NotNil(t, result.BodyCapture)
+	require.Equal(t, `{"x":1}`, result.BodyCapture.RequestBody())
+	require.Equal(t, "", result.BodyCapture.ResponseBody(),
+		"response capture must stay off unless the config asks for it")
+	require.False(t, result.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestHTTPProxy_BodyCapture_NonMatchingHostNotCaptured(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "some other service's reply")
+	}))
+	defer upstream.Close()
+
+	bc := newBodyCaptureTransform(t, `
+capture_response_body: true
+rules:
+  - host: "api.anthropic.com"
+`)
+	proxyAddr, results := startProxyWithAudit(t, []transform.Transformer{bc})
+
+	req, err := http.NewRequest("GET", "http://"+proxyAddr+"/anything", nil)
+	require.NoError(t, err)
+	req.Host = upstream.Listener.Addr().String()
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "some other service's reply", string(body))
+
+	result := awaitAudit(t, results)
+	require.Nil(t, result.BodyCapture, "a non-matching host must not be captured at all")
+}
+
+// TestHTTPProxy_BodyCapture_SlowReplyDoesNotDelayOtherTraffic is the
+// head-of-line-blocking guard at the proxy level: while one request sits on a
+// model reply that has not finished, unrelated traffic through the same proxy
+// must complete normally.
+func TestHTTPProxy_BodyCapture_SlowReplyDoesNotDelayOtherTraffic(t *testing.T) {
+	release := make(chan struct{})
+	var once sync.Once
+	t.Cleanup(func() { once.Do(func() { close(release) }) })
+
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			_, _ = io.WriteString(w, "data: thinking\n\n")
+			f.Flush()
+		}
+		<-release
+	}))
+	defer slow.Close()
+
+	quick := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "pong")
+	}))
+	defer quick.Close()
+
+	bc := newBodyCaptureTransform(t, `
+capture_response_body: true
+rules:
+  - host: "127.0.0.1"
+`)
+	proxyAddr, _ := startProxyWithAudit(t, []transform.Transformer{bc})
+	client := &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: proxyAddr})},
+	}
+
+	// Kick off the never-ending reply and wait until its first frame lands, so we
+	// know the proxy is genuinely mid-stream on it.
+	streaming := make(chan struct{})
+	go func() {
+		resp, err := client.Get(slow.URL + "/v1/messages")
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		buf := make([]byte, 512)
+		if _, err := resp.Body.Read(buf); err == nil {
+			close(streaming)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+	}()
+	select {
+	case <-streaming:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the streaming reply never delivered its first frame")
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		resp, err := client.Get(quick.URL + "/ping")
+		if err != nil {
+			done <- "error: " + err.Error()
+			return
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		done <- string(b)
+	}()
+
+	select {
+	case got := <-done:
+		require.Equal(t, "pong", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("unrelated traffic was blocked while an AI reply was still streaming")
+	}
+
+	once.Do(func() { close(release) })
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -600,6 +600,16 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 
 	// Run response transforms
 	finalResp, err := pl.ProcessResponse(r.Context(), tctx, r, resp, &result.ResponseTransforms)
+	// The response leg can create the body_capture side channel too — a matching
+	// request with no body of its own leaves it nil above, but its response is
+	// still worth capturing. Nil-guarded so the request-leg capture (already
+	// copied, and the one holding request_body) is never clobbered. What the
+	// response leg installed is a tee, so the bytes it carries are filled in as
+	// the body streams below and are only complete by the time the deferred
+	// finish() emits the audit record.
+	if result.BodyCapture == nil {
+		result.BodyCapture = tctx.BodyCapture
+	}
 	if err != nil {
 		if markIfClientCancel(r, err, result) {
 			return

--- a/internal/transform/audit.go
+++ b/internal/transform/audit.go
@@ -89,11 +89,26 @@ func NewAuditLogger(logger *slog.Logger) AuditFunc {
 			}
 			attrs = append(attrs, slog.Group("mcp", mcpAttrs...))
 		}
-		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
-			attrs = append(attrs, slog.Group("body_capture",
-				slog.String("request_body", result.BodyCapture.RequestBody()),
-				slog.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
-			))
+		if result.BodyCapture != nil {
+			var bodyAttrs []any
+			if body := result.BodyCapture.RequestBody(); body != "" {
+				bodyAttrs = append(bodyAttrs,
+					slog.String("request_body", body),
+					slog.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
+				)
+			}
+			// Safe to read the response half here: this callback fires after the
+			// response body has been streamed to the client, so the tee has seen
+			// everything it is going to see.
+			if body := result.BodyCapture.ResponseBody(); body != "" {
+				bodyAttrs = append(bodyAttrs,
+					slog.String("response_body", body),
+					slog.Bool("response_body_truncated", result.BodyCapture.ResponseBodyTruncated()),
+				)
+			}
+			if len(bodyAttrs) > 0 {
+				attrs = append(attrs, slog.Group("body_capture", bodyAttrs...))
+			}
 		}
 
 		switch {

--- a/internal/transform/audit_test.go
+++ b/internal/transform/audit_test.go
@@ -271,12 +271,16 @@ func TestAudit_EmptyTransforms(t *testing.T) {
 // the audit emitters without pulling in the bodycapture package (which would
 // cause an import cycle via its dependency on transform).
 type fakeBodyCapture struct {
-	body      string
-	truncated bool
+	body              string
+	truncated         bool
+	respBody          string
+	respBodyTruncated bool
 }
 
-func (f *fakeBodyCapture) RequestBody() string        { return f.body }
-func (f *fakeBodyCapture) RequestBodyTruncated() bool { return f.truncated }
+func (f *fakeBodyCapture) RequestBody() string         { return f.body }
+func (f *fakeBodyCapture) RequestBodyTruncated() bool  { return f.truncated }
+func (f *fakeBodyCapture) ResponseBody() string        { return f.respBody }
+func (f *fakeBodyCapture) ResponseBodyTruncated() bool { return f.respBodyTruncated }
 
 func TestAudit_BodyCapture_PopulatesGroup(t *testing.T) {
 	result := &PipelineResult{
@@ -359,4 +363,55 @@ func TestAudit_BodyCapture_EmptyBodyOmitsGroup(t *testing.T) {
 
 	_, hasGroup := parsed["body_capture"]
 	require.False(t, hasGroup, "body_capture group should be absent when RequestBody() is empty")
+}
+
+func TestAudit_BodyCapture_ResponseFieldsJoinTheSameGroup(t *testing.T) {
+	// The response half is namespaced alongside the request half rather than
+	// getting a group of its own, so a consumer reads one record shape.
+	result := &PipelineResult{
+		Host:       "api.anthropic.com",
+		Method:     "POST",
+		Path:       "/v1/messages",
+		StartedAt:  time.Now(),
+		Duration:   1 * time.Millisecond,
+		Action:     ActionContinue,
+		StatusCode: 200,
+		BodyCapture: &fakeBodyCapture{
+			body:              `{"prompt":"hi"}`,
+			respBody:          "data: {\"delta\":\"hello\"}\n\n",
+			respBodyTruncated: true,
+		},
+	}
+
+	parsed, raw := captureAuditLog(result)
+
+	bc, ok := parsed["body_capture"].(map[string]any)
+	require.True(t, ok, "body_capture group should be present. raw=%s", raw)
+	require.Equal(t, `{"prompt":"hi"}`, bc["request_body"])
+	require.Equal(t, false, bc["request_body_truncated"])
+	require.Equal(t, "data: {\"delta\":\"hello\"}\n\n", bc["response_body"])
+	require.Equal(t, true, bc["response_body_truncated"])
+}
+
+func TestAudit_BodyCapture_ResponseOnlyStillEmitsGroup(t *testing.T) {
+	// A matching GET has no request body but its reply is still worth keeping,
+	// so the group appears with only the response half.
+	result := &PipelineResult{
+		Host:        "api.anthropic.com",
+		Method:      "GET",
+		Path:        "/v1/models",
+		StartedAt:   time.Now(),
+		Duration:    1 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{respBody: `{"data":[]}`},
+	}
+
+	parsed, raw := captureAuditLog(result)
+
+	bc, ok := parsed["body_capture"].(map[string]any)
+	require.True(t, ok, "body_capture group should be present. raw=%s", raw)
+	require.NotContains(t, bc, "request_body")
+	require.Equal(t, `{"data":[]}`, bc["response_body"])
+	require.Equal(t, false, bc["response_body_truncated"])
 }

--- a/internal/transform/body.go
+++ b/internal/transform/body.go
@@ -17,6 +17,9 @@ import (
 //
 // A maxBytes of 0 means unlimited; when the limit is exceeded the body is
 // truncated silently.
+//
+// TeeTo adds a third mode: an observer can take a streaming *copy* of the bytes
+// without forcing the all-or-nothing buffering above. See TeeTo.
 type BufferedBody struct {
 	once     sync.Once
 	mu       sync.Mutex // protects pos only
@@ -24,6 +27,7 @@ type BufferedBody struct {
 	data     []byte
 	pos      int
 	maxBytes int64
+	tee      io.Writer
 }
 
 // NewBufferedBody wraps an io.ReadCloser for lazy buffering. maxBytes caps
@@ -61,6 +65,35 @@ func (b *BufferedBody) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// TeeTo installs sink as a streaming copy of the bytes this body hands to its
+// consumer. Installing a tee does not read, buffer, or delay the body: the copy
+// happens byte-for-byte as the consumer (the response write or the upstream
+// send) pulls them through, so an observer can watch a slow or never-ending
+// stream without the consumer ever waiting on it.
+//
+// Two rules the sink must honor, because it sits inline on the consumer's read
+// path:
+//
+//   - Write must not block. Anything the sink waits for, the client waits for.
+//   - Write must bound its own memory. TeeTo imposes no cap; a sink that wants
+//     one drops the excess (see internal/transform/bodycapture) rather than
+//     applying back-pressure, which would stall the consumer.
+//
+// A sink write error is discarded: an observer failing must never turn into a
+// read error for the consumer.
+//
+// The copy happens exactly once, on whichever path consumes the underlying
+// reader - StreamingReader (which hands off original and clears it) or buffer()
+// (which consumes it under sync.Once). Only one of them can win. A body that is
+// never consumed is never tee'd, and a body replaced wholesale by a later
+// transform (NewBufferedBodyFromBytes) drops the tee with it.
+//
+// Call before the body is consumed; a later call has no effect on bytes already
+// delivered.
+func (b *BufferedBody) TeeTo(sink io.Writer) {
+	b.tee = sink
+}
+
 // buffer eagerly reads the entire original body into memory exactly once.
 func (b *BufferedBody) buffer() error {
 	var err error
@@ -72,6 +105,12 @@ func (b *BufferedBody) buffer() error {
 		b.data, err = io.ReadAll(r)
 		b.original.Close()
 		b.original = nil
+		// The buffering path consumed the reader, so StreamingReader will serve
+		// from b.data and never see the tee. Feed the sink here instead, so the
+		// copy still happens exactly once whichever path wins.
+		if b.tee != nil && len(b.data) > 0 {
+			_, _ = b.tee.Write(b.data)
+		}
 	})
 	return err
 }
@@ -92,6 +131,12 @@ func (b *BufferedBody) StreamingReader() io.Reader {
 	if b.original != nil {
 		r := b.original
 		b.original = nil
+		if b.tee != nil {
+			// Streaming path: the consumer drives the copy. Deliberately not
+			// io.TeeReader - that propagates a sink write error to the consumer,
+			// which would let a failing observer break the client's stream.
+			return &teeReader{r: r, w: b.tee}
+		}
 		return r
 	}
 	b.mu.Lock()
@@ -117,6 +162,24 @@ func (b *BufferedBody) Close() error {
 		return err
 	}
 	return nil
+}
+
+// teeReader copies what it reads into w, best effort. Unlike io.TeeReader it
+// swallows the sink's write errors and short writes: the reader's job is to
+// deliver bytes to the consumer, and an observer must never be able to fail
+// that. It intentionally implements neither io.WriterTo nor io.ReaderFrom, so
+// io.Copy cannot bypass Read and skip the copy.
+type teeReader struct {
+	r io.Reader
+	w io.Writer
+}
+
+func (t *teeReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 {
+		_, _ = t.w.Write(p[:n])
+	}
+	return n, err
 }
 
 // RequireBufferedBody asserts that body is a *BufferedBody and returns it.

--- a/internal/transform/body_tee_test.go
+++ b/internal/transform/body_tee_test.go
@@ -1,0 +1,128 @@
+package transform
+
+import (
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// countingSink records everything written to it and how many separate Write
+// calls it took, so a test can tell an incremental stream from one big flush.
+type countingSink struct {
+	mu     sync.Mutex
+	buf    []byte
+	writes int
+}
+
+func (s *countingSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf = append(s.buf, p...)
+	s.writes++
+	return len(p), nil
+}
+
+func (s *countingSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.buf)
+}
+
+func (s *countingSink) Writes() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writes
+}
+
+func TestBufferedBody_TeeTo_StreamingPathCopies(t *testing.T) {
+	sink := &countingSink{}
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("hello tee")), 1024)
+	body.TeeTo(sink)
+
+	// Installing a tee must not buffer: Len() == -1 means "never read".
+	require.Equal(t, -1, body.Len(), "TeeTo must not consume the body")
+
+	data, err := io.ReadAll(body.StreamingReader())
+	require.NoError(t, err)
+	require.Equal(t, "hello tee", string(data))
+	require.Equal(t, "hello tee", sink.String())
+}
+
+func TestBufferedBody_TeeTo_CopiesIncrementallyNotAtEOF(t *testing.T) {
+	// The whole point of a tee: the sink sees each chunk as the consumer reads
+	// it, so an observer never has to wait for the stream to finish. A
+	// buffer-then-forward implementation could only satisfy this at EOF.
+	sink := &countingSink{}
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("abcdef")), 1024)
+	body.TeeTo(sink)
+	reader := body.StreamingReader()
+
+	chunk := make([]byte, 2)
+	n, err := reader.Read(chunk)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, "ab", sink.String(), "sink must see the first chunk before EOF")
+
+	_, err = reader.Read(chunk)
+	require.NoError(t, err)
+	require.Equal(t, "abcd", sink.String())
+}
+
+func TestBufferedBody_TeeTo_BufferedPathCopiesExactlyOnce(t *testing.T) {
+	// When a transform reads the body (forcing buffering), the tee still fires —
+	// but exactly once, not once per consumer. Reading via Read() and then
+	// draining StreamingReader() must not double the sink's copy.
+	sink := &countingSink{}
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("once only")), 1024)
+	body.TeeTo(sink)
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "once only", string(data))
+	require.Equal(t, "once only", sink.String())
+	require.Equal(t, 1, sink.Writes())
+
+	body.Reset()
+	_, err = io.ReadAll(body.StreamingReader())
+	require.NoError(t, err)
+	require.Equal(t, "once only", sink.String(), "a second consumer must not duplicate the copy")
+	require.Equal(t, 1, sink.Writes())
+}
+
+// failingSink always errors, standing in for an observer that has broken.
+type failingSink struct{}
+
+func (failingSink) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }
+
+func TestBufferedBody_TeeTo_SinkErrorDoesNotBreakTheConsumer(t *testing.T) {
+	// A failing audit observer must never surface as a read error on the
+	// client's stream. This is why the tee is not io.TeeReader.
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("still delivered")), 1024)
+	body.TeeTo(failingSink{})
+
+	data, err := io.ReadAll(body.StreamingReader())
+	require.NoError(t, err)
+	require.Equal(t, "still delivered", string(data))
+}
+
+func TestBufferedBody_TeeTo_NeverConsumed_NothingCopied(t *testing.T) {
+	sink := &countingSink{}
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("unread")), 1024)
+	body.TeeTo(sink)
+
+	require.NoError(t, body.Close())
+	require.Equal(t, "", sink.String())
+	require.Equal(t, 0, sink.Writes())
+}
+
+func TestBufferedBody_NoTee_StreamingReaderIsTheOriginal(t *testing.T) {
+	// Without a tee installed, StreamingReader must still hand back the
+	// original reader untouched — no wrapper, no per-Read indirection for the
+	// overwhelmingly common case where nothing is observing.
+	body := NewBufferedBody(io.NopCloser(strings.NewReader("passthrough")), 1024)
+	_, wrapped := body.StreamingReader().(*teeReader)
+	require.False(t, wrapped, "an un-tee'd body must not be wrapped")
+}

--- a/internal/transform/bodycapture/bodycapture.go
+++ b/internal/transform/bodycapture/bodycapture.go
@@ -1,20 +1,45 @@
-// Package bodycapture implements a transform that captures request bodies of
-// matching requests and exposes them via PipelineResult.BodyCapture for the
-// audit emitters to render as a `body_capture` group holding `request_body`
-// and `request_body_truncated`.
+// Package bodycapture implements a transform that captures the request bodies
+// of matching requests - and, when explicitly enabled, their response bodies -
+// and exposes them via PipelineResult.BodyCapture for the audit emitters to
+// render as a `body_capture` group holding `request_body`,
+// `request_body_truncated`, `response_body` and `response_body_truncated`.
 //
-// This transform captures request bodies only. It does not capture response
-// bodies: BufferedBody buffers then replays rather than streaming, so reading
-// a response body in a transform would stall SSE-streaming model replies
-// (Anthropic / OpenAI) for the duration of the stream.
+// The two halves are captured by different mechanisms, and the difference is
+// the whole design:
+//
+//   - A REQUEST is already fully in hand before it can go upstream, so it is
+//     read via BufferedBody and copied.
+//   - A RESPONSE is TEE'D, never buffered-then-forwarded. Model replies stream:
+//     an Anthropic or OpenAI SSE reply trickles for as long as the model talks.
+//     Buffering a reply in order to copy it would hold the client's bytes
+//     hostage for the length of the stream, which is a visible hang; missing
+//     the audit signal is strictly better than that. So the copy rides
+//     BufferedBody.TeeTo, the client's own reads drive it, and bytes past the
+//     cap are DROPPED rather than queued - dropping cannot apply back-pressure,
+//     queueing can.
+//
+// What lands in `response_body` is the raw reply as it went over the wire, only
+// content-decoded (gzip/deflate) when the upstream compressed it. SSE frames
+// are NOT merged and JSON is NOT parsed here: the consumer of these records
+// does that, and doing it in the proxy would mean guessing at a provider's
+// streaming shape in the one place that must never slow down.
+//
+// Response capture is off by default. Set `capture_response_body: true` to turn
+// it on.
 package bodycapture
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
@@ -34,16 +59,29 @@ func init() {
 // surface lets downstream consumers see when this happens.
 const defaultMaxRequestBodyBytes = 16 * 1024
 
+// defaultMaxResponseBodyBytes is the per-response cap when response capture is
+// enabled without specifying max_response_body_bytes. Larger than the request
+// cap because a reply is the payload a consumer actually reads, while a request
+// is context — and because an SSE reply spends most of its bytes on frame
+// envelopes rather than text. Deployments should set the key explicitly rather
+// than inherit this; the excess past the cap is dropped as it streams by, never
+// queued.
+const defaultMaxResponseBodyBytes = 64 * 1024
+
 // bodyCapture is the transform itself. Unexported because all external use
 // goes through the factory registration.
 type bodyCapture struct {
-	rules               []hostmatch.Rule
-	maxRequestBodyBytes int64
+	rules                []hostmatch.Rule
+	maxRequestBodyBytes  int64
+	captureResponseBody  bool
+	maxResponseBodyBytes int64
 }
 
 type config struct {
-	MaxRequestBodyBytes int64                  `yaml:"max_request_body_bytes"`
-	Rules               []hostmatch.RuleConfig `yaml:"rules"`
+	MaxRequestBodyBytes  int64                  `yaml:"max_request_body_bytes"`
+	CaptureResponseBody  bool                   `yaml:"capture_response_body"`
+	MaxResponseBodyBytes int64                  `yaml:"max_response_body_bytes"`
+	Rules                []hostmatch.RuleConfig `yaml:"rules"`
 }
 
 func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
@@ -55,11 +93,20 @@ func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
 	if err != nil {
 		return nil, err
 	}
-	maxBytes := c.MaxRequestBodyBytes
-	if maxBytes <= 0 {
-		maxBytes = defaultMaxRequestBodyBytes
+	maxReq := c.MaxRequestBodyBytes
+	if maxReq <= 0 {
+		maxReq = defaultMaxRequestBodyBytes
 	}
-	return &bodyCapture{rules: rules, maxRequestBodyBytes: maxBytes}, nil
+	maxResp := c.MaxResponseBodyBytes
+	if maxResp <= 0 {
+		maxResp = defaultMaxResponseBodyBytes
+	}
+	return &bodyCapture{
+		rules:                rules,
+		maxRequestBodyBytes:  maxReq,
+		captureResponseBody:  c.CaptureResponseBody,
+		maxResponseBodyBytes: maxResp,
+	}, nil
 }
 
 // Name returns the transform's registered name.
@@ -96,24 +143,10 @@ func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.Transf
 	}
 	truncated := false
 	if int64(len(data)) > b.maxRequestBodyBytes {
-		data = data[:b.maxRequestBodyBytes]
+		data = trimPartialRune(data[:b.maxRequestBodyBytes])
 		truncated = true
-		// The byte-boundary cut above may have split a multi-byte UTF-8 rune,
-		// leaving an invalid trailing fragment that renders as U+FFFD in the
-		// audit JSON. Drop up to UTFMax-1 trailing bytes to land on a rune
-		// boundary. Bounded so a body that is genuinely not UTF-8 (binary)
-		// keeps its tail rather than being progressively stripped.
-		for i := 0; i < utf8.UTFMax-1 && len(data) > 0; i++ {
-			if r, size := utf8.DecodeLastRune(data); r != utf8.RuneError || size > 1 {
-				break
-			}
-			data = data[:len(data)-1]
-		}
 	}
-	tctx.BodyCapture = &capture{
-		requestBody:          string(data),
-		requestBodyTruncated: truncated,
-	}
+	b.captureFor(tctx).setRequest(string(data), truncated)
 	// Lightweight markers on the transform's own trace entry so the
 	// request_transforms array self-documents that a body was captured. The
 	// body itself is not duplicated here — it lives in the top-level
@@ -123,17 +156,268 @@ func (b *bodyCapture) TransformRequest(_ context.Context, tctx *transform.Transf
 	return cont, nil
 }
 
-// TransformResponse is a no-op for body_capture. See the package doc for why
-// response bodies are not captured.
-func (b *bodyCapture) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
-	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+// TransformResponse arranges for the response body to be TEE'D into the audit
+// capture as it streams to the client. It does not read, buffer, or delay the
+// body: installing the tee is O(1), and the client's own reads drive the copy
+// (see transform.BufferedBody.TeeTo). A reply that trickles for two minutes is
+// forwarded byte-for-byte as it arrives, and the capture simply holds whatever
+// went past by the time the audit record is emitted — which the proxy defers
+// until after the body has been written to the client.
+//
+// A no-op unless `capture_response_body: true`, so an existing configuration
+// sees exactly the behavior it saw before.
+//
+// Always returns ActionContinue: body_capture is observation-only and never
+// rejects or rewrites a response. A response whose Content-Encoding this
+// transform cannot decode is deliberately NOT captured — see decodable — since
+// shipping undecodable bytes into the audit log spends the byte budget on
+// something no consumer can read.
+func (b *bodyCapture) TransformResponse(_ context.Context, tctx *transform.TransformContext, req *http.Request, resp *http.Response) (*transform.TransformResult, error) {
+	cont := &transform.TransformResult{Action: transform.ActionContinue}
+	if !b.captureResponseBody {
+		return cont, nil
+	}
+	if !hostmatch.MatchAnyRule(b.rules, req) {
+		return cont, nil
+	}
+	if resp == nil || resp.Body == nil || resp.Body == http.NoBody {
+		return cont, nil
+	}
+	enc := normalizeEncoding(resp.Header.Get("Content-Encoding"))
+	if !decodable(enc) {
+		// br / zstd / a chain of encodings. Annotate so the gap is visible on
+		// the audit trace instead of silently reading as "the upstream said
+		// nothing".
+		tctx.Annotate("response_body_encoding_unsupported", enc)
+		return cont, nil
+	}
+	bb, ok := resp.Body.(*transform.BufferedBody)
+	if !ok {
+		// A transform ahead of this one replaced the body with something that
+		// isn't a BufferedBody. Nothing to tee off; don't panic over an audit
+		// concern the way RequireBufferedBody would.
+		tctx.Annotate("response_body_capture_skipped", fmt.Sprintf("%T", resp.Body))
+		return cont, nil
+	}
+	c := b.captureFor(tctx)
+	c.armResponse(enc)
+	bb.TeeTo(c)
+	return cont, nil
 }
 
-// capture is the concrete implementation of transform.BodyCapture.
+// captureFor returns the per-request capture, creating and installing it on the
+// TransformContext the first time either leg needs it. The request leg usually
+// creates it, but a matching request with no body (or one whose body failed to
+// read) leaves it nil, and the response leg still has something worth keeping.
+func (b *bodyCapture) captureFor(tctx *transform.TransformContext) *capture {
+	if existing, ok := tctx.BodyCapture.(*capture); ok && existing != nil {
+		return existing
+	}
+	c := &capture{maxResponseBodyBytes: b.maxResponseBodyBytes}
+	tctx.BodyCapture = c
+	return c
+}
+
+// capture is the concrete implementation of transform.BodyCapture. One per
+// request. The response half is written by whichever goroutine streams the
+// response body and read by the audit callback, so every field goes through the
+// mutex — the two are the same goroutine in today's proxy, but an audit sink
+// that ever moves off it must not turn into a data race.
 type capture struct {
+	mu                   sync.Mutex
 	requestBody          string
 	requestBodyTruncated bool
+	responseEncoding     string
+	maxResponseBodyBytes int64
+	responseRaw          []byte
+	responseTruncated    bool
+	responseDecoded      string
+	responseDecodedValid bool
 }
 
-func (c *capture) RequestBody() string        { return c.requestBody }
-func (c *capture) RequestBodyTruncated() bool { return c.requestBodyTruncated }
+func (c *capture) setRequest(body string, truncated bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.requestBody = body
+	c.requestBodyTruncated = truncated
+}
+
+// armResponse records that a tee is about to be installed, along with the
+// content encoding the captured bytes will be in.
+func (c *capture) armResponse(encoding string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.responseEncoding = encoding
+	c.responseRaw = nil
+	c.responseTruncated = false
+	c.responseDecoded = ""
+	c.responseDecodedValid = false
+}
+
+// Write implements io.Writer as the tee sink for the response body.
+//
+// It is bounded and NON-BLOCKING BY CONSTRUCTION. Bytes past the cap are
+// dropped and the write still reports full success, because this Write sits
+// inline on the client's read path: anything it waited for — a lock held
+// elsewhere, a channel, a flush, room in a queue — the client would wait for
+// too. Reporting a short write or an error would be just as bad, since a strict
+// tee would surface it as a read error on the client's stream.
+func (c *capture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.responseDecoded = ""
+	c.responseDecodedValid = false
+	room := c.maxResponseBodyBytes - int64(len(c.responseRaw))
+	switch {
+	case room <= 0:
+		c.responseTruncated = true
+	case int64(len(p)) > room:
+		c.responseRaw = append(c.responseRaw, p[:room]...)
+		c.responseTruncated = true
+	default:
+		c.responseRaw = append(c.responseRaw, p...)
+	}
+	return len(p), nil
+}
+
+func (c *capture) RequestBody() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.requestBody
+}
+
+func (c *capture) RequestBodyTruncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.requestBodyTruncated
+}
+
+// ResponseBody returns the tee'd bytes, content-decoded if needed. Decoding
+// happens here rather than in Write so the client's read path never pays for
+// it: by the time anything calls this, the response has already been forwarded.
+func (c *capture) ResponseBody() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decodeLocked()
+	return c.responseDecoded
+}
+
+// ResponseBodyTruncated reports whether the capture lost the tail of the reply —
+// either because the wire bytes hit the cap, or because decoding a compressed
+// reply hit it. For SSE a truncated capture simply loses its trailing frames.
+func (c *capture) ResponseBodyTruncated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.decodeLocked()
+	return c.responseTruncated
+}
+
+// decodeLocked memoizes the decoded body and folds any decode-side truncation
+// into responseTruncated, so the two accessors agree no matter which is called
+// first. Caller holds c.mu.
+func (c *capture) decodeLocked() {
+	if c.responseDecodedValid {
+		return
+	}
+	decoded, clipped := decodeBody(c.responseRaw, c.responseEncoding, c.maxResponseBodyBytes)
+	if clipped {
+		c.responseTruncated = true
+	}
+	if c.responseTruncated {
+		decoded = trimPartialRune(decoded)
+	}
+	c.responseDecoded = string(decoded)
+	c.responseDecodedValid = true
+}
+
+// trimPartialRune drops a dangling multi-byte UTF-8 fragment from the end of a
+// body that was cut at a byte boundary, which would otherwise render as U+FFFD
+// in the audit JSON. Bounded to UTFMax-1 bytes so a body that is genuinely not
+// UTF-8 (binary) keeps its tail rather than being progressively stripped.
+func trimPartialRune(data []byte) []byte {
+	for i := 0; i < utf8.UTFMax-1 && len(data) > 0; i++ {
+		if r, size := utf8.DecodeLastRune(data); r != utf8.RuneError || size > 1 {
+			break
+		}
+		data = data[:len(data)-1]
+	}
+	return data
+}
+
+// normalizeEncoding lowercases and trims a Content-Encoding header value.
+func normalizeEncoding(v string) string {
+	return strings.ToLower(strings.TrimSpace(v))
+}
+
+// decodable reports whether decodeBody can turn bytes in this encoding back
+// into text. Anything else (br, zstd, or a comma-separated chain) is not
+// captured at all.
+func decodable(enc string) bool {
+	switch enc {
+	case "", "identity", "gzip", "x-gzip", "deflate":
+		return true
+	default:
+		return false
+	}
+}
+
+// decodeBody content-decodes captured wire bytes, returning the decoded body and
+// whether the decode was clipped by max.
+//
+// A truncated input stream is expected and normal — the tee's cap cuts it
+// mid-stream — so a decode error after some output has been produced keeps that
+// output rather than discarding the reply.
+//
+// max also bounds the OUTPUT, which is the point: the cap on the tee bounds the
+// compressed bytes, and a compression ratio is not something this process gets
+// to choose. Without an output bound, a small stream that expands enormously
+// would size the audit copy for us.
+func decodeBody(data []byte, enc string, max int64) ([]byte, bool) {
+	if len(data) == 0 {
+		return nil, false
+	}
+	switch enc {
+	case "", "identity":
+		return data, false
+	case "gzip", "x-gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, false
+		}
+		// Close errors are ignored throughout: these readers wrap an in-memory
+		// slice, and a checksum complaint on the deliberately truncated tail is
+		// expected rather than informative.
+		defer func() { _ = zr.Close() }()
+		return readAllBounded(zr, max)
+	case "deflate":
+		// RFC 9110 "deflate" is zlib-wrapped, but raw deflate is common enough
+		// in the wild that it is worth the second attempt.
+		if zr, err := zlib.NewReader(bytes.NewReader(data)); err == nil {
+			defer func() { _ = zr.Close() }()
+			if out, clipped := readAllBounded(zr, max); len(out) > 0 {
+				return out, clipped
+			}
+		}
+		fr := flate.NewReader(bytes.NewReader(data))
+		defer func() { _ = fr.Close() }()
+		return readAllBounded(fr, max)
+	default:
+		return nil, false
+	}
+}
+
+// readAllBounded reads at most max bytes from r, reporting whether there was
+// more. A max of 0 or less means unbounded.
+func readAllBounded(r io.Reader, max int64) ([]byte, bool) {
+	if max <= 0 {
+		out, _ := io.ReadAll(r)
+		return out, false
+	}
+	// Read one byte past the cap so hitting it exactly is distinguishable from
+	// overflowing it.
+	out, _ := io.ReadAll(io.LimitReader(r, max+1))
+	if int64(len(out)) > max {
+		return out[:max], true
+	}
+	return out, false
+}

--- a/internal/transform/bodycapture/bodycapture_test.go
+++ b/internal/transform/bodycapture/bodycapture_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 // newTransform constructs a bodyCapture for testing without going through the
-// YAML factory. Tests pin behavior, not parsing.
+// YAML factory, with response capture off — the shipped default. Tests pin
+// behavior, not parsing.
 func newTransform(t *testing.T, maxBytes int64, rules []hostmatch.RuleConfig) *bodyCapture {
 	t.Helper()
 	compiled, err := hostmatch.CompileRules(rules, "body_capture")
@@ -24,6 +25,20 @@ func newTransform(t *testing.T, maxBytes int64, rules []hostmatch.RuleConfig) *b
 	return &bodyCapture{
 		rules:               compiled,
 		maxRequestBodyBytes: maxBytes,
+	}
+}
+
+// newResponseTransform is newTransform with response capture enabled and both
+// caps pinned, for the tests that exercise the response half.
+func newResponseTransform(t *testing.T, maxRequest, maxResponse int64, rules []hostmatch.RuleConfig) *bodyCapture {
+	t.Helper()
+	compiled, err := hostmatch.CompileRules(rules, "body_capture")
+	require.NoError(t, err)
+	return &bodyCapture{
+		rules:                compiled,
+		maxRequestBodyBytes:  maxRequest,
+		captureResponseBody:  true,
+		maxResponseBodyBytes: maxResponse,
 	}
 }
 
@@ -164,10 +179,11 @@ func TestBodyCapture_MultipleRules_FirstMatchCapturesOnce(t *testing.T) {
 	require.False(t, tctx.BodyCapture.RequestBodyTruncated())
 }
 
-func TestBodyCapture_TransformResponse_IsNoop(t *testing.T) {
-	// TransformResponse must NOT touch the response body — doing so would
-	// force-buffer streaming SSE responses (Claude/OpenAI replies), stalling
-	// the client. This test pins that behavior.
+func TestBodyCapture_TransformResponse_IsNoopByDefault(t *testing.T) {
+	// Response capture is opt-in. Without `capture_response_body: true` the
+	// response leg must not touch the response body at all — an existing
+	// configuration sees exactly the behavior it saw before. The tests in
+	// response_test.go cover the opted-in path.
 	bc := newTransform(t, 16*1024, []hostmatch.RuleConfig{
 		{Host: "api.anthropic.com"},
 	})
@@ -197,4 +213,6 @@ func TestBodyCapture_BodyCaptureInterface(t *testing.T) {
 	c := &capture{requestBody: "hi", requestBodyTruncated: true}
 	require.Equal(t, "hi", c.RequestBody())
 	require.True(t, c.RequestBodyTruncated())
+	require.Equal(t, "", c.ResponseBody())
+	require.False(t, c.ResponseBodyTruncated())
 }

--- a/internal/transform/bodycapture/response_test.go
+++ b/internal/transform/bodycapture/response_test.go
@@ -1,0 +1,637 @@
+package bodycapture
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// The tests in this file cover the response half of body_capture. The two
+// load-bearing ones are TestBodyCaptureResponse_NeverBlocksOnANeverEndingBody
+// and TestBodyCaptureResponse_CapTruncatesInsteadOfStalling: an audit copy that
+// can wait on a slow model reply — or that applies back-pressure when it runs
+// out of room — is a client-visible hang, which is exactly the trade-off the
+// package used to refuse response capture over. Both are asserted under a
+// deadline so a regression fails the suite instead of hanging it.
+
+const testDeadline = 3 * time.Second
+
+// steppedBody is an upstream response body that hands out its chunks one at a
+// time and then BLOCKS on hold until the test releases it. With a nil hold it
+// simply ends. It stands in for a streaming model reply that is still being
+// generated.
+type steppedBody struct {
+	mu       sync.Mutex
+	chunks   [][]byte
+	leftover []byte
+	hold     <-chan struct{}
+	closed   bool
+}
+
+func newSteppedBody(hold <-chan struct{}, chunks ...string) *steppedBody {
+	b := &steppedBody{hold: hold}
+	for _, c := range chunks {
+		b.chunks = append(b.chunks, []byte(c))
+	}
+	return b
+}
+
+func (b *steppedBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	if len(b.leftover) > 0 {
+		n := copy(p, b.leftover)
+		b.leftover = b.leftover[n:]
+		b.mu.Unlock()
+		return n, nil
+	}
+	if len(b.chunks) > 0 {
+		chunk := b.chunks[0]
+		b.chunks = b.chunks[1:]
+		n := copy(p, chunk)
+		b.leftover = chunk[n:]
+		b.mu.Unlock()
+		return n, nil
+	}
+	hold := b.hold
+	b.mu.Unlock()
+	if hold != nil {
+		// Out of chunks but not done: the model is still thinking. A
+		// buffer-then-forward implementation parks here forever.
+		<-hold
+	}
+	return 0, io.EOF
+}
+
+func (b *steppedBody) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	return nil
+}
+
+func (b *steppedBody) wasClosed() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closed
+}
+
+// makeResponse wraps body in a BufferedBody the way proxy.handleHTTP does
+// before the response pipeline runs, with optional headers.
+func makeResponse(body io.ReadCloser, header http.Header) *http.Response {
+	if header == nil {
+		header = http.Header{}
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		// 0 = unlimited, matching the proxy's default BodyLimits.
+		Body: transform.NewBufferedBody(body, 0),
+	}
+}
+
+// forwardToClient drains the response body the way the proxy's writeResponse /
+// streamSSE do — through StreamingReader, chunk by chunk — and returns what the
+// client saw. Fails the test if it takes longer than testDeadline.
+func forwardToClient(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
+	type result struct {
+		data string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		data, err := io.ReadAll(reader)
+		done <- result{string(data), err}
+	}()
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		return r.data
+	case <-time.After(testDeadline):
+		t.Fatal("forwarding the response body to the client did not finish within the deadline")
+		return ""
+	}
+}
+
+func messagesRules() []hostmatch.RuleConfig {
+	return []hostmatch.RuleConfig{
+		{Host: "api.anthropic.com", Methods: []string{"POST"}, Paths: []string{"/v1/messages"}},
+	}
+}
+
+func TestBodyCaptureResponse_TeesRatherThanBuffering(t *testing.T) {
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader(`{"content":[{"type":"text","text":"hi"}]}`)), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	res, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	// The contract that keeps the proxy honest: after TransformResponse the body
+	// is still UNREAD (Len() == -1 means "never buffered"), and the capture is
+	// still empty. If a future change goes back to reading the body here, both
+	// of these fail.
+	require.Equal(t, -1, transform.RequireBufferedBody(resp.Body).Len(),
+		"TransformResponse must not buffer the response body")
+	require.Equal(t, "", tctx.BodyCapture.ResponseBody(),
+		"nothing should be captured until the body actually streams")
+
+	got := forwardToClient(t, resp)
+	require.Equal(t, `{"content":[{"type":"text","text":"hi"}]}`, got)
+	require.Equal(t, got, tctx.BodyCapture.ResponseBody(),
+		"the capture is a copy of exactly what the client received")
+	require.False(t, tctx.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestBodyCaptureResponse_NeverBlocksOnANeverEndingBody(t *testing.T) {
+	// A reply that produces two frames and then hangs — a model that is still
+	// generating, or an upstream that stalls. The client must still get those
+	// two frames, and the audit copy must already hold them, while the stream is
+	// open. Buffer-then-forward would deliver nothing until the hang cleared.
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"stream":true}`)
+	body := newSteppedBody(hold,
+		"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"one\"}}\n\n",
+		"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"two\"}}\n\n",
+	)
+	resp := makeResponse(body, http.Header{"Content-Type": []string{"text/event-stream"}})
+	tctx := &transform.TransformContext{}
+
+	// 1. Installing the tee returns immediately; it never touches the body.
+	installed := make(chan error, 1)
+	go func() {
+		_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+		installed <- err
+	}()
+	select {
+	case err := <-installed:
+		require.NoError(t, err)
+	case <-time.After(testDeadline):
+		t.Fatal("TransformResponse blocked on a body that has not finished — it must only install a tee")
+	}
+
+	// 2. The client's reads still land while upstream is mid-stream.
+	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
+	buf := make([]byte, 32*1024)
+	for i := 1; i <= 2; i++ {
+		type readResult struct {
+			n   int
+			err error
+		}
+		done := make(chan readResult, 1)
+		go func() {
+			n, err := reader.Read(buf)
+			done <- readResult{n, err}
+		}()
+		select {
+		case r := <-done:
+			require.NoError(t, r.err)
+			require.Greater(t, r.n, 0, "client read %d returned no bytes", i)
+		case <-time.After(testDeadline):
+			t.Fatalf("client read %d blocked while the response body was still streaming", i)
+		}
+
+		// 3. And the audit copy is already there — mid-stream, not at EOF.
+		require.Contains(t, tctx.BodyCapture.ResponseBody(),
+			[]string{"\"one\"", "\"two\""}[i-1],
+			"tee must capture frame %d as it passes, not after the stream ends", i)
+	}
+
+	// The stream is still open (the body is still holding), yet both frames have
+	// been delivered and captured.
+	require.False(t, body.wasClosed(), "the upstream body should still be open")
+	require.False(t, tctx.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestBodyCaptureResponse_CapTruncatesInsteadOfStalling(t *testing.T) {
+	// The cap bounds the audit copy, not the client's stream. Past the cap the
+	// sink drops bytes and keeps reporting success: it must never withhold room
+	// as back-pressure, because that back-pressure lands on the client.
+	const capBytes = 100
+	const chunk = 512
+	const chunks = 40 // 20 KiB total, 200x the cap
+
+	bc := newResponseTransform(t, 16*1024, capBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+
+	pieces := make([]string, chunks)
+	for i := range pieces {
+		pieces[i] = strings.Repeat("y", chunk)
+	}
+	// No hold: this body ends. The deadline in forwardToClient is what proves
+	// the oversized stream is not stalled by the full sink.
+	resp := makeResponse(newSteppedBody(nil, pieces...), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	got := forwardToClient(t, resp)
+	require.Equal(t, chunk*chunks, len(got),
+		"the client must receive every byte regardless of the audit cap")
+
+	require.Equal(t, capBytes, len(tctx.BodyCapture.ResponseBody()),
+		"the audit copy must stop at exactly the cap")
+	require.Equal(t, strings.Repeat("y", capBytes), tctx.BodyCapture.ResponseBody())
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated(),
+		"truncation must be reported, not silent")
+}
+
+func TestBodyCaptureResponse_TruncationTrimsPartialUTF8Rune(t *testing.T) {
+	// Same rune-boundary care the request path takes: a cap that lands mid-rune
+	// must not leave a dangling fragment that renders as U+FFFD in the audit
+	// JSON. "€" is 3 bytes (0xE2 0x82 0xAC); with a body of "ab€cd" and a cap of
+	// 4, the naive cut keeps "ab" plus the first 2 bytes of "€".
+	const capBytes = 4
+	bc := newResponseTransform(t, 16*1024, capBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader("ab€cd")), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, "ab€cd", forwardToClient(t, resp), "the client still gets every byte")
+
+	got := tctx.BodyCapture.ResponseBody()
+	require.True(t, utf8.ValidString(got), "captured body must be valid UTF-8, got %q", got)
+	require.Equal(t, "ab", got, "partial trailing rune should be trimmed back to a boundary")
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestBodyCaptureResponse_BinaryTailSurvivesTruncation(t *testing.T) {
+	// The rune trim is bounded to UTFMax-1 bytes so a body that is genuinely not
+	// UTF-8 keeps its tail rather than being progressively stripped.
+	const capBytes = 8
+	bc := newResponseTransform(t, 16*1024, capBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	binary := string([]byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6})
+	resp := makeResponse(io.NopCloser(strings.NewReader(binary)), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	forwardToClient(t, resp)
+
+	// 8 bytes capped, at most 3 trimmed — never the whole thing.
+	require.GreaterOrEqual(t, len(tctx.BodyCapture.ResponseBody()), capBytes-(utf8.UTFMax-1))
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestBodyCaptureResponse_SSECapturedRawAndUnmerged(t *testing.T) {
+	// Merging SSE frames or pre-parsing JSON is the log consumer's job. Doing it
+	// here would mean guessing at a provider's streaming shape in the one place
+	// that must stay fast and provider-agnostic, so the capture hands over the
+	// concatenated raw body.
+	sse := strings.Join([]string{
+		"event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+		"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"def \"}}\n\n",
+		"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"main():\"}}\n\n",
+		"data: [DONE]\n\n",
+	}, "")
+
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"stream":true}`)
+	resp := makeResponse(
+		io.NopCloser(strings.NewReader(sse)),
+		http.Header{"Content-Type": []string{"text/event-stream"}},
+	)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, sse, forwardToClient(t, resp))
+
+	captured := tctx.BodyCapture.ResponseBody()
+	require.Equal(t, sse, captured, "SSE must be captured byte-for-byte")
+	require.Contains(t, captured, "data: [DONE]", "envelope lines must survive")
+	require.NotEqual(t, "def main():", captured, "the proxy must not merge the deltas itself")
+}
+
+func TestBodyCaptureResponse_NoMatch_NothingCaptured(t *testing.T) {
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "example.com", "/anywhere", `{"x":1}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader("not ours")), nil)
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Nil(t, tctx.BodyCapture)
+
+	// And the body still reaches the client untouched.
+	require.Equal(t, "not ours", forwardToClient(t, resp))
+}
+
+func TestBodyCaptureResponse_BodylessRequest_StillCapturesTheResponse(t *testing.T) {
+	// A matching request with no body of its own leaves BodyCapture nil on the
+	// request leg. The response leg has to create it, or a GET's reply would be
+	// dropped on the floor.
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, []hostmatch.RuleConfig{{Host: "api.anthropic.com"}})
+	req := httptest.NewRequest("GET", "http://api.anthropic.com/v1/models", nil)
+	req.Host = "api.anthropic.com"
+	req.Body = transform.NewBufferedBody(req.Body, 1024)
+	resp := makeResponse(io.NopCloser(strings.NewReader(`{"data":[]}`)), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Nil(t, tctx.BodyCapture, "no request body to capture")
+
+	_, err = bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.NotNil(t, tctx.BodyCapture, "the response leg must create the capture")
+
+	require.Equal(t, `{"data":[]}`, forwardToClient(t, resp))
+	require.Equal(t, `{"data":[]}`, tctx.BodyCapture.ResponseBody())
+	require.Equal(t, "", tctx.BodyCapture.RequestBody())
+}
+
+func TestBodyCaptureResponse_SharesOneCaptureWithTheRequestLeg(t *testing.T) {
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"prompt":"hi"}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader("reply")), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	first := tctx.BodyCapture
+
+	_, err = bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Same(t, first, tctx.BodyCapture, "both legs must write the same capture")
+
+	forwardToClient(t, resp)
+	require.Equal(t, `{"prompt":"hi"}`, tctx.BodyCapture.RequestBody())
+	require.Equal(t, "reply", tctx.BodyCapture.ResponseBody())
+}
+
+func TestBodyCaptureResponse_GzipDecoded(t *testing.T) {
+	// An upstream that honors the client's Accept-Encoding sends compressed
+	// bytes. Capturing them raw would hand the log consumer binary noise, so the
+	// capture decodes — but only when read, after the client already has its
+	// bytes, never on the streaming path.
+	const plain = `{"content":[{"type":"text","text":"compressed reply"}]}`
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, err := zw.Write([]byte(plain))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	wire := gz.String()
+
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(
+		io.NopCloser(strings.NewReader(wire)),
+		http.Header{"Content-Encoding": []string{"gzip"}},
+	)
+	tctx := &transform.TransformContext{}
+
+	_, err = bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	require.Equal(t, wire, forwardToClient(t, resp),
+		"the client must receive the compressed bytes unchanged")
+	require.Equal(t, plain, tctx.BodyCapture.ResponseBody())
+}
+
+func TestBodyCaptureResponse_GzipDecodeIsBoundedByTheCap(t *testing.T) {
+	// The tee's cap bounds COMPRESSED bytes, and a compression ratio is not ours
+	// to pick: a few KiB of gzip can decode to megabytes. The decode is bounded
+	// too, and reports the clip as truncation.
+	const capBytes = 8 * 1024
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, err := zw.Write([]byte(strings.Repeat("A", 8*1024*1024))) // ~8 KiB compressed
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.Less(t, gz.Len(), capBytes, "the compressed form must fit under the cap for this test to mean anything")
+
+	bc := newResponseTransform(t, 16*1024, capBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(
+		io.NopCloser(bytes.NewReader(gz.Bytes())),
+		http.Header{"Content-Encoding": []string{"gzip"}},
+	)
+	tctx := &transform.TransformContext{}
+
+	_, err = bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	forwardToClient(t, resp)
+
+	require.Equal(t, capBytes, len(tctx.BodyCapture.ResponseBody()),
+		"the decoded copy must be bounded by the cap, not by the compression ratio")
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated())
+}
+
+func TestBodyCaptureResponse_TruncatedFlagAgreesWhicheverAccessorRunsFirst(t *testing.T) {
+	// The emitters call ResponseBody() then ResponseBodyTruncated(); nothing
+	// should depend on that order, since decode-side clipping is discovered
+	// during the decode.
+	const capBytes = 512
+	var gz bytes.Buffer
+	zw := gzip.NewWriter(&gz)
+	_, err := zw.Write([]byte(strings.Repeat("B", 1024*1024)))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	bc := newResponseTransform(t, 16*1024, capBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(
+		io.NopCloser(bytes.NewReader(gz.Bytes())),
+		http.Header{"Content-Encoding": []string{"gzip"}},
+	)
+	tctx := &transform.TransformContext{}
+
+	_, err = bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	forwardToClient(t, resp)
+
+	// Truncated first, body second — the reverse of the emitters' order.
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated())
+	require.Equal(t, capBytes, len(tctx.BodyCapture.ResponseBody()))
+}
+
+func TestBodyCaptureResponse_UnsupportedEncodingSkippedAndAnnotated(t *testing.T) {
+	// brotli/zstd: capturing bytes nothing downstream can decode would burn the
+	// audit byte budget on noise. Skip, and say so on the trace so the gap is
+	// visible rather than looking like an empty reply.
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(
+		io.NopCloser(strings.NewReader("\x1b brotli bytes")),
+		http.Header{"Content-Encoding": []string{"br"}},
+	)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	require.Equal(t, "\x1b brotli bytes", forwardToClient(t, resp))
+	if tctx.BodyCapture != nil {
+		require.Equal(t, "", tctx.BodyCapture.ResponseBody())
+	}
+	require.Equal(t, "br", tctx.DrainAnnotations()["response_body_encoding_unsupported"])
+}
+
+func TestBodyCaptureResponse_ClientDisconnectKeepsThePartialCopy(t *testing.T) {
+	// The client gives up mid-reply. Whatever already streamed is still valid
+	// audit data; the capture must not be all-or-nothing.
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(newSteppedBody(hold, "data: partial\n\n"), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	reader := transform.RequireBufferedBody(resp.Body).StreamingReader()
+	buf := make([]byte, 4096)
+	n, err := reader.Read(buf)
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+	// ...and the client walks away without reading the rest.
+
+	require.Equal(t, "data: partial\n\n", tctx.BodyCapture.ResponseBody())
+	require.False(t, tctx.BodyCapture.ResponseBodyTruncated(),
+		"a short read is not a cap truncation")
+}
+
+func TestBodyCaptureResponse_NoResponseBody(t *testing.T) {
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := &http.Response{StatusCode: http.StatusNoContent, Header: http.Header{}, Body: http.NoBody}
+	tctx := &transform.TransformContext{}
+
+	res, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Nil(t, tctx.BodyCapture)
+}
+
+func TestBodyCaptureResponse_NonBufferedBodySkippedNotPanicked(t *testing.T) {
+	// A transform ahead of this one can hand back a plain body. That is an audit
+	// concern, not a request-killing one — RequireBufferedBody would panic.
+	bc := newResponseTransform(t, 16*1024, defaultMaxResponseBodyBytes, messagesRules())
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("plain body")),
+	}
+	tctx := &transform.TransformContext{}
+
+	require.NotPanics(t, func() {
+		res, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+		require.NoError(t, err)
+		require.Equal(t, transform.ActionContinue, res.Action)
+	})
+	require.Contains(t, tctx.DrainAnnotations(), "response_body_capture_skipped")
+}
+
+// --- config -----------------------------------------------------------------
+
+func factoryFromYAML(t *testing.T, doc string) *bodyCapture {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+	// yaml.Unmarshal gives a document node; the factory expects the mapping.
+	require.NotEmpty(t, node.Content)
+	tr, err := factory(*node.Content[0], nil)
+	require.NoError(t, err)
+	bc, ok := tr.(*bodyCapture)
+	require.True(t, ok)
+	return bc
+}
+
+func TestBodyCaptureConfig_ResponseCaptureIsOffUnlessAskedFor(t *testing.T) {
+	// The compatibility guarantee: a config written before this feature existed
+	// keeps its exact previous behavior.
+	bc := factoryFromYAML(t, `
+max_request_body_bytes: 16384
+rules:
+  - host: "api.anthropic.com"
+`)
+	require.False(t, bc.captureResponseBody)
+
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader("reply")), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, -1, transform.RequireBufferedBody(resp.Body).Len(),
+		"the default must not so much as install a tee")
+	require.Nil(t, tctx.BodyCapture)
+}
+
+func TestBodyCaptureConfig_ExplicitCapsAreHonored(t *testing.T) {
+	bc := factoryFromYAML(t, `
+max_request_body_bytes: 16384
+capture_response_body: true
+max_response_body_bytes: 65536
+rules:
+  - host: "api.anthropic.com"
+    methods: ["POST"]
+    paths: ["/v1/messages", "/v1/complete"]
+`)
+	require.Equal(t, int64(16384), bc.maxRequestBodyBytes)
+	require.True(t, bc.captureResponseBody)
+	require.Equal(t, int64(65536), bc.maxResponseBodyBytes)
+	require.Len(t, bc.rules, 1)
+}
+
+func TestBodyCaptureConfig_DefaultsWhenUnset(t *testing.T) {
+	bc := factoryFromYAML(t, `
+capture_response_body: true
+rules:
+  - host: "api.openai.com"
+`)
+	require.Equal(t, int64(defaultMaxRequestBodyBytes), bc.maxRequestBodyBytes)
+	require.Equal(t, int64(defaultMaxResponseBodyBytes), bc.maxResponseBodyBytes)
+}
+
+func TestBodyCaptureConfig_ResponseCapReachesTheCapture(t *testing.T) {
+	// The configured cap has to arrive on the per-request capture, not just sit
+	// on the transform. A zero here would mean capturing nothing at all.
+	bc := factoryFromYAML(t, `
+capture_response_body: true
+max_response_body_bytes: 8
+rules:
+  - host: "api.anthropic.com"
+`)
+	req := makeRequest(t, "api.anthropic.com", "/v1/messages", `{"x":1}`)
+	resp := makeResponse(io.NopCloser(strings.NewReader("0123456789abcdef")), nil)
+	tctx := &transform.TransformContext{}
+
+	_, err := bc.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, "0123456789abcdef", forwardToClient(t, resp))
+	require.Equal(t, "01234567", tctx.BodyCapture.ResponseBody())
+	require.True(t, tctx.BodyCapture.ResponseBodyTruncated())
+}

--- a/internal/transform/otelaudit.go
+++ b/internal/transform/otelaudit.go
@@ -100,11 +100,25 @@ func NewOTELAuditFunc(provider *sdklog.LoggerProvider) AuditFunc {
 			}
 			attrs = append(attrs, log.KeyValue{Key: "mcp", Value: log.MapValue(mcpKVs...)})
 		}
-		if result.BodyCapture != nil && result.BodyCapture.RequestBody() != "" {
-			attrs = append(attrs, log.KeyValue{Key: "body_capture", Value: log.MapValue(
-				log.String("request_body", result.BodyCapture.RequestBody()),
-				log.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
-			)})
+		if result.BodyCapture != nil {
+			var bodyKVs []log.KeyValue
+			if body := result.BodyCapture.RequestBody(); body != "" {
+				bodyKVs = append(bodyKVs,
+					log.String("request_body", body),
+					log.Bool("request_body_truncated", result.BodyCapture.RequestBodyTruncated()),
+				)
+			}
+			// See NewAuditLogger: the response half is only complete by the time
+			// this callback runs, which is after the body reached the client.
+			if body := result.BodyCapture.ResponseBody(); body != "" {
+				bodyKVs = append(bodyKVs,
+					log.String("response_body", body),
+					log.Bool("response_body_truncated", result.BodyCapture.ResponseBodyTruncated()),
+				)
+			}
+			if len(bodyKVs) > 0 {
+				attrs = append(attrs, log.KeyValue{Key: "body_capture", Value: log.MapValue(bodyKVs...)})
+			}
 		}
 
 		rec.AddAttributes(attrs...)

--- a/internal/transform/otelaudit_test.go
+++ b/internal/transform/otelaudit_test.go
@@ -319,3 +319,61 @@ func mapFromValue(v log.Value) map[string]log.Value {
 	}
 	return m
 }
+
+func TestOTELAuditFunc_BodyCapture_ResponseFieldsJoinTheSameGroup(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:       "api.anthropic.com",
+		Method:     "POST",
+		Path:       "/v1/messages",
+		StartedAt:  time.Now(),
+		Duration:   50 * time.Millisecond,
+		Action:     ActionContinue,
+		StatusCode: 200,
+		BodyCapture: &fakeBodyCapture{
+			body:              `{"prompt":"hi"}`,
+			respBody:          "data: {\"delta\":\"hello\"}\n\n",
+			respBodyTruncated: true,
+		},
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	attrs := recordAttrs(records[0])
+	require.Contains(t, attrs, "body_capture")
+	bc := mapFromValue(attrs["body_capture"])
+	require.Equal(t, `{"prompt":"hi"}`, bc["request_body"].AsString())
+	require.Equal(t, "data: {\"delta\":\"hello\"}\n\n", bc["response_body"].AsString())
+	require.True(t, bc["response_body_truncated"].AsBool())
+}
+
+func TestOTELAuditFunc_BodyCapture_ResponseOnlyStillEmitsGroup(t *testing.T) {
+	proc := &recordProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	auditFunc := NewOTELAuditFunc(provider)
+
+	auditFunc(&PipelineResult{
+		Host:        "api.anthropic.com",
+		Method:      "GET",
+		Path:        "/v1/models",
+		StartedAt:   time.Now(),
+		Duration:    50 * time.Millisecond,
+		Action:      ActionContinue,
+		StatusCode:  200,
+		BodyCapture: &fakeBodyCapture{respBody: `{"data":[]}`},
+	})
+
+	records := proc.Records()
+	require.Len(t, records, 1)
+
+	attrs := recordAttrs(records[0])
+	require.Contains(t, attrs, "body_capture")
+	bc := mapFromValue(attrs["body_capture"])
+	require.NotContains(t, bc, "request_body")
+	require.Equal(t, `{"data":[]}`, bc["response_body"].AsString())
+	require.False(t, bc["response_body_truncated"].AsBool())
+}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -82,10 +82,12 @@ type TransformContext struct {
 	Tunnel     *TunnelInfo
 
 	// BodyCapture is the side channel a body_capture transform uses to
-	// communicate captured request body bytes out of the pipeline. The proxy
-	// copies it onto PipelineResult after the request pipeline runs so the
-	// audit emitters can render a `body_capture` group with `request_body` /
-	// `request_body_truncated`. nil when no body_capture rule matched.
+	// communicate captured body bytes out of the pipeline. The proxy copies it
+	// onto PipelineResult after the request pipeline runs, and again after the
+	// response pipeline for a match that only produced a response capture, so
+	// the audit emitters can render a `body_capture` group with `request_body` /
+	// `request_body_truncated` / `response_body` / `response_body_truncated`.
+	// nil when no body_capture rule matched.
 	BodyCapture BodyCapture
 
 	// annotations is written by transforms via Annotate and read by the pipeline
@@ -149,13 +151,18 @@ type PipelineResult struct {
 	// internal/mcp.
 	MCP MCPAudit
 
-	// BodyCapture carries captured request body bytes from a body_capture
-	// transform when the request matched a configured rule. nil otherwise.
-	// Populated by the proxy by copying tctx.BodyCapture after the request
-	// pipeline runs; rendered by the audit functions as a `body_capture`
-	// group with `request_body` and `request_body_truncated`. The transform
-	// package treats the concrete type as opaque to avoid an import cycle
-	// with internal/transform/bodycapture.
+	// BodyCapture carries captured request (and, when enabled, response) body
+	// bytes from a body_capture transform when the request matched a configured
+	// rule. nil otherwise. Populated by the proxy by copying tctx.BodyCapture
+	// after the request pipeline runs; rendered by the audit functions as a
+	// `body_capture` group with `request_body`, `request_body_truncated` and,
+	// when response capture is enabled, `response_body` and
+	// `response_body_truncated`. The transform package treats the concrete type
+	// as opaque to avoid an import cycle with internal/transform/bodycapture.
+	//
+	// The response half is tee'd off the live stream, so it only holds its final
+	// value once the body has been written to the client. Read it in the audit
+	// callback, which fires after that, and not earlier.
 	BodyCapture BodyCapture
 
 	Err error
@@ -185,7 +192,14 @@ type MCPAudit interface {
 // renderers from the concrete struct in internal/transform/bodycapture so the
 // audit emitters can render captured bodies without an import cycle.
 //
-// This interface covers request bodies only.
+// The two halves are captured by different mechanisms. A request is already
+// fully in hand before it can go upstream, so it is buffered and copied. A
+// response is TEE'D (see BufferedBody.TeeTo) so a streaming reply is never
+// buffered before being forwarded. One consequence to keep in mind: the
+// response accessors only hold their final value once the response body has
+// been consumed, which is why the audit record is emitted after the body is
+// written to the client (the deferred finish in the proxy's HTTP handler)
+// rather than when the response pipeline returns.
 type BodyCapture interface {
 	// RequestBody returns the captured request body bytes (truncated to the
 	// transform's configured cap). Empty string when no rule matched the
@@ -194,6 +208,21 @@ type BodyCapture interface {
 	// RequestBodyTruncated reports whether the captured RequestBody was
 	// truncated to fit the transform's configured cap.
 	RequestBodyTruncated() bool
+	// ResponseBody returns the response body bytes tee'd off the stream as it
+	// was forwarded to the client - truncated to the transform's configured
+	// cap, and content-decoded when the reply was compressed. Empty string when
+	// response capture is not enabled, no rule matched, the response had no
+	// body, the body was never consumed, or its Content-Encoding is one the
+	// transform cannot decode.
+	//
+	// These are the raw bytes of the reply, never a parsed or merged view: an
+	// SSE reply comes back as its frames concatenated exactly as they went over
+	// the wire, because merging them is the consumer's job.
+	ResponseBody() string
+	// ResponseBodyTruncated reports whether the captured ResponseBody hit the
+	// transform's configured cap and lost its tail. Excess bytes are dropped as
+	// they stream past, so a truncated capture is never a stalled stream.
+	ResponseBodyTruncated() bool
 }
 
 // TransformTrace records what a single transform did.

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -575,14 +575,19 @@ transforms:
   #       - host: "api.openai.com"
 
   # Body capture: records decoded request bodies of matching hosts onto the
-  # audit log as top-level request_body / request_body_truncated fields.
-  # Observation-only — never rejects. max_request_body_bytes caps each capture
-  # (default 16384); larger bodies are truncated and flagged. When secrets runs
-  # with match_body: true, place body_capture BEFORE secrets so the audit log
-  # records proxy tokens rather than the real swapped-in credentials.
+  # audit log as request_body / request_body_truncated inside a body_capture
+  # group. Observation-only — never rejects. max_request_body_bytes caps each
+  # capture (default 16384); larger bodies are truncated and flagged. When
+  # secrets runs with match_body: true, place body_capture BEFORE secrets so the
+  # audit log records proxy tokens rather than the real swapped-in credentials.
   # - name: body_capture
   #   config:
   #     max_request_body_bytes: 16384
+  #     # Response capture is off by default. When enabled the reply is tee'd as
+  #     # it streams to the client, so a streaming (SSE) response is never
+  #     # buffered before being forwarded.
+  #     capture_response_body: true
+  #     max_response_body_bytes: 65536
   #     rules:
   #       - host: "api.anthropic.com"
   #         methods: ["POST"]


### PR DESCRIPTION
`internal/transform/bodycapture` says why it captures requests only:

> This transform captures request bodies only. It does not capture response
> bodies: BufferedBody buffers then replays rather than streaming, so reading
> a response body in a transform would stall SSE-streaming model replies
> (Anthropic / OpenAI) for the duration of the stream.

That is exactly right about `BufferedBody` as it stands, and `TransformResponse`
being a no-op is the correct call given it. This PR doesn't ask you to
reconsider that trade-off — it removes the thing that forced it, by giving
`BufferedBody` a streaming mode it didn't have.

## The tee

`BufferedBody` grows one method, `TeeTo(io.Writer)` (~60 lines in
`internal/transform/body.go`). It installs a sink and returns; it does not
read, buffer, or delay anything. The copy happens byte-for-byte as the
consumer — the response write, or the upstream send — pulls bytes through, so
a reply that trickles for two minutes is forwarded as it arrives and the
observer just watches it go past.

Three properties do the load-bearing work, and each is deliberate:

- **The sink can't apply back-pressure.** `body_capture`'s sink drops bytes
  past its cap and still reports a full successful write. Anything it waited
  on — a lock, a channel, room in a queue — the client would wait on too.
- **The sink can't fail the stream.** It's deliberately *not* `io.TeeReader`,
  which propagates the sink's write error to the consumer. A broken observer
  must never become a read error on someone's response.
- **The copy happens exactly once.** Whichever path consumes the underlying
  reader wins — `StreamingReader()` (which hands off `original` and clears it)
  or `buffer()` (under `sync.Once`). A body nothing consumes is never tee'd,
  and a body replaced wholesale by a later transform drops the tee with it.

`io.WriterTo`/`io.ReaderFrom` are intentionally not implemented on the tee
reader, so `io.Copy` can't bypass `Read` and skip the copy.

## The test is the argument

`TestHTTPProxy_BodyCapture_SSEResponseReachesTheAuditRecord` runs a real
streaming upstream through the real proxy with the real transform. The upstream
**refuses to flush frame 2 until the client has actually read frame 1**. A
buffer-then-forward implementation can't satisfy both halves of that handshake:
it parks draining an upstream body that won't advance until the client reads,
so the client never even receives response headers.

I verified that's a real regression test rather than a smoke test — I
temporarily replaced the tee with a buffer-then-forward implementation (an
`io.ReadAll` into the capture, then `NewBufferedBodyFromBytes`):

| | tee | buffered |
|---|---|---|
| `TestHTTPProxy_BodyCapture_SSEResponseReachesTheAuditRecord` | pass | **fail (5.00s)** |
| `TestBodyCaptureResponse_NeverBlocksOnANeverEndingBody` | pass | **fail (3.00s)** |
| `TestBodyCaptureResponse_TeesRatherThanBuffering` | pass | **fail** |

The failure message is the objection itself: *"the first SSE frame never
reached the client while the reply was still streaming - the response body is
being buffered before it is forwarded."* Each assertion sits behind a deadline,
so a regression fails the suite instead of hanging it.

`TestHTTPProxy_BodyCapture_SlowReplyDoesNotDelayOtherTraffic` covers the other
half: unrelated traffic through the same proxy completes normally while one
request is parked mid-reply.

## Opt-in, off by default

`capture_response_body` defaults to `false`. Existing configurations get
byte-identical behaviour — no tee is installed, and
`TestBodyCapture_TransformResponse_IsNoopByDefault` (the existing test, kept)
still pins the response body as never read.

```yaml
- name: body_capture
  config:
    max_request_body_bytes: 16384
    capture_response_body: true      # off by default
    max_response_body_bytes: 65536   # default 64 KiB
    rules:
      - host: "api.anthropic.com"
        methods: ["POST"]
        paths: ["/v1/messages"]
```

`response_body` and `response_body_truncated` join the existing `body_capture`
group rather than getting one of their own, so consumers read one record shape:

```json
"body_capture": {
  "request_body": "{\"model\":\"...\",\"stream\":true}",
  "request_body_truncated": false,
  "response_body": "data: {\"delta\":...}\n\ndata: [DONE]\n\n",
  "response_body_truncated": false
}
```

## Details worth flagging

- **Raw, unmerged.** SSE frames are concatenated exactly as they went over the
  wire; nothing is merged or parsed. Guessing at a provider's streaming shape
  doesn't belong on the hot path — that's the log consumer's job.
- **Truncation matches the request path.** The rune-boundary trim already used
  for truncated request bodies is now a shared helper applied to both halves,
  so a capped response can't leave a dangling UTF-8 fragment either.
- **Compression.** `gzip`/`deflate` replies are decoded on *read*, after the
  client already has its bytes — never on the streaming path. The decode is
  bounded by the same cap, since a compression ratio isn't ours to choose. An
  encoding the transform can't decode (`br`, `zstd`, a chain) is skipped and
  annotated on the trace, so the gap is visible rather than reading as an empty
  reply.
- **Ordering.** The response half only holds its final value once the body has
  been consumed. That works because the audit record is already emitted from
  the deferred `finish()` in the HTTP handler, after the body is written. The
  interface doc says so explicitly, since it's the one sharp edge here.
- **Bodyless requests.** The proxy copies `tctx.BodyCapture` again after the
  response pipeline (nil-guarded, so the request-leg capture is never
  clobbered), otherwise a matching `GET` would lose its reply.

## Prior context

The `body_capture` transform came from [#121](https://github.com/paradigmxyz/iron-proxy/pull/121),
which shipped as [#123](https://github.com/paradigmxyz/iron-proxy/pull/123) in
v0.33.0. This is the response half of that same work, and its author handed it
over for upstreaming. It has been running in production at Litmus against
streaming LLM traffic.

"Allow edits from maintainers" is ticked on this PR — last time around the
branch couldn't be pushed to, so please push directly rather than recreating it.

## Testing

On this branch, against `main`:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -count=1 ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues

New: `internal/transform/body_tee_test.go` (the tee primitive: incremental
copying, exactly-once across both consumption paths, sink errors swallowed,
no wrapper when nothing is observing), `internal/transform/bodycapture/response_test.go`
(the transform, including the never-ending-body and cap-doesn't-stall cases),
`internal/proxy/bodycapture_response_test.go` (end-to-end through the proxy),
plus emitter cases in `audit_test.go` / `otelaudit_test.go`.

Happy to split the `TeeTo` primitive into its own commit, rename
`capture_response_body`, or adjust the default cap if 64 KiB reads wrong for
this codebase.
