### PR TITLE
feat(secretbroker): substitute a placeholder for a real credential (ENG-2027)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+## Layout
+
+Module path is `github.com/ironsh/iron-proxy` even though the repo is now `litmus-team/iron-proxy` — the import path was never renamed. Config schema lives in `internal/config/config.go`; `iron-proxy.example.yaml` and the README's Configuration section are the user-facing docs for it and are expected to move together with a schema change.
+
+## Adding a transform
+
+Transforms live one per package under `internal/transform/<name>/` and implement `transform.Transformer` (see `internal/transform/transform.go`). Copy the shape of a recent one — `internal/transform/gcpauth` is the cleanest example. Three steps are easy to miss:
+
+1. `transform.Register("<yaml_name>", factory)` in the package's `init()`.
+2. A blank import in `cmd/iron-proxy/main.go` under "Register built-in transforms" — without it the factory is never registered and the config fails with `unknown transform`.
+3. Document the config in both `iron-proxy.example.yaml` and the README.
+
+Keep the factory free of I/O beyond config validation, and split out a `newFromConfig(cfg, ..., dep)` that takes injectable dependencies so tests do not need real backends.
+
+Conventions worth reusing rather than reinventing: `internal/hostmatch` for host/method/path rules (`RuleConfig` + `CompileRules`), `transform.BufferedBody` for any body access, `tctx.Annotate` for audit metadata (never secret values), and `secrets.BuildSource` to load an input from any configured secret backend.
+
+## Reload semantics
+
+There is no SIGHUP handler and no file watcher. Config is re-read by `POST /v1/reload` on the management API, which rebuilds the whole pipeline (`newReloadFunc` in `cmd/iron-proxy/main.go`), and by the control-plane poller in managed mode. A transform that needs to pick up an out-of-band file change has to do it itself — see the `fileStore` in `internal/transform/secretbroker`.
+
+## Build, test, lint
+
+- `go build ./...` and `go test ./...` are the gates; both must be clean.
+- `integration_test/` needs `-integration` plus real external services (AWS, GCP, 1Password), so it does not run locally by default.
+- Lint config is `.golangci.yml`. `gofmt -l ./...` reports several files that are already unformatted on `main`; check only the files you touched.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -414,6 +414,87 @@ long success TTL does not delay recovery from a transient backend outage.
   > so iron-proxy pins a [fork](https://github.com/ironsh/onepassword-sdk-go)
   > via a `replace` directive in `go.mod` until the fix lands upstream.
 
+### Secret broker
+
+The `secrets` transform above assumes the workload is merely untrusted with the
+network. `secretbroker` assumes the workload is untrusted with the credential
+itself: it is built for sandboxes — work-trial containers, evaluation
+environments, shared dev boxes — where whoever is inside may actively try to
+read the secret rather than just use it.
+
+The sandbox holds only a placeholder. `secretbroker` swaps the placeholder for
+the real credential on requests to hosts you have listed for that placeholder,
+and swaps any echoed credential back to the placeholder on the way in, so the
+credential cannot be recovered by bouncing a request off an echo endpoint.
+
+```yaml
+- name: secretbroker
+  config:
+    # Root-owned file holding a flat JSON object of secret_ref -> credential.
+    # Mode 0600, owned by the user iron-proxy runs as; the sandbox must not be
+    # able to read it.
+    secrets_file: "/etc/iron-proxy/secrets.json"
+    entries:
+      - placeholder: "IRON_PLACEHOLDER_GITHUB_TOKEN" # what the sandbox holds
+        secret_ref: "github_token" # key in secrets_file
+        hosts: ["api.github.com"] # the only hosts it may be sent to
+        headers: ["X-Api-Key"] # scanned in addition to Authorization
+        match_body: false # scan the request body too
+        scrub_response: true # default; swap echoes back to the placeholder
+```
+
+```json
+{ "github_token": "ghp_the_real_token" }
+```
+
+Per entry:
+
+- **`placeholder`:** the fake token the sandbox holds. Must be unique across
+  entries.
+- **`secret_ref`:** a key in `secrets_file`. Mutually exclusive with `source`.
+- **`source`:** any secret source the [`secrets`](#secrets) transform accepts
+  (`env`, `aws_sm`, `aws_ssm`, `1password`, `1password_connect`) when the
+  credential does not live in `secrets_file`. Mutually exclusive with
+  `secret_ref`.
+- **`hosts`:** domain globs or CIDRs the credential may be sent to. `"*"` is
+  rejected — an entry that substitutes everywhere defeats the point.
+- **`rules`:** full `host`/`methods`/`paths` rules, as elsewhere in
+  iron-proxy. Combined with `hosts`; at least one of the two is required.
+- **`headers`:** request headers to scan, in addition to `Authorization`,
+  which is always scanned. Headers outside this set are left untouched, so the
+  sandbox cannot smuggle the credential out through a header of its choosing.
+- **`match_body`:** scan the request body. Off by default.
+- **`scrub_response`:** replace the credential with the placeholder in the
+  response headers and body. On by default.
+
+Notes on the guarantees:
+
+- **Host scoping is per entry.** A placeholder is only ever substituted on a
+  request matching that entry's own rules, so one entry's credential can never
+  reach another entry's host.
+- **It fails closed.** If `secrets_file` is missing, unreadable, or malformed,
+  no substitution happens: the placeholder travels upstream and the upstream
+  rejects it. One warning naming the path — never its contents — is logged per
+  distinct failure, and the entry is annotated `secret_unavailable`.
+- **`Authorization: Basic` is decoded.** A credential embedded as
+  `base64(user:token)`, which is how git-over-HTTPS sends one, is swapped
+  inside the encoded payload and re-encoded.
+- **The audit stream keeps showing the placeholder.** `secretbroker` annotates
+  the placeholder and the `secret_ref` — both non-secret names — and never the
+  credential. Place `secretbroker` **last** in `transforms:` so that transforms
+  which capture request headers into the audit stream, such as
+  [`annotate`](#annotate), run first and record the placeholder.
+- **`secrets_file` is re-read when it changes** (size or mtime), so rotating a
+  credential in place needs no restart. `POST /v1/reload` on the
+  [management API](#management-api) also re-reads it, since it rebuilds the
+  pipeline from the config file.
+- **Response scrubbing is bounded by
+  [`max_response_body_bytes`](#body-limits).** The response body is scrubbed
+  within the proxy's existing body-capture limit; a body past that limit is
+  truncated by that mechanism. Server-Sent Events bodies are left alone so
+  per-chunk streaming keeps working — their headers are still scrubbed, and the
+  entry is annotated `scrub_skipped: sse_body`.
+
 ### Judge
 
 The judge transform calls an LLM to produce an allow/deny decision for

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
 	_ "github.com/ironsh/iron-proxy/internal/transform/oauth"
+	_ "github.com/ironsh/iron-proxy/internal/transform/secretbroker"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 

--- a/internal/transform/secretbroker/secretbroker.go
+++ b/internal/transform/secretbroker/secretbroker.go
@@ -1,0 +1,640 @@
+// Package secretbroker implements a transform that lets a sandboxed workload
+// USE a credential without ever being able to READ it.
+//
+// The workload holds only a placeholder token. On requests to hosts the
+// operator has allowed for that placeholder, secretbroker swaps the
+// placeholder for the real credential just before the request leaves the
+// proxy; on the way back it swaps any echoed credential back to the
+// placeholder, so a workload cannot recover the secret by bouncing it off an
+// echo endpoint. The real value only ever exists inside the proxy process and
+// on the wire to the allowed upstream.
+//
+// Three properties are load-bearing and are what the tests pin down:
+//
+//   - Host scoping. A placeholder is only ever substituted on a request whose
+//     host matches that entry's own rules. An entry never leaks its credential
+//     to another entry's host, and never to an unlisted host.
+//   - Fail closed. When the secrets file is missing or unreadable, the entry
+//     performs no substitution at all: the placeholder travels upstream and the
+//     upstream rejects it. One warning naming the path (never the contents) is
+//     logged per distinct failure, not per request.
+//   - Audit stays clean. secretbroker annotates the placeholder and the
+//     secret_ref (both non-secret names) and never the credential, so the audit
+//     stream continues to show the placeholder.
+//
+// Like all header-rewriting transforms this requires MITM mode; in sni-only
+// mode there are no headers or body to rewrite and every entry no-ops.
+//
+// Pipeline ordering: place secretbroker last. Transforms that capture request
+// headers into the audit stream (e.g. annotate) must run before it so they
+// record the placeholder rather than the substituted credential.
+package secretbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+)
+
+const transformName = "secretbroker"
+
+func init() {
+	transform.Register(transformName, factory)
+}
+
+// config is the YAML config structure.
+type config struct {
+	// SecretsFile is a root-owned file holding a flat JSON object of
+	// secret_ref -> credential. Required when any entry uses secret_ref.
+	SecretsFile string `yaml:"secrets_file,omitempty"`
+
+	Entries []entryConfig `yaml:"entries"`
+}
+
+type entryConfig struct {
+	// Placeholder is the fake token the workload holds.
+	Placeholder string `yaml:"placeholder"`
+
+	// SecretRef names a key in the secrets file. Mutually exclusive with Source.
+	SecretRef string `yaml:"secret_ref,omitempty"`
+
+	// Source is any secrets-package source block ({type: env, var: FOO},
+	// aws_sm, 1password, ...). Mutually exclusive with SecretRef.
+	Source yaml.Node `yaml:"source,omitempty"`
+
+	// Hosts is flat sugar for rules with no method/path restriction, matching
+	// the shape the allowlist transform accepts.
+	Hosts []string `yaml:"hosts,omitempty"`
+
+	// Rules are full host/method/path rules. Combined with Hosts.
+	Rules []hostmatch.RuleConfig `yaml:"rules,omitempty"`
+
+	// Headers lists request headers to scan in addition to Authorization,
+	// which is always scanned.
+	Headers []string `yaml:"headers,omitempty"`
+
+	// MatchBody opts the entry into scanning the request body.
+	MatchBody bool `yaml:"match_body,omitempty"`
+
+	// ScrubResponse controls swapping an echoed credential back to the
+	// placeholder on the response. Defaults to true; set false to opt out.
+	ScrubResponse *bool `yaml:"scrub_response,omitempty"`
+}
+
+// entry is a config entry compiled and ready to use.
+type entry struct {
+	placeholder string
+
+	// ref is a non-secret display name for the credential — the secret_ref
+	// key or the source's name. Safe to put in logs and audit annotations.
+	ref string
+
+	// get returns the real credential, or an error when it is unavailable.
+	get func(ctx context.Context) (string, error)
+
+	rules         []hostmatch.Rule
+	headers       []string // canonical names; always includes Authorization
+	matchBody     bool
+	scrubResponse bool
+}
+
+// SecretBroker is the transform.
+type SecretBroker struct {
+	entries []entry
+}
+
+func factory(cfg yaml.Node, logger *slog.Logger) (transform.Transformer, error) {
+	var c config
+	if err := cfg.Decode(&c); err != nil {
+		return nil, fmt.Errorf("parsing %s config: %w", transformName, err)
+	}
+	return newFromConfig(c, logger, secrets.BuildSource)
+}
+
+// sourceBuilder is the signature of secrets.BuildSource, pulled out so tests
+// can inject a stub instead of constructing real source backends.
+type sourceBuilder func(yaml.Node, *slog.Logger) (secrets.Source, error)
+
+func newFromConfig(c config, logger *slog.Logger, buildSource sourceBuilder) (*SecretBroker, error) {
+	if len(c.Entries) == 0 {
+		return nil, fmt.Errorf("%s: at least one entry is required", transformName)
+	}
+
+	// The file store is created lazily so a config that only uses source
+	// blocks does not need secrets_file at all. Creating it performs the
+	// startup load, which is where a missing file logs its one warning.
+	var store *fileStore
+	fileStoreFor := func() (*fileStore, error) {
+		if c.SecretsFile == "" {
+			return nil, fmt.Errorf("secret_ref requires \"secrets_file\" to be set")
+		}
+		if store == nil {
+			store = newFileStore(c.SecretsFile, logger)
+		}
+		return store, nil
+	}
+
+	entries := make([]entry, 0, len(c.Entries))
+	seen := make(map[string]int, len(c.Entries))
+
+	for i, ec := range c.Entries {
+		ctxName := fmt.Sprintf("%s: entries[%d]", transformName, i)
+
+		if ec.Placeholder == "" {
+			return nil, fmt.Errorf("%s: placeholder is required", ctxName)
+		}
+		if prev, dup := seen[ec.Placeholder]; dup {
+			// Two entries sharing a placeholder would substitute
+			// different credentials depending on rule order, which is
+			// never what an operator means.
+			return nil, fmt.Errorf("%s: placeholder %q is already used by entries[%d]", ctxName, ec.Placeholder, prev)
+		}
+		// A placeholder that contains another is a silent-corruption hazard:
+		// substituting the shorter one first mangles the longer one, and what
+		// goes upstream is neither credential.
+		for other := range seen {
+			if strings.Contains(ec.Placeholder, other) || strings.Contains(other, ec.Placeholder) {
+				return nil, fmt.Errorf("%s: placeholder %q overlaps placeholder %q from entries[%d]", ctxName, ec.Placeholder, other, seen[other])
+			}
+		}
+		seen[ec.Placeholder] = i
+
+		hasRef := ec.SecretRef != ""
+		hasSource := ec.Source.Kind != 0
+		if hasRef == hasSource {
+			return nil, fmt.Errorf("%s: requires exactly one of \"secret_ref\" or \"source\"", ctxName)
+		}
+
+		var (
+			ref string
+			get func(context.Context) (string, error)
+		)
+		if hasRef {
+			fs, err := fileStoreFor()
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", ctxName, err)
+			}
+			ref = ec.SecretRef
+			get = func(context.Context) (string, error) { return fs.get(ec.SecretRef) }
+		} else {
+			src, err := buildSource(ec.Source, logger)
+			if err != nil {
+				return nil, fmt.Errorf("%s: building source: %w", ctxName, err)
+			}
+			ref = src.Name()
+			get = src.Get
+		}
+
+		rules, err := compileRules(ec, ctxName)
+		if err != nil {
+			return nil, err
+		}
+		if len(rules) == 0 {
+			// Unlike allowlist, an empty rule set is a config error rather
+			// than "match everything": a credential that substitutes onto
+			// every host is exactly what this transform exists to prevent.
+			return nil, fmt.Errorf("%s: at least one entry in \"hosts\" or \"rules\" is required", ctxName)
+		}
+
+		entries = append(entries, entry{
+			placeholder:   ec.Placeholder,
+			ref:           ref,
+			get:           get,
+			rules:         rules,
+			headers:       compileHeaders(ec.Headers),
+			matchBody:     ec.MatchBody,
+			scrubResponse: ec.ScrubResponse == nil || *ec.ScrubResponse,
+		})
+	}
+
+	return &SecretBroker{entries: entries}, nil
+}
+
+// compileRules turns the flat hosts sugar and the explicit rules block into
+// one compiled rule set.
+func compileRules(ec entryConfig, ctxName string) ([]hostmatch.Rule, error) {
+	var rules []hostmatch.Rule
+	for _, h := range ec.Hosts {
+		if h == "*" {
+			return nil, fmt.Errorf("%s: host \"*\" is not allowed; list the hosts the credential may be sent to", ctxName)
+		}
+		m, err := hostmatch.New([]string{h}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", ctxName, err)
+		}
+		rules = append(rules, hostmatch.Rule{Matcher: m})
+	}
+	for _, rc := range ec.Rules {
+		if rc.Host == "*" {
+			return nil, fmt.Errorf("%s: host \"*\" is not allowed; list the hosts the credential may be sent to", ctxName)
+		}
+	}
+	compiled, err := hostmatch.CompileRules(ec.Rules, ctxName)
+	if err != nil {
+		return nil, err
+	}
+	return append(rules, compiled...), nil
+}
+
+// compileHeaders canonicalizes the header allowlist and guarantees
+// Authorization is present, since that is where a credential lands by default.
+func compileHeaders(names []string) []string {
+	out := []string{"Authorization"}
+	for _, n := range names {
+		canonical := http.CanonicalHeaderKey(n)
+		if canonical == "" || canonical == "Authorization" {
+			continue
+		}
+		if !containsString(out, canonical) {
+			out = append(out, canonical)
+		}
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *SecretBroker) Name() string { return transformName }
+
+// substitution is the audit record for one entry. It deliberately carries the
+// placeholder and the secret_ref — both non-secret — and never the credential.
+type substitution struct {
+	Placeholder string   `json:"placeholder"`
+	SecretRef   string   `json:"secret_ref"`
+	Locations   []string `json:"locations"`
+}
+
+// TransformRequest swaps each matching entry's placeholder for its real
+// credential in the allowed request headers and, when the entry opts in, the
+// request body.
+func (b *SecretBroker) TransformRequest(ctx context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	cont := &transform.TransformResult{Action: transform.ActionContinue}
+	if tctx.Mode == transform.ModeSNIOnly {
+		return cont, nil
+	}
+
+	var substituted []substitution
+	var unavailable []string
+
+	for i := range b.entries {
+		e := &b.entries[i]
+
+		// Host scoping. Checked before the credential is even fetched, so a
+		// request to a host this entry does not allow cannot pull the
+		// credential into the process for any reason.
+		if !hostmatch.MatchAnyRule(e.rules, req) {
+			continue
+		}
+
+		secret, err := e.get(ctx)
+		if err != nil || secret == "" {
+			// Fail closed: no substitution. The placeholder travels upstream
+			// and the upstream rejects it. e.ref is a name, not a value.
+			unavailable = append(unavailable, e.ref)
+			continue
+		}
+
+		locations := substituteHeaders(req.Header, e.headers, e.placeholder, secret)
+		if e.matchBody {
+			if loc := substituteRequestBody(req, e.placeholder, secret); loc != "" {
+				locations = append(locations, loc)
+			}
+		}
+
+		if len(locations) > 0 {
+			substituted = append(substituted, substitution{
+				Placeholder: e.placeholder,
+				SecretRef:   e.ref,
+				Locations:   locations,
+			})
+		}
+	}
+
+	if len(substituted) > 0 {
+		tctx.Annotate("substituted", substituted)
+	}
+	if len(unavailable) > 0 {
+		tctx.Annotate("secret_unavailable", unavailable)
+	}
+	return cont, nil
+}
+
+// TransformResponse swaps any echoed credential back to the placeholder before
+// the response reaches the workload, so an echo endpoint cannot be used to read
+// the credential.
+//
+// Response headers are scanned in full rather than through the entry's header
+// allowlist: the allowlist says where the proxy is willing to *write* a
+// credential, but a leak on the way back can surface in any header.
+//
+// Body scrubbing is bounded by the proxy's existing response body-capture
+// limit (proxy.max_response_body_bytes): the body has already been wrapped in
+// a size-capped BufferedBody by the time it reaches here, so a body past the
+// cap is truncated by that mechanism rather than by anything here. SSE
+// responses are left alone so per-chunk streaming is preserved.
+func (b *SecretBroker) TransformResponse(ctx context.Context, tctx *transform.TransformContext, req *http.Request, resp *http.Response) (*transform.TransformResult, error) {
+	cont := &transform.TransformResult{Action: transform.ActionContinue}
+	if tctx.Mode == transform.ModeSNIOnly || resp == nil {
+		return cont, nil
+	}
+
+	var scrubbed []substitution
+	streaming := isSSE(resp)
+
+	for i := range b.entries {
+		e := &b.entries[i]
+		if !e.scrubResponse || !hostmatch.MatchAnyRule(e.rules, req) {
+			continue
+		}
+
+		secret, err := e.get(ctx)
+		if err != nil || secret == "" {
+			continue
+		}
+
+		locations := scrubHeaders(resp.Header, e.placeholder, secret)
+		if !streaming {
+			if loc := scrubResponseBody(resp, e.placeholder, secret); loc != "" {
+				locations = append(locations, loc)
+			}
+		}
+
+		if len(locations) > 0 {
+			scrubbed = append(scrubbed, substitution{
+				Placeholder: e.placeholder,
+				SecretRef:   e.ref,
+				Locations:   locations,
+			})
+		}
+	}
+
+	if len(scrubbed) > 0 {
+		tctx.Annotate("scrubbed", scrubbed)
+		if streaming {
+			// Worth surfacing: a credential echoed inside an SSE stream is
+			// not scrubbed, and the operator should know the entry matched a
+			// streaming response.
+			tctx.Annotate("scrub_skipped", "sse_body")
+		}
+	}
+	return cont, nil
+}
+
+// substituteHeaders replaces the placeholder with the credential in the named
+// headers only, and returns the locations touched.
+func substituteHeaders(h http.Header, names []string, placeholder, secret string) []string {
+	var locations []string
+	for _, name := range names {
+		vals := h.Values(name)
+		if len(vals) == 0 {
+			continue
+		}
+		hit := false
+		replaced := make([]string, len(vals))
+		for i, v := range vals {
+			replaced[i] = secrets.ReplaceInHeader(name, v, placeholder, secret)
+			if replaced[i] != v {
+				hit = true
+			}
+		}
+		if !hit {
+			continue
+		}
+		h.Del(name)
+		for _, v := range replaced {
+			h.Add(name, v)
+		}
+		locations = append(locations, "header:"+name)
+	}
+	return locations
+}
+
+// scrubHeaders replaces the credential with the placeholder across every
+// response header.
+func scrubHeaders(h http.Header, placeholder, secret string) []string {
+	var locations []string
+	for name, vals := range h {
+		hit := false
+		for i, v := range vals {
+			if replaced := secrets.ReplaceInHeader(name, v, secret, placeholder); replaced != v {
+				vals[i] = replaced
+				hit = true
+			}
+		}
+		if hit {
+			locations = append(locations, "header:"+name)
+		}
+	}
+	return locations
+}
+
+// substituteRequestBody replaces the placeholder with the credential in the
+// request body. Returns "body" when the body was rewritten.
+func substituteRequestBody(req *http.Request, placeholder, secret string) string {
+	if req.Body == nil {
+		return ""
+	}
+	replaced, changed := replaceBody(req.Body, placeholder, secret)
+	if !changed {
+		return ""
+	}
+	req.Body = transform.NewBufferedBodyFromBytes(replaced)
+	req.ContentLength = int64(len(replaced))
+	return "body"
+}
+
+// scrubResponseBody replaces the credential with the placeholder in the
+// response body. Returns "body" when the body was rewritten.
+func scrubResponseBody(resp *http.Response, placeholder, secret string) string {
+	if resp.Body == nil {
+		return ""
+	}
+	replaced, changed := replaceBody(resp.Body, secret, placeholder)
+	if !changed {
+		return ""
+	}
+	resp.Body = transform.NewBufferedBodyFromBytes(replaced)
+	resp.ContentLength = int64(len(replaced))
+	return "body"
+}
+
+// replaceBody reads a pipeline body and returns the rewritten bytes. changed
+// is false when the body could not be read or did not contain from, in which
+// case the caller leaves the original body in place.
+//
+// The body is rewound after reading. The pipeline resets it between
+// transforms, but not between entries within one pass: without this a second
+// entry would read EOF whenever the first entry read the body and found
+// nothing to rewrite.
+func replaceBody(body io.ReadCloser, from, to string) (out []byte, changed bool) {
+	data, err := io.ReadAll(body)
+	if buf, ok := body.(*transform.BufferedBody); ok {
+		buf.Reset()
+	}
+	if err != nil || !bytes.Contains(data, []byte(from)) {
+		return nil, false
+	}
+	return bytes.ReplaceAll(data, []byte(from), []byte(to)), true
+}
+
+// isSSE mirrors the proxy's Server-Sent Events detection. Buffering an SSE
+// body to scrub it would break per-chunk streaming, so those bodies are left
+// untouched.
+func isSSE(resp *http.Response) bool {
+	return strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream")
+}
+
+// --- secrets file store ---
+
+// fileStore reads a flat JSON object of secret_ref -> credential from a
+// root-owned path.
+//
+// The file is loaded once at startup and re-read when the file changes on
+// disk, detected by comparing size and mtime. That covers credential rotation
+// in place; the fork's other reload vector, the management API's
+// POST /v1/reload, rebuilds the whole pipeline and so re-reads the file too.
+//
+// A missing or unreadable file is not fatal: get returns an error, the caller
+// skips substitution, and the credential is never at risk. One warning naming
+// the path — never the contents — is logged per distinct failure, so a
+// persistently missing file does not flood the log on every request.
+type fileStore struct {
+	path   string
+	logger *slog.Logger
+
+	// Injectable for tests.
+	stat func(string) (os.FileInfo, error)
+	read func(string) ([]byte, error)
+
+	mu     sync.Mutex
+	values map[string]string
+	stamp  stamp
+
+	// warnedFor is the error text of the last warning emitted, used to
+	// collapse repeats of the same failure into a single log line.
+	warnedFor string
+}
+
+// stamp identifies a file version cheaply enough to check on every request.
+type stamp struct {
+	size    int64
+	modTime time.Time
+}
+
+func newFileStore(path string, logger *slog.Logger) *fileStore {
+	fs := &fileStore{
+		path:   path,
+		logger: logger,
+		stat:   os.Stat,
+		read:   os.ReadFile,
+	}
+	// Startup load: surfaces a missing or malformed file at boot rather than
+	// on the first request that needs it.
+	fs.mu.Lock()
+	fs.reload()
+	fs.mu.Unlock()
+	return fs
+}
+
+// get returns the credential for ref. Callers treat any error as "substitution
+// disabled for this entry".
+func (fs *fileStore) get(ref string) (string, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.changedOnDisk() {
+		fs.reload()
+	}
+	if fs.values == nil {
+		return "", fmt.Errorf("secrets file %q is unavailable", fs.path)
+	}
+	v, ok := fs.values[ref]
+	if !ok || v == "" {
+		return "", fmt.Errorf("secret_ref %q not present in secrets file %q", ref, fs.path)
+	}
+	return v, nil
+}
+
+// changedOnDisk reports whether the file's size or mtime differs from the last
+// load. A stat failure counts as changed so the reload path emits the warning
+// and drops any stale values.
+//
+// Callers must hold fs.mu.
+func (fs *fileStore) changedOnDisk() bool {
+	fi, err := fs.stat(fs.path)
+	if err != nil {
+		return true
+	}
+	return stamp{size: fi.Size(), modTime: fi.ModTime()} != fs.stamp
+}
+
+// reload re-reads and re-parses the file. On any failure the cached values are
+// cleared, so a file that becomes unreadable disables substitution rather than
+// serving a stale credential.
+//
+// Callers must hold fs.mu.
+func (fs *fileStore) reload() {
+	fi, err := fs.stat(fs.path)
+	if err != nil {
+		fs.fail(fmt.Sprintf("cannot stat secrets file: %v", err))
+		return
+	}
+
+	data, err := fs.read(fs.path)
+	if err != nil {
+		fs.fail(fmt.Sprintf("cannot read secrets file: %v", err))
+		return
+	}
+
+	var values map[string]string
+	if err := json.Unmarshal(data, &values); err != nil {
+		// Deliberately does not include err's text: a JSON syntax error
+		// message can quote the offending bytes, which are credentials.
+		fs.fail("secrets file is not a flat JSON object of secret_ref to value")
+		return
+	}
+
+	fs.values = values
+	fs.stamp = stamp{size: fi.Size(), modTime: fi.ModTime()}
+	fs.warnedFor = ""
+}
+
+// fail records a load failure, clearing cached values and logging at most one
+// warning per distinct reason. The message names the path only.
+//
+// Callers must hold fs.mu.
+func (fs *fileStore) fail(reason string) {
+	fs.values = nil
+	fs.stamp = stamp{}
+	if fs.warnedFor == reason {
+		return
+	}
+	fs.warnedFor = reason
+	if fs.logger != nil {
+		fs.logger.Warn("secretbroker substitution disabled",
+			slog.String("path", fs.path),
+			slog.String("reason", reason),
+		)
+	}
+}

--- a/internal/transform/secretbroker/secretbroker_test.go
+++ b/internal/transform/secretbroker/secretbroker_test.go
@@ -1,0 +1,974 @@
+package secretbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/secrets"
+
+	// Registers the annotate transform, which the audit test composes with
+	// secretbroker to prove header captures see the placeholder.
+	_ "github.com/ironsh/iron-proxy/internal/transform/annotate"
+)
+
+const (
+	placeholder = "IRON_PLACEHOLDER_GITHUB_TOKEN"
+	realSecret  = "ghp_realcredential000000000000000000"
+)
+
+// --- helpers ---
+
+// writeSecretsFile writes a secrets file and returns its path.
+func writeSecretsFile(t *testing.T, values map[string]string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	data, err := json.Marshal(values)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func yamlFromString(t *testing.T, src string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &node))
+	return *node.Content[0]
+}
+
+// newBroker builds a transform from YAML config, failing the test on error.
+func newBroker(t *testing.T, cfg string, logger *slog.Logger) *SecretBroker {
+	t.Helper()
+	b, err := newFromConfig(decodeConfig(t, cfg), logger, secrets.BuildSource)
+	require.NoError(t, err)
+	return b
+}
+
+func decodeConfig(t *testing.T, src string) config {
+	t.Helper()
+	var c config
+	node := yamlFromString(t, src)
+	require.NoError(t, node.Decode(&c))
+	return c
+}
+
+// staticSource implements secrets.Source with a fixed value.
+type staticSource struct {
+	name  string
+	value string
+	err   error
+	calls atomic.Int64
+}
+
+func (s *staticSource) Name() string { return s.name }
+func (s *staticSource) Get(context.Context) (string, error) {
+	s.calls.Add(1)
+	return s.value, s.err
+}
+
+func staticBuilder(src secrets.Source) sourceBuilder {
+	return func(yaml.Node, *slog.Logger) (secrets.Source, error) { return src, nil }
+}
+
+// newRequest builds a MITM-shaped request with a buffered body, the way the
+// proxy hands one to the pipeline.
+func newRequest(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, url, nil)
+	req.Body = transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20)
+	return req
+}
+
+// newResponse builds a response with a buffered body, the way the proxy hands
+// one to the response pipeline.
+func newResponse(body string, header http.Header) *http.Response {
+	if header == nil {
+		header = http.Header{}
+	}
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        header,
+		Body:          transform.NewBufferedBody(io.NopCloser(strings.NewReader(body)), 1<<20),
+		ContentLength: int64(len(body)),
+	}
+}
+
+func newContext() *transform.TransformContext {
+	return &transform.TransformContext{Mode: transform.ModeMITM}
+}
+
+// readBody drains a pipeline body and rewinds it, as the pipeline does between
+// transforms.
+func readBody(t *testing.T, body io.ReadCloser) string {
+	t.Helper()
+	buf := transform.RequireBufferedBody(body)
+	data, err := io.ReadAll(buf)
+	require.NoError(t, err)
+	buf.Reset()
+	return string(data)
+}
+
+// capturingLogger returns a logger and the buffer holding its JSON output.
+func capturingLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+// githubEntry is the common single-entry config used across tests.
+func githubEntry(secretsFile string, extra string) string {
+	return `
+secrets_file: ` + secretsFile + `
+entries:
+  - placeholder: "` + placeholder + `"
+    secret_ref: github_token
+    hosts: ["api.github.com"]` + extra
+}
+
+// --- header substitution ---
+
+func TestTransformRequest_SubstitutesAuthorizationHeader(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	res, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	require.Equal(t, "Bearer "+realSecret, req.Header.Get("Authorization"))
+
+	ann := tctx.DrainAnnotations()
+	subs := ann["substituted"].([]substitution)
+	require.Len(t, subs, 1)
+	require.Equal(t, placeholder, subs[0].Placeholder)
+	require.Equal(t, "github_token", subs[0].SecretRef)
+	require.Equal(t, []string{"header:Authorization"}, subs[0].Locations)
+}
+
+func TestTransformRequest_SubstitutesListedHeaderOnly(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    headers: ["X-Api-Key"]`), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("X-Api-Key", placeholder)
+	// Not in the allowlist and not Authorization: must be left alone, so a
+	// workload cannot smuggle the credential into an arbitrary header.
+	req.Header.Set("X-Debug-Echo", placeholder)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, realSecret, req.Header.Get("X-Api-Key"))
+	require.Equal(t, placeholder, req.Header.Get("X-Debug-Echo"))
+}
+
+func TestTransformRequest_AuthorizationAlwaysScannedAlongsideAllowlist(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    headers: ["X-Api-Key"]`), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "token "+placeholder)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, "token "+realSecret, req.Header.Get("Authorization"))
+}
+
+func TestTransformRequest_SubstitutesInsideBasicAuth(t *testing.T) {
+	// git-over-HTTPS sends the credential as base64(user:token), so an exact
+	// scan of the raw header value would miss it entirely.
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	encoded := base64.StdEncoding.EncodeToString([]byte("git:" + placeholder))
+	req.Header.Set("Authorization", "Basic "+encoded)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	after, ok := strings.CutPrefix(req.Header.Get("Authorization"), "Basic ")
+	require.True(t, ok)
+	decoded, err := base64.StdEncoding.DecodeString(after)
+	require.NoError(t, err)
+	require.Equal(t, "git:"+realSecret, string(decoded))
+}
+
+func TestTransformRequest_LeavesRequestsWithoutPlaceholderUntouched(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer some-other-token")
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer some-other-token", req.Header.Get("Authorization"))
+	require.Empty(t, tctx.DrainAnnotations())
+}
+
+// --- body substitution on and off ---
+
+func TestTransformRequest_SubstitutesBodyWhenEnabled(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    match_body: true`), slog.Default())
+
+	body := `{"token":"` + placeholder + `"}`
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", body)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, `{"token":"`+realSecret+`"}`, readBody(t, req.Body))
+	require.EqualValues(t, len(`{"token":"`+realSecret+`"}`), req.ContentLength)
+
+	subs := tctx.DrainAnnotations()["substituted"].([]substitution)
+	require.Equal(t, []string{"body"}, subs[0].Locations)
+}
+
+func TestTransformRequest_LeavesBodyAloneWhenDisabled(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	// match_body defaults to false.
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	body := `{"token":"` + placeholder + `"}`
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", body)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, body, readBody(t, req.Body))
+	require.Empty(t, tctx.DrainAnnotations())
+}
+
+func TestTransformRequest_SubstitutesHeaderAndBodyTogether(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    match_body: true`), slog.Default())
+
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", "token="+placeholder)
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer "+realSecret, req.Header.Get("Authorization"))
+	require.Equal(t, "token="+realSecret, readBody(t, req.Body))
+
+	subs := tctx.DrainAnnotations()["substituted"].([]substitution)
+	require.Equal(t, []string{"header:Authorization", "body"}, subs[0].Locations)
+}
+
+func TestTransformRequest_SecondEntryStillSeesBodyAfterFirstReadsIt(t *testing.T) {
+	// The pipeline rewinds the body between transforms but not between
+	// entries within one pass. The first entry here reads the body and finds
+	// nothing to rewrite; the second must still see the whole body.
+	file := writeSecretsFile(t, map[string]string{
+		"unused_token": "unused-credential",
+		"github_token": realSecret,
+	})
+	b := newBroker(t, `
+secrets_file: `+file+`
+entries:
+  - placeholder: "PH_NOT_IN_THIS_BODY"
+    secret_ref: unused_token
+    hosts: ["api.github.com"]
+    match_body: true
+  - placeholder: "`+placeholder+`"
+    secret_ref: github_token
+    hosts: ["api.github.com"]
+    match_body: true
+`, slog.Default())
+
+	body := `{"token":"` + placeholder + `"}`
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", body)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, `{"token":"`+realSecret+`"}`, readBody(t, req.Body))
+}
+
+func TestTransformResponse_SecondEntryStillSeesBodyAfterFirstReadsIt(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{
+		"unused_token": "unused-credential",
+		"github_token": realSecret,
+	})
+	b := newBroker(t, `
+secrets_file: `+file+`
+entries:
+  - placeholder: "PH_NOT_IN_THIS_BODY"
+    secret_ref: unused_token
+    hosts: ["api.github.com"]
+  - placeholder: "`+placeholder+`"
+    secret_ref: github_token
+    hosts: ["api.github.com"]
+`, slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/echo", "")
+	resp := newResponse(`{"echo":"`+realSecret+`"}`, nil)
+
+	tctx := newContext()
+	_, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	got := readBody(t, resp.Body)
+	require.NotContains(t, got, realSecret)
+	require.Equal(t, `{"echo":"`+placeholder+`"}`, got)
+}
+
+// --- host not allowed ---
+
+func TestTransformRequest_NeverSubstitutesOnDisallowedHost(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    match_body: true`), slog.Default())
+
+	body := `{"token":"` + placeholder + `"}`
+	req := newRequest(t, http.MethodPost, "https://evil.example.com/collect", body)
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	res, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+	require.Equal(t, body, readBody(t, req.Body))
+	require.Empty(t, tctx.DrainAnnotations())
+}
+
+func TestTransformRequest_HostRulesAreScopedPerEntry(t *testing.T) {
+	// Two credentials, two hosts. Neither may cross to the other's host.
+	file := writeSecretsFile(t, map[string]string{
+		"github_token": realSecret,
+		"stripe_key":   "sk_live_realstripekey0000",
+	})
+	b := newBroker(t, `
+secrets_file: `+file+`
+entries:
+  - placeholder: "PH_GITHUB"
+    secret_ref: github_token
+    hosts: ["api.github.com"]
+  - placeholder: "PH_STRIPE"
+    secret_ref: stripe_key
+    hosts: ["api.stripe.com"]
+`, slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer PH_GITHUB")
+	req.Header.Add("Authorization", "Bearer PH_STRIPE")
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	vals := req.Header.Values("Authorization")
+	require.Equal(t, []string{"Bearer " + realSecret, "Bearer PH_STRIPE"}, vals)
+}
+
+func TestTransformRequest_RespectsMethodAndPathRules(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, `
+secrets_file: `+file+`
+entries:
+  - placeholder: "`+placeholder+`"
+    secret_ref: github_token
+    rules:
+      - host: "api.github.com"
+        methods: ["POST"]
+        paths: ["/repos/*"]
+`, slog.Default())
+
+	cases := []struct {
+		name, method, url string
+		wantSubstituted   bool
+	}{
+		{"matching method and path", http.MethodPost, "https://api.github.com/repos/o/r/issues", true},
+		{"wrong method", http.MethodGet, "https://api.github.com/repos/o/r/issues", false},
+		{"wrong path", http.MethodPost, "https://api.github.com/user", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := newRequest(t, tc.method, tc.url, "")
+			req.Header.Set("Authorization", "Bearer "+placeholder)
+			_, err := b.TransformRequest(context.Background(), newContext(), req)
+			require.NoError(t, err)
+
+			want := "Bearer " + placeholder
+			if tc.wantSubstituted {
+				want = "Bearer " + realSecret
+			}
+			require.Equal(t, want, req.Header.Get("Authorization"))
+		})
+	}
+}
+
+func TestTransformRequest_NoOpInSNIOnlyMode(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := &transform.TransformContext{Mode: transform.ModeSNIOnly}
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+}
+
+// --- missing secrets file ---
+
+func TestTransformRequest_MissingSecretsFileFailsClosed(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	logger, logs := capturingLogger()
+	b := newBroker(t, githubEntry(missing, `
+    match_body: true`), logger)
+
+	body := `{"token":"` + placeholder + `"}`
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", body)
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	res, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	// Fail closed: nothing substituted, the placeholder goes upstream.
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+	require.Equal(t, body, readBody(t, req.Body))
+
+	ann := tctx.DrainAnnotations()
+	require.Nil(t, ann["substituted"])
+	require.Equal(t, []string{"github_token"}, ann["secret_unavailable"])
+
+	// Exactly one warning, naming the path.
+	require.Equal(t, 1, strings.Count(logs.String(), `"level":"WARN"`))
+	require.Contains(t, logs.String(), missing)
+}
+
+func TestMissingSecretsFile_WarnsOncePerFailureNotPerRequest(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	logger, logs := capturingLogger()
+	b := newBroker(t, githubEntry(missing, ""), logger)
+
+	for range 5 {
+		req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+		req.Header.Set("Authorization", "Bearer "+placeholder)
+		_, err := b.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 1, strings.Count(logs.String(), `"level":"WARN"`))
+}
+
+func TestMissingSecretsFile_NeverLogsCredentials(t *testing.T) {
+	// A malformed file must not have its contents echoed into the warning:
+	// a JSON error message can quote the offending bytes.
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"github_token": "`+realSecret+`"`), 0o600))
+
+	logger, logs := capturingLogger()
+	b := newBroker(t, githubEntry(path, ""), logger)
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	_, err := b.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+	require.Contains(t, logs.String(), path)
+	require.NotContains(t, logs.String(), realSecret)
+}
+
+func TestSecretsFile_RefNotPresentFailsClosed(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"other_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+	require.Equal(t, []string{"github_token"}, tctx.DrainAnnotations()["secret_unavailable"])
+}
+
+func TestSecretsFile_RereadOnFileChange(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	substitute := func() string {
+		req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+		req.Header.Set("Authorization", "Bearer "+placeholder)
+		_, err := b.TransformRequest(context.Background(), newContext(), req)
+		require.NoError(t, err)
+		return req.Header.Get("Authorization")
+	}
+
+	require.Equal(t, "Bearer "+realSecret, substitute())
+
+	// Rotate the credential in place. The mtime is bumped explicitly so the
+	// change is visible regardless of filesystem timestamp granularity.
+	rotated := "ghp_rotatedcredential11111111111111"
+	data, err := json.Marshal(map[string]string{"github_token": rotated})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(file, data, 0o600))
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(file, future, future))
+
+	require.Equal(t, "Bearer "+rotated, substitute())
+}
+
+func TestSecretsFile_RecoversAfterFileAppears(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	logger, logs := capturingLogger()
+	b := newBroker(t, githubEntry(path, ""), logger)
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	_, err := b.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+
+	data, err := json.Marshal(map[string]string{"github_token": realSecret})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	req = newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	_, err = b.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer "+realSecret, req.Header.Get("Authorization"))
+
+	require.Equal(t, 1, strings.Count(logs.String(), `"level":"WARN"`))
+}
+
+func TestSourceEntry_UnavailableSecretFailsClosed(t *testing.T) {
+	src := &staticSource{name: "GITHUB_TOKEN", err: io.ErrUnexpectedEOF}
+	b, err := newFromConfig(decodeConfig(t, `
+entries:
+  - placeholder: "`+placeholder+`"
+    source:
+      type: env
+      var: GITHUB_TOKEN
+    hosts: ["api.github.com"]
+`), slog.Default(), staticBuilder(src))
+	require.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	_, err = b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Bearer "+placeholder, req.Header.Get("Authorization"))
+	require.Equal(t, []string{"GITHUB_TOKEN"}, tctx.DrainAnnotations()["secret_unavailable"])
+}
+
+func TestSourceEntry_SubstitutesFromSecretsSource(t *testing.T) {
+	src := &staticSource{name: "GITHUB_TOKEN", value: realSecret}
+	b, err := newFromConfig(decodeConfig(t, `
+entries:
+  - placeholder: "`+placeholder+`"
+    source:
+      type: env
+      var: GITHUB_TOKEN
+    hosts: ["api.github.com"]
+`), slog.Default(), staticBuilder(src))
+	require.NoError(t, err)
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	_, err = b.TransformRequest(context.Background(), newContext(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer "+realSecret, req.Header.Get("Authorization"))
+}
+
+// --- response scrubbing ---
+
+func TestTransformResponse_ScrubsCredentialFromBody(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	// A debugging workload bounces its request off an echo endpoint.
+	echoed := `{"headers":{"authorization":"Bearer ` + realSecret + `"}}`
+	req := newRequest(t, http.MethodGet, "https://api.github.com/echo", "")
+	resp := newResponse(echoed, nil)
+
+	tctx := newContext()
+	res, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+
+	got := readBody(t, resp.Body)
+	require.NotContains(t, got, realSecret)
+	require.Equal(t, `{"headers":{"authorization":"Bearer `+placeholder+`"}}`, got)
+	require.EqualValues(t, len(got), resp.ContentLength)
+
+	scrubbed := tctx.DrainAnnotations()["scrubbed"].([]substitution)
+	require.Equal(t, placeholder, scrubbed[0].Placeholder)
+	require.Equal(t, []string{"body"}, scrubbed[0].Locations)
+}
+
+func TestTransformResponse_ScrubsCredentialFromAnyHeader(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/echo", "")
+	// Not Authorization and not in the request header allowlist: the
+	// allowlist bounds where the proxy writes, never where it scrubs.
+	resp := newResponse("", http.Header{"X-Echoed-Token": {realSecret}})
+
+	tctx := newContext()
+	_, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	require.Equal(t, placeholder, resp.Header.Get("X-Echoed-Token"))
+	scrubbed := tctx.DrainAnnotations()["scrubbed"].([]substitution)
+	require.Equal(t, []string{"header:X-Echoed-Token"}, scrubbed[0].Locations)
+}
+
+func TestTransformResponse_SkipsWhenScrubDisabled(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, `
+    scrub_response: false`), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/echo", "")
+	resp := newResponse(realSecret, nil)
+
+	tctx := newContext()
+	_, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	require.Equal(t, realSecret, readBody(t, resp.Body))
+	require.Empty(t, tctx.DrainAnnotations())
+}
+
+func TestTransformResponse_SkipsDisallowedHost(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://evil.example.com/echo", "")
+	resp := newResponse(realSecret, nil)
+
+	tctx := newContext()
+	_, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	require.Equal(t, realSecret, readBody(t, resp.Body))
+	require.Empty(t, tctx.DrainAnnotations())
+}
+
+func TestTransformResponse_LeavesSSEBodyStreaming(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	b := newBroker(t, githubEntry(file, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/events", "")
+	resp := newResponse("data: hello\n\n", http.Header{
+		"Content-Type":   {"text/event-stream"},
+		"X-Echoed-Token": {realSecret},
+	})
+
+	tctx := newContext()
+	_, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+
+	// Headers are still scrubbed; the body is left unbuffered so the proxy's
+	// per-chunk streaming path keeps working.
+	require.Equal(t, placeholder, resp.Header.Get("X-Echoed-Token"))
+	require.Equal(t, -1, transform.RequireBufferedBody(resp.Body).Len())
+	require.Equal(t, "sse_body", tctx.DrainAnnotations()["scrub_skipped"])
+}
+
+func TestTransformResponse_MissingSecretsFileIsNotAnError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	b := newBroker(t, githubEntry(missing, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/echo", "")
+	resp := newResponse("nothing to scrub", nil)
+
+	tctx := newContext()
+	res, err := b.TransformResponse(context.Background(), tctx, req, resp)
+	require.NoError(t, err)
+	require.Equal(t, transform.ActionContinue, res.Action)
+	require.Equal(t, "nothing to scrub", readBody(t, resp.Body))
+}
+
+// --- audit records carry the placeholder only ---
+
+func TestAudit_CarriesPlaceholderNeverCredential(t *testing.T) {
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+
+	// annotate captures the Authorization header into the audit stream and
+	// runs before secretbroker, the documented pipeline order.
+	annotateT, err := transform.Lookup("annotate")
+	require.NoError(t, err)
+	capture, err := annotateT(yamlFromString(t, `
+annotations:
+  - rules:
+      - host: "api.github.com"
+    headers: ["Authorization"]
+`), slog.Default())
+	require.NoError(t, err)
+
+	broker := newBroker(t, githubEntry(file, `
+    match_body: true`), slog.Default())
+
+	pl := transform.NewPipeline([]transform.Transformer{capture, broker}, transform.BodyLimits{}, slog.Default())
+
+	logger, logs := capturingLogger()
+	pl.SetAuditFunc(transform.NewAuditLogger(logger))
+
+	req := newRequest(t, http.MethodPost, "https://api.github.com/graphql", `{"t":"`+placeholder+`"}`)
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	result := &transform.PipelineResult{Host: "api.github.com", Method: http.MethodPost, Path: "/graphql"}
+	tctx := newContext()
+	short, err := pl.ProcessRequest(context.Background(), tctx, req, &result.RequestTransforms)
+	require.NoError(t, err)
+	require.Nil(t, short)
+
+	// The credential did reach the wire: this is a real substitution, not a
+	// no-op that would make the assertion below vacuous.
+	require.Equal(t, "Bearer "+realSecret, req.Header.Get("Authorization"))
+
+	// An upstream that echoes the credential back.
+	resp := newResponse(`{"echo":"`+realSecret+`"}`, http.Header{"X-Echoed-Token": {realSecret}})
+	_, err = pl.ProcessResponse(context.Background(), tctx, req, resp, &result.ResponseTransforms)
+	require.NoError(t, err)
+
+	pl.EmitAudit(result)
+
+	require.NotContains(t, logs.String(), realSecret)
+	require.Contains(t, logs.String(), placeholder)
+
+	// And specifically: the header annotate captured is the placeholder.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &parsed))
+	traces := parsed["request_transforms"].([]any)
+	annotations := traces[0].(map[string]any)["annotations"].(map[string]any)
+	require.Equal(t, "Bearer "+placeholder, annotations["header:Authorization"])
+}
+
+func TestAudit_SecretUnavailableRecordsRefNotValue(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+	b := newBroker(t, githubEntry(missing, ""), slog.Default())
+
+	req := newRequest(t, http.MethodGet, "https://api.github.com/user", "")
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+
+	tctx := newContext()
+	_, err := b.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+
+	result := &transform.PipelineResult{
+		Host: "api.github.com",
+		RequestTransforms: []transform.TransformTrace{
+			{Name: transformName, Annotations: tctx.DrainAnnotations()},
+		},
+	}
+	logger, logs := capturingLogger()
+	transform.NewAuditLogger(logger)(result)
+
+	require.Contains(t, logs.String(), "github_token")
+	require.NotContains(t, logs.String(), realSecret)
+}
+
+// --- config validation ---
+
+func TestNewFromConfig_Validation(t *testing.T) {
+	cases := []struct {
+		name      string
+		yaml      string
+		wantError string
+	}{
+		{
+			name:      "no entries",
+			yaml:      "entries: []",
+			wantError: "at least one entry is required",
+		},
+		{
+			name: "missing placeholder",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - secret_ref: github_token
+    hosts: ["api.github.com"]
+`,
+			wantError: "placeholder is required",
+		},
+		{
+			name: "neither secret_ref nor source",
+			yaml: `
+entries:
+  - placeholder: PH
+    hosts: ["api.github.com"]
+`,
+			wantError: "exactly one of",
+		},
+		{
+			name: "both secret_ref and source",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+    source:
+      type: env
+      var: X
+    hosts: ["api.github.com"]
+`,
+			wantError: "exactly one of",
+		},
+		{
+			name: "secret_ref without secrets_file",
+			yaml: `
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+    hosts: ["api.github.com"]
+`,
+			wantError: `requires "secrets_file"`,
+		},
+		{
+			name: "no hosts or rules",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+`,
+			wantError: `at least one entry in "hosts" or "rules"`,
+		},
+		{
+			name: "wildcard host in hosts",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+    hosts: ["*"]
+`,
+			wantError: `host "*" is not allowed`,
+		},
+		{
+			name: "wildcard host in rules",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+    rules:
+      - host: "*"
+`,
+			wantError: `host "*" is not allowed`,
+		},
+		{
+			name: "duplicate placeholder",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: a
+    hosts: ["api.github.com"]
+  - placeholder: PH
+    secret_ref: b
+    hosts: ["api.stripe.com"]
+`,
+			wantError: "already used by entries[0]",
+		},
+		{
+			name: "overlapping placeholder",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH_TOKEN
+    secret_ref: a
+    hosts: ["api.github.com"]
+  - placeholder: PH_TOKEN_LONG
+    secret_ref: b
+    hosts: ["api.stripe.com"]
+`,
+			wantError: `overlaps placeholder "PH_TOKEN" from entries[0]`,
+		},
+		{
+			name: "invalid rule path",
+			yaml: `
+secrets_file: /etc/secrets.json
+entries:
+  - placeholder: PH
+    secret_ref: github_token
+    rules:
+      - host: "api.github.com"
+        paths: ["repos"]
+`,
+			wantError: "must start with /",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A logger writing nowhere: the missing-file warning that a
+			// startup load emits is not what these cases assert on.
+			logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+			_, err := newFromConfig(decodeConfig(t, tc.yaml), logger, secrets.BuildSource)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantError)
+		})
+	}
+}
+
+func TestFactory_RegisteredUnderName(t *testing.T) {
+	f, err := transform.Lookup(transformName)
+	require.NoError(t, err)
+
+	file := writeSecretsFile(t, map[string]string{"github_token": realSecret})
+	tr, err := f(yamlFromString(t, githubEntry(file, "")), slog.Default())
+	require.NoError(t, err)
+	require.Equal(t, transformName, tr.Name())
+}
+
+func TestCompileHeaders_AlwaysIncludesAuthorizationWithoutDuplicating(t *testing.T) {
+	require.Equal(t, []string{"Authorization"}, compileHeaders(nil))
+	require.Equal(t, []string{"Authorization"}, compileHeaders([]string{"authorization"}))
+	require.Equal(t,
+		[]string{"Authorization", "X-Api-Key", "X-Token"},
+		compileHeaders([]string{"x-api-key", "X-Token", "x-api-key"}),
+	)
+}

--- a/internal/transform/secrets/secrets.go
+++ b/internal/transform/secrets/secrets.go
@@ -428,8 +428,8 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue 
 	if len(sec.matchHeaders) == 0 {
 		for name, vals := range req.Header {
 			for i, v := range vals {
-				if headerContains(name, v, sec.proxyValue) {
-					req.Header[name][i] = replaceInHeader(name, v, sec.proxyValue, realValue)
+				if HeaderContains(name, v, sec.proxyValue) {
+					req.Header[name][i] = ReplaceInHeader(name, v, sec.proxyValue, realValue)
 					locations = append(locations, "header:"+name)
 				}
 			}
@@ -449,14 +449,14 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue 
 		}
 		hit := false
 		for _, v := range vals {
-			if headerContains(name, v, sec.proxyValue) {
+			if HeaderContains(name, v, sec.proxyValue) {
 				hit = true
 				break
 			}
 		}
 		req.Header.Del(name)
 		for _, v := range vals {
-			req.Header.Add(name, replaceInHeader(name, v, sec.proxyValue, realValue))
+			req.Header.Add(name, ReplaceInHeader(name, v, sec.proxyValue, realValue))
 		}
 		if hit {
 			locations = append(locations, "header:"+name)
@@ -476,29 +476,35 @@ func (s *Secrets) swapHeaders(req *http.Request, sec *resolvedSecret, realValue 
 	return locations
 }
 
-// replaceInHeader performs a secret replacement in a header value. For
+// ReplaceInHeader performs a substitution in a header value. For
 // Authorization headers with HTTP Basic auth, the base64 payload is decoded
-// before replacement and re-encoded after.
-func replaceInHeader(headerName, value, proxyValue, realValue string) string {
+// before replacement and re-encoded after, so a credential embedded in
+// "Basic base64(user:secret)" is still swapped.
+//
+// The substitution is direction-agnostic: pass (placeholder, real) to swap a
+// placeholder for a credential on the way upstream, or (real, placeholder) to
+// scrub an echoed credential on the way back. Exported so other transforms
+// (e.g. secretbroker) share this one implementation of the Basic-auth case.
+func ReplaceInHeader(headerName, value, from, to string) string {
 	if strings.EqualFold(headerName, "Authorization") {
 		if decoded, ok := decodeBasicAuth(value); ok {
-			replaced := strings.ReplaceAll(decoded, proxyValue, realValue)
+			replaced := strings.ReplaceAll(decoded, from, to)
 			return "Basic " + base64.StdEncoding.EncodeToString([]byte(replaced))
 		}
 	}
-	return strings.ReplaceAll(value, proxyValue, realValue)
+	return strings.ReplaceAll(value, from, to)
 }
 
-// headerContains checks whether a header value contains the proxy token.
-// For Authorization headers with HTTP Basic auth, the base64 payload is
-// decoded before checking.
-func headerContains(headerName, value, proxyValue string) bool {
+// HeaderContains reports whether a header value contains needle. For
+// Authorization headers with HTTP Basic auth, the base64 payload is decoded
+// before checking. Exported alongside ReplaceInHeader.
+func HeaderContains(headerName, value, needle string) bool {
 	if strings.EqualFold(headerName, "Authorization") {
 		if decoded, ok := decodeBasicAuth(value); ok {
-			return strings.Contains(decoded, proxyValue)
+			return strings.Contains(decoded, needle)
 		}
 	}
-	return strings.Contains(value, proxyValue)
+	return strings.Contains(value, needle)
 }
 
 // decodeBasicAuth extracts and base64-decodes the payload from a "Basic ..."

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -226,6 +226,46 @@ transforms:
         #   rules:
         #     - host: "api.openai.com"
 
+  # Secret broker: let a sandbox USE a credential without being able to READ
+  # it. The sandbox holds only a placeholder; the proxy swaps it for the real
+  # credential on requests to the hosts listed for that placeholder, and swaps
+  # any echoed credential back to the placeholder on the response so it cannot
+  # be recovered via an echo endpoint. Requires MITM mode.
+  #
+  # Where the secrets transform above scopes a swap by host, secretbroker also
+  # bounds which headers it will write into, refuses a "*" host, fails closed
+  # when the secrets file is unavailable, and scrubs the response. Use it when
+  # whoever is inside the sandbox may actively try to read the credential.
+  #
+  # Place this LAST in transforms: so header-capturing transforms (annotate)
+  # run first and record the placeholder rather than the real credential.
+  # - name: secretbroker
+  #   config:
+  #     # Root-owned file (mode 0600) holding a flat JSON object of
+  #     # secret_ref -> credential: {"github_token": "ghp_the_real_token"}.
+  #     # Missing, unreadable, or malformed disables substitution and logs one
+  #     # warning naming the path — never the contents. Re-read when the file
+  #     # changes (size or mtime), so rotating in place needs no restart.
+  #     secrets_file: "/etc/iron-proxy/secrets.json"
+  #     entries:
+  #       - placeholder: "IRON_PLACEHOLDER_GITHUB_TOKEN"  # what the sandbox holds
+  #         secret_ref: "github_token"     # key in secrets_file
+  #         hosts: ["api.github.com"]      # the only hosts it may be sent to; "*" rejected
+  #         headers: ["X-Api-Key"]         # scanned in addition to Authorization
+  #         match_body: false              # scan the request body too
+  #         scrub_response: true           # default; swap echoes back to the placeholder
+  #
+  #       # A credential that lives in a secrets backend rather than the file.
+  #       # source and secret_ref are mutually exclusive.
+  #       - placeholder: "IRON_PLACEHOLDER_OPENAI_KEY"
+  #         source:
+  #           type: env
+  #           var: OPENAI_API_KEY
+  #         rules:                         # full host/method/path rules also work
+  #           - host: "api.openai.com"
+  #             methods: ["POST"]
+  #             paths: ["/v1/*"]
+
   # GCP service account authentication. Signs a JWT with the configured
   # keyfile, exchanges it at Google's token endpoint for a short-lived OAuth2
   # access token, and sets Authorization: Bearer on matching requests. Tokens


### PR DESCRIPTION
## ENG-2027 — iron-proxy half

A work-trial candidate needs to **use** a company credential without ever being able to **read** it. The container holds only a placeholder; iron-proxy already MITMs container HTTPS with a per-container CA the candidate cannot read, so the swap can happen inside the proxy where the real value is out of reach.

This adds a `secretbroker` transform of the same shape as the existing ones (registered factory, `hostmatch` rules, `BufferedBody` for bodies, `tctx.Annotate` for audit).

### Config schema

This is the exact schema the litmus side renders from `infra/codespaces-v2-image/scripts/render-iron-proxy-config.sh`. It was posted to the status file as a `note: schema:` line at the start of the work so the sibling worker could proceed against it, and has not changed since.

```yaml
- name: secretbroker
  config:
    secrets_file: "/etc/iron-proxy/secrets.json"
    entries:
      - placeholder: "IRON_PLACEHOLDER_GITHUB_TOKEN"
        secret_ref: "github_token"
        hosts: ["api.github.com"]
        headers: ["X-Api-Key"]
        match_body: false
        scrub_response: true
```

One-line JSON form (JSON is valid YAML, so this can be emitted directly):

```json
{"name":"secretbroker","config":{"secrets_file":"/etc/iron-proxy/secrets.json","entries":[{"placeholder":"IRON_PLACEHOLDER_GITHUB_TOKEN","secret_ref":"github_token","hosts":["api.github.com"],"headers":["X-Api-Key"],"match_body":false,"scrub_response":true}]}}
```

`secrets_file` is a flat JSON object, root-owned and mode 0600:

```json
{ "github_token": "ghp_the_real_token" }
```

| Field | Required | Default | Meaning |
| --- | --- | --- | --- |
| `secrets_file` | when any entry uses `secret_ref` | — | Root-owned file holding `{secret_ref: credential}`. |
| `entries[].placeholder` | yes | — | The fake token the sandbox holds. Unique across entries, and may not contain or be contained by another entry's placeholder. |
| `entries[].secret_ref` | one of `secret_ref`/`source` | — | Key in `secrets_file`. |
| `entries[].source` | one of `secret_ref`/`source` | — | Any existing secrets-package source block (`env`, `aws_sm`, `aws_ssm`, `1password`, `1password_connect`), e.g. `{type: env, var: GITHUB_TOKEN}`. |
| `entries[].hosts` | one of `hosts`/`rules` | — | Domain globs or CIDRs the credential may be sent to. `"*"` is rejected. |
| `entries[].rules` | one of `hosts`/`rules` | — | Full `host`/`methods`/`paths` rules, as elsewhere in iron-proxy. Combined with `hosts`. |
| `entries[].headers` | no | `[]` | Request headers scanned **in addition to** `Authorization`, which is always scanned. |
| `entries[].match_body` | no | `false` | Also scan the request body. |
| `entries[].scrub_response` | no | `true` | Swap an echoed credential back to the placeholder on the response. |

### Behaviour

- **Host scoping is per entry.** Rules are checked before the credential is fetched, so a request to a host an entry does not allow never pulls that credential into the process. One entry's credential can never reach another entry's host.
- **Fail closed.** A missing, unreadable, or malformed `secrets_file` disables substitution: the placeholder travels upstream and the upstream rejects it. Exactly one warning naming the path — never its contents — is logged per distinct failure, not per request. A JSON parse error's text is deliberately dropped from the log, since such messages can quote the offending bytes.
- **Reload.** `secrets_file` is loaded at startup and re-read when its size or mtime changes, so rotating a credential in place needs no restart. The fork has no SIGHUP handler and no file watcher; its other reload vector, `POST /v1/reload`, rebuilds the pipeline from the config file and so re-reads the secrets file too.
- **Response scrubbing** covers every response header (the header allowlist bounds where the proxy *writes* a credential, but a leak on the way back can surface in any header) and the response body, bounded by the existing `proxy.max_response_body_bytes` body-capture limit. SSE bodies are left unbuffered so per-chunk streaming keeps working; their headers are still scrubbed and the entry is annotated `scrub_skipped: sse_body`.
- **Audit keeps the placeholder.** Annotations carry the `placeholder` and the `secret_ref`, both non-secret names, never the credential. `secretbroker` belongs **last** in `transforms:` so header-capturing transforms such as `annotate` run first and record the placeholder — the test below pins this by running the two in a real pipeline and asserting the credential appears nowhere in the audit output.
- **No `require` mode**, so `secretbroker` cannot hit the synthetic-CONNECT rejection defect class in #222 — it never rejects a request.

### Tests

`go test ./...` is green. 34 unit tests in `internal/transform/secretbroker`, covering the six cases the ticket asks for — header substitution, body substitution on and off, host not allowed, missing secrets file, response scrubbing, audit-carries-placeholder-only — plus per-entry host scoping, method/path rules, `Authorization: Basic` base64 payloads, secret-ref-absent, file rotation, recovery after the file appears, source-backed entries, sni-only no-op, SSE, and config validation.

Also verified end to end against the built binary and a local echo server (pipeline `allowlist → annotate → secretbroker`):

```
1. localhost:9911   substituted [header:Authorization, body] → scrubbed [header:X-Echoed-Auth, body]
2. 127.0.0.1:9911   (no annotations — host not allowed for this entry)
3-5. localhost:9911 secret_unavailable [echo_token]   ← file removed mid-run; 1 warning total
6. localhost:9911   substituted [header:Authorization] ← rotated credential picked up, no restart
```

The real credential appeared 0 times in the full proxy log, while `annotate` recorded `"header:Authorization": "Bearer IRON_PLACEHOLDER_ECHO"`.

### Notes for review

- **Overlap with the existing `secrets` transform.** `secrets` already does host-scoped placeholder→credential replacement, and I'd flag that this is adjacent to it. What `secretbroker` adds is the threat model: the workload is untrusted with the credential itself, not just with the network. Concretely — response scrubbing (`secrets` has none), a root-owned file source with in-place rotation, a bounded header allowlist rather than "empty means all headers", a refused `"*"` host, and fail-closed-with-one-warning. Folding these into `secrets` would have meant changing defaults for existing users (notably `match_headers: []` meaning "all headers", and no response side at all), so I built it as a sibling transform as the ticket asked. Worth a maintainer opinion on whether the two should converge later.
- **Shared helper extraction.** `secrets.replaceInHeader`/`headerContains` became `secrets.ReplaceInHeader`/`HeaderContains` so the Basic-auth base64 case has one implementation instead of two. Pure rename plus doc comments; call sites updated, `secrets` tests unchanged and green. The functions are direction-agnostic, which is what lets the response scrub reuse them.
- **Pre-existing bug spotted, not fixed here.** `secrets.swapBody` reads the request body without rewinding, so a second `match_body` entry matching the same host reads EOF and silently skips its substitution. `secretbroker` has the same shape and I hit it during review — fixed here (`replaceBody` rewinds, with a regression test that fails without the fix). The equivalent fix in `secrets` wants its own test and PR rather than riding along in this one; happy to open it.
- Adds `AGENTS.md` (the repo had none) with the transform-registration checklist — the blank import in `cmd/iron-proxy/main.go` is easy to miss — and the reload semantics, since neither is obvious from the code.
- No release tag cut, per the ticket.

Closes ENG-2027 (iron-proxy half).
