### PR TITLE
Add exact HTTP and JSON-RPC egress policies

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+FROM --platform=linux/amd64 golang:1.26.1-alpine@sha256:d337ecb3075f0ec76d81652b3fa52af47c3eba6c8ba9f93b835752df7ce62946 AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+COPY . .
+ARG VERSION=dev
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -buildvcs=false \
+    -ldflags="-s -w -X github.com/ironsh/iron-proxy/internal/version.Version=${VERSION}" \
+    -o /out/iron-proxy ./cmd/iron-proxy
+
+FROM --platform=linux/amd64 alpine/openssl:3.5.4@sha256:42c7389ef077aed0eb4e96d0abbd094083d701bbaff1313073b061c0c9cd8278
+COPY --from=builder /out/iron-proxy /usr/local/bin/iron-proxy
+COPY LICENSE /usr/local/share/licenses/iron-proxy/LICENSE
+ENTRYPOINT ["iron-proxy"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Or build from source:
 go build -o iron-proxy ./cmd/iron-proxy
 ```
 
+To build a Linux/amd64 image directly from source:
+
+```bash
+docker build -f Dockerfile.build -t iron-proxy .
+```
+
 ## Quick start
 
 ```bash
@@ -324,6 +330,82 @@ actually enforcing it. Requests that would be rejected are allowed through but
 annotated with `"action": "warn"` in the transform trace. This is useful for
 rolling out new allowlist rules or auditing existing traffic before switching
 to enforcement.
+
+### Exact request policies
+
+`request_policy` restricts an exact host and port by path, HTTP method, query
+parameters, and optional empty body. Unmatched endpoints on that host/port
+are rejected; other destinations pass through, so retain `allowlist` as the
+overall egress gate.
+
+```yaml
+transforms:
+  - name: request_policy
+    config:
+      rules:
+        - host: "api.example.com"
+          port: "443"
+          path: "/v1/item"
+          http_methods: ["GET", "HEAD"]
+          require_empty_body: true
+          query:
+            mode: exact
+            parameters:
+              - {name: id, required: true, value_pattern: "[0-9]+"}
+              - {name: format, required: true, exact_values: [json]}
+```
+
+Use `query: {mode: empty}` to disallow query values. In `exact` mode, unknown
+parameters are rejected. Each parameter requires either `exact_values` (the
+complete expected list, including multiplicity, regardless of order) or
+`value_pattern` (a whole-value RE2 match against exactly one decoded value).
+`case_insensitive: true` applies to exact values; regex flags belong inside
+the pattern. Parameters may be omitted unless `required: true` is set.
+
+### JSON-RPC method policies
+
+`json_rpc` allows specific JSON-RPC 2.0 methods at an exact endpoint,
+independently of MCP tool policy. Configure one rule per host/port; the first
+matching host/port rule applies. Other destinations pass through.
+
+```yaml
+transforms:
+  - name: json_rpc
+    config:
+      max_body_bytes: 1048576
+      rules:
+        - host: "rpc.example.com"
+          port: "443"
+          path: "/rpc"
+          http_methods: ["POST"]
+          allowed_methods: ["getStatus", "getItem"]
+```
+
+Every entry in a nonempty batch must pass. Requests require an ID and
+`application/json` content type (optional UTF-8 charset). Notifications,
+duplicate JSON keys, unknown envelope fields, incomplete/oversized bodies,
+content/transfer encoding, and WebSocket upgrades are rejected. RPC parameters
+must be an array or object; their contents are not restricted.
+
+Both transforms reject unknown YAML fields. CONNECT establishes transport;
+the inner HTTP request is evaluated separately. Place `request_policy` before
+`secrets` to constrain placeholder values and `json_rpc` after `secrets` when
+its path must match the rewritten upstream path.
+
+### Ports, private upstreams, and timeouts
+
+Shared host/method/path rules accept `ports: ["443"]`; omitting ports retains
+all-port matching. Implicit HTTP/HTTPS ports resolve to 80/443.
+
+`proxy.upstream_private_exceptions` maps exact hostnames to `/32` or `/128`
+addresses, for example `managed-rpc.internal: ["10.20.0.7/32"]`. The named
+host may resolve to those addresses despite `upstream_deny_cidrs`; IP-literal
+destinations cannot use exceptions. Transform policies still apply.
+
+Downstream defaults are 10 seconds for headers/tunnel handshakes and 30 seconds
+for request reads/idle connections. Upstream response timeouts are unchanged.
+The Go `proxy.Options` timeout fields accept positive overrides; zero/negative
+values retain these defaults.
 
 ### Annotate
 

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -42,8 +42,10 @@ import (
 	_ "github.com/ironsh/iron-proxy/internal/transform/grpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/headerallowlist"
 	_ "github.com/ironsh/iron-proxy/internal/transform/hmacsign"
+	_ "github.com/ironsh/iron-proxy/internal/transform/jsonrpc"
 	_ "github.com/ironsh/iron-proxy/internal/transform/judge"
 	_ "github.com/ironsh/iron-proxy/internal/transform/oauth"
+	_ "github.com/ironsh/iron-proxy/internal/transform/requestpolicy"
 	_ "github.com/ironsh/iron-proxy/internal/transform/secrets"
 )
 
@@ -203,7 +205,10 @@ func main() {
 
 	// Build the upstream-dial deny guard. config.Validate has already
 	// confirmed the entries parse, so this should not fail.
-	guard, err := dnsguard.New(cfg.Proxy.UpstreamDenyCIDRs.Values)
+	guard, err := dnsguard.NewWithExceptions(
+		cfg.Proxy.UpstreamDenyCIDRs.Values,
+		cfg.Proxy.UpstreamPrivateExceptions,
+	)
 	if err != nil {
 		logger.Error("initializing upstream deny guard", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,10 @@ type Proxy struct {
 	// at connect time against the resolved address. When unset, a secure
 	// default (IMDS + loopback) is applied; set to an empty list to disable.
 	UpstreamDenyCIDRs CIDRList `yaml:"upstream_deny_cidrs"`
+	// UpstreamPrivateExceptions permits an otherwise denied resolved IP only
+	// for the exact original hostname and listed CIDR. This is intended for a
+	// named, managed private upstream without relaxing the denylist globally.
+	UpstreamPrivateExceptions map[string][]string `yaml:"upstream_private_exceptions"`
 	// UpstreamProxy routes iron-proxy's own outbound connections through an
 	// upstream SOCKS5/HTTP CONNECT proxy. The standard HTTP_PROXY/HTTPS_PROXY/
 	// NO_PROXY environment variables override these fields when set.
@@ -314,6 +318,9 @@ func Validate(cfg *Config) error {
 
 	if err := dnsguard.ValidateCIDRs(cfg.Proxy.UpstreamDenyCIDRs.Values); err != nil {
 		return fmt.Errorf("proxy.upstream_deny_cidrs: %w", err)
+	}
+	if err := dnsguard.ValidateExceptions(cfg.Proxy.UpstreamPrivateExceptions); err != nil {
+		return fmt.Errorf("proxy.upstream_private_exceptions: %w", err)
 	}
 
 	if cfg.Management.Listen != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -418,6 +418,22 @@ tls:
 	})
 }
 
+func TestLoad_UpstreamPrivateExceptions(t *testing.T) {
+	yaml := validYAML() + `
+proxy:
+  upstream_private_exceptions:
+    managed-rpc: ["10.23.4.5/32"]
+`
+	cfg, err := Load(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{"managed-rpc": {"10.23.4.5/32"}}, cfg.Proxy.UpstreamPrivateExceptions)
+
+	yaml = strings.Replace(yaml, "managed-rpc:", "'*':", 1)
+	_, err = Load(strings.NewReader(yaml))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "proxy.upstream_private_exceptions")
+}
+
 func TestLoad_Management(t *testing.T) {
 	t.Run("disabled by default", func(t *testing.T) {
 		cfg, err := Load(strings.NewReader(validYAML()))

--- a/internal/dnsguard/dnsguard.go
+++ b/internal/dnsguard/dnsguard.go
@@ -5,6 +5,7 @@
 package dnsguard
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -64,13 +65,22 @@ func IsDenyError(err error) bool {
 // Guard holds the compiled deny prefixes and exposes hooks for the dialer.
 // The zero value is a valid empty guard whose DialControl is a no-op.
 type Guard struct {
-	prefixes []netip.Prefix
+	prefixes   []netip.Prefix
+	exceptions map[string][]netip.Prefix
 }
 
 // New compiles a Guard from CIDR strings. CIDR notation is required: bare IPs
 // like "1.2.3.4" are rejected, forcing operators to be explicit about scope.
 // A nil or empty list yields an empty guard whose checks always pass.
 func New(cidrs []string) (*Guard, error) {
+	return NewWithExceptions(cidrs, nil)
+}
+
+// NewWithExceptions compiles a Guard with hostname-scoped exceptions. An
+// exception permits an otherwise denied resolved IP only when the original
+// dial target is the exact configured hostname and the IP is inside one of
+// that hostname's prefixes. IP-literal targets can never use an exception.
+func NewWithExceptions(cidrs []string, exceptions map[string][]string) (*Guard, error) {
 	prefixes := make([]netip.Prefix, 0, len(cidrs))
 	for _, raw := range cidrs {
 		p, err := parsePrefix(raw)
@@ -79,7 +89,48 @@ func New(cidrs []string) (*Guard, error) {
 		}
 		prefixes = append(prefixes, p)
 	}
-	return &Guard{prefixes: prefixes}, nil
+	compiledExceptions := make(map[string][]netip.Prefix, len(exceptions))
+	for rawHost, rawPrefixes := range exceptions {
+		host, err := canonicalExceptionHost(rawHost)
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range rawPrefixes {
+			prefix, err := parsePrefix(raw)
+			if err != nil {
+				return nil, fmt.Errorf("private exception %q: %w", rawHost, err)
+			}
+			if prefix.Bits() != prefix.Addr().BitLen() {
+				return nil, fmt.Errorf(
+					"private exception %q: %q must identify exactly one address (/32 or /128)",
+					rawHost, raw,
+				)
+			}
+			compiledExceptions[host] = append(compiledExceptions[host], prefix)
+		}
+	}
+	return &Guard{prefixes: prefixes, exceptions: compiledExceptions}, nil
+}
+
+func canonicalExceptionHost(raw string) (string, error) {
+	host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(raw)), ".")
+	if host == "" || strings.ContainsAny(host, ":/@*[]") {
+		return "", fmt.Errorf("invalid private exception hostname %q", raw)
+	}
+	if _, err := netip.ParseAddr(host); err == nil {
+		return "", fmt.Errorf("private exception hostname %q must not be an IP literal", raw)
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", fmt.Errorf("invalid private exception hostname %q", raw)
+		}
+		for _, char := range label {
+			if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+				return "", fmt.Errorf("invalid private exception hostname %q", raw)
+			}
+		}
+	}
+	return host, nil
 }
 
 // ValidateCIDRs reports whether every entry in cidrs is a valid CIDR string
@@ -93,6 +144,13 @@ func ValidateCIDRs(cidrs []string) error {
 		}
 	}
 	return nil
+}
+
+// ValidateExceptions reports whether all private exception hostnames and
+// prefixes are valid without constructing a Guard.
+func ValidateExceptions(exceptions map[string][]string) error {
+	_, err := NewWithExceptions(nil, exceptions)
+	return err
 }
 
 func parsePrefix(raw string) (netip.Prefix, error) {
@@ -130,6 +188,25 @@ func (g *Guard) IsDenied(ip netip.Addr) bool {
 // (e.g. SOCKS5 IPv4 atyp) are both covered. Returning an error aborts the
 // connect.
 func (g *Guard) DialControl(_ string, address string, _ syscall.RawConn) error {
+	return g.dialControlForHost("", address)
+}
+
+// DialContext applies the guard while retaining the original hostname. A
+// net.Dialer Control hook sees only the post-resolution IP, so the target name
+// has to be captured per dial for destination-scoped exceptions to be safe.
+func (g *Guard) DialContext(ctx context.Context, dialer *net.Dialer, network, address string) (net.Conn, error) {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	copy := *dialer
+	copy.Control = func(network, resolved string, raw syscall.RawConn) error {
+		return g.dialControlForHost(host, resolved)
+	}
+	return copy.DialContext(ctx, network, address)
+}
+
+func (g *Guard) dialControlForHost(originalHost, address string) error {
 	if g == nil || len(g.prefixes) == 0 {
 		return nil
 	}
@@ -144,8 +221,27 @@ func (g *Guard) DialControl(_ string, address string, _ syscall.RawConn) error {
 	addr = addr.Unmap()
 	for _, p := range g.prefixes {
 		if p.Contains(addr) {
+			if g.isExcepted(originalHost, addr) {
+				return nil
+			}
 			return &DenyError{Address: host, Prefix: p}
 		}
 	}
 	return nil
+}
+
+func (g *Guard) isExcepted(originalHost string, address netip.Addr) bool {
+	if g == nil || originalHost == "" {
+		return false
+	}
+	if _, err := netip.ParseAddr(strings.Trim(originalHost, "[]")); err == nil {
+		return false
+	}
+	host := strings.TrimSuffix(strings.ToLower(originalHost), ".")
+	for _, prefix := range g.exceptions[host] {
+		if prefix.Contains(address) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/dnsguard/dnsguard_test.go
+++ b/internal/dnsguard/dnsguard_test.go
@@ -1,8 +1,11 @@
 package dnsguard
 
 import (
+	"context"
+	"net"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -178,7 +181,73 @@ func TestDialControl_EmptyGuardNoop(t *testing.T) {
 	require.NoError(t, g.DialControl("tcp", "127.0.0.1:443", nil))
 }
 
+func TestDialContextRejectsDeniedAddressAfterHostnameResolution(t *testing.T) {
+	g, err := New([]string{"127.0.0.0/8", "::1/128"})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	connection, err := g.DialContext(
+		ctx,
+		&net.Dialer{Timeout: time.Second},
+		"tcp",
+		"localhost:443",
+	)
+	if connection != nil {
+		_ = connection.Close()
+	}
+	require.Error(t, err)
+	require.True(t, IsDenyError(err), "resolved loopback must fail at the dial guard")
+}
+
 func TestDialControl_NilGuardNoop(t *testing.T) {
 	var g *Guard
 	require.NoError(t, g.DialControl("tcp", "127.0.0.1:443", nil))
+}
+
+func TestPrivateException_IsExactHostnameAndAddress(t *testing.T) {
+	g, err := NewWithExceptions(
+		[]string{"10.0.0.0/8", "169.254.0.0/16"},
+		map[string][]string{"managed-rpc": {"10.23.4.5/32"}},
+	)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name, host, address string
+		allow               bool
+	}{
+		{"exact match", "managed-rpc", "10.23.4.5:8899", true},
+		{"canonical hostname", "MANAGED-RPC.", "10.23.4.5:8899", true},
+		{"wrong address", "managed-rpc", "10.23.4.6:8899", false},
+		{"wrong host", "other-rpc", "10.23.4.5:8899", false},
+		{"literal IP", "10.23.4.5", "10.23.4.5:8899", false},
+		{"metadata address", "managed-rpc", "169.254.169.254:80", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.allow, g.dialControlForHost(tc.host, tc.address) == nil)
+		})
+	}
+	// The compatibility hook has no original hostname and therefore never
+	// applies private exceptions.
+	require.Error(t, g.DialControl("tcp", "10.23.4.5:8899", nil))
+}
+
+func TestPrivateException_RejectsUnsafeConfiguration(t *testing.T) {
+	cases := []struct{ name, host, prefix string }{
+		{"empty host", "", "10.0.0.2/32"},
+		{"wildcard", "*.example", "10.0.0.2/32"},
+		{"literal IP", "10.0.0.1", "10.0.0.2/32"},
+		{"port in host", "rpc:8899", "10.0.0.2/32"},
+		{"invalid host", "-rpc", "10.0.0.2/32"},
+		{"missing prefix", "managed-rpc", "10.0.0.2"},
+		{"broad IPv4 prefix", "managed-rpc", "10.0.0.0/8"},
+		{"broad IPv6 prefix", "managed-rpc", "2001:db8::/64"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewWithExceptions(nil, map[string][]string{tc.host: {tc.prefix}})
+			require.Error(t, err)
+		})
+	}
 }

--- a/internal/hostmatch/rule.go
+++ b/internal/hostmatch/rule.go
@@ -2,6 +2,7 @@ package hostmatch
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -10,6 +11,7 @@ import (
 type RuleConfig struct {
 	Host    string   `yaml:"host,omitempty"`
 	CIDR    string   `yaml:"cidr,omitempty"`
+	Ports   []string `yaml:"ports,omitempty"`
 	Methods []string `yaml:"methods,omitempty"`
 	Paths   []string `yaml:"paths,omitempty"`
 }
@@ -17,13 +19,17 @@ type RuleConfig struct {
 // Rule is a compiled matching rule ready for use.
 type Rule struct {
 	Matcher *Matcher
+	Ports   map[string]bool // nil = all ports
 	Methods map[string]bool // nil = all methods
 	Paths   []string        // nil = all paths
 }
 
 // Matches returns true if the request matches this rule.
-func (r *Rule) Matches(host, method, path string) bool {
+func (r *Rule) Matches(host, port, method, path string) bool {
 	if !r.Matcher.Matches(host) {
+		return false
+	}
+	if r.Ports != nil && !r.Ports[port] {
 		return false
 	}
 	if r.Methods != nil && !r.Methods[method] {
@@ -67,6 +73,15 @@ func CompileRules(configs []RuleConfig, prefix string) ([]Rule, error) {
 		}
 
 		r := Rule{Matcher: m}
+		if len(rc.Ports) > 0 {
+			r.Ports = make(map[string]bool, len(rc.Ports))
+			for _, port := range rc.Ports {
+				if port == "" || strings.ContainsAny(port, "*?/\\") {
+					return nil, fmt.Errorf("%s: rules[%d]: invalid exact port %q", prefix, i, port)
+				}
+				r.Ports[port] = true
+			}
+		}
 		if !isWildcard(rc.Methods) {
 			r.Methods = make(map[string]bool, len(rc.Methods))
 			for _, method := range rc.Methods {
@@ -88,11 +103,25 @@ func isWildcard(methods []string) bool {
 
 // MatchAnyRule returns true if the request matches any rule in the list.
 func MatchAnyRule(rules []Rule, req *http.Request) bool {
-	host := StripPort(req.Host)
+	host, port := HostPort(req)
 	for _, r := range rules {
-		if r.Matches(host, req.Method, req.URL.Path) {
+		if r.Matches(host, port, req.Method, req.URL.Path) {
 			return true
 		}
 	}
 	return false
+}
+
+// HostPort returns the normalized request hostname and effective destination
+// port. It preserves explicit non-default ports instead of allowing a
+// hostname rule to silently authorize every service on that host.
+func HostPort(req *http.Request) (string, string) {
+	host := StripPort(req.Host)
+	if _, port, err := net.SplitHostPort(req.Host); err == nil {
+		return host, port
+	}
+	if req.URL != nil && strings.EqualFold(req.URL.Scheme, "https") || req.TLS != nil {
+		return host, "443"
+	}
+	return host, "80"
 }

--- a/internal/hostmatch/rule_test.go
+++ b/internal/hostmatch/rule_test.go
@@ -15,7 +15,7 @@ func TestCompileRules_WildcardMethodMatchesAll(t *testing.T) {
 	require.Nil(t, rules[0].Methods, "wildcard method should result in nil Methods (match all)")
 
 	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"} {
-		require.True(t, rules[0].Matches("example.com", method, "/"), "method %s should match", method)
+		require.True(t, rules[0].Matches("example.com", "80", method, "/"), "method %s should match", method)
 	}
 }
 
@@ -27,9 +27,9 @@ func TestCompileRules_ExplicitMethodsFiltered(t *testing.T) {
 	require.Len(t, rules, 1)
 	require.NotNil(t, rules[0].Methods)
 
-	require.True(t, rules[0].Matches("example.com", "GET", "/"))
-	require.True(t, rules[0].Matches("example.com", "POST", "/"))
-	require.False(t, rules[0].Matches("example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "80", "GET", "/"))
+	require.True(t, rules[0].Matches("example.com", "80", "POST", "/"))
+	require.False(t, rules[0].Matches("example.com", "80", "DELETE", "/"))
 }
 
 func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
@@ -40,6 +40,13 @@ func TestCompileRules_NoMethodsMatchesAll(t *testing.T) {
 	require.Len(t, rules, 1)
 	require.Nil(t, rules[0].Methods)
 
-	require.True(t, rules[0].Matches("example.com", "GET", "/"))
-	require.True(t, rules[0].Matches("example.com", "DELETE", "/"))
+	require.True(t, rules[0].Matches("example.com", "80", "GET", "/"))
+	require.True(t, rules[0].Matches("example.com", "80", "DELETE", "/"))
+}
+
+func TestCompileRules_ExactPort(t *testing.T) {
+	rules, err := CompileRules([]RuleConfig{{Host: "example.com", Ports: []string{"443"}}}, "test")
+	require.NoError(t, err)
+	require.True(t, rules[0].Matches("example.com", "443", "GET", "/"))
+	require.False(t, rules[0].Matches("example.com", "8443", "GET", "/"))
 }

--- a/internal/mcp/policy.go
+++ b/internal/mcp/policy.go
@@ -195,10 +195,10 @@ func (p *Policy) MatchServer(req *http.Request) *Server {
 	if p == nil {
 		return nil
 	}
-	host := hostmatch.StripPort(req.Host)
+	host, port := hostmatch.HostPort(req)
 	for _, s := range p.servers {
 		for _, r := range s.rules {
-			if r.Matches(host, req.Method, req.URL.Path) {
+			if r.Matches(host, port, req.Method, req.URL.Path) {
 				return s
 			}
 		}

--- a/internal/mcpgateway/gateway.go
+++ b/internal/mcpgateway/gateway.go
@@ -203,10 +203,10 @@ func (g *Gateway) Match(req *http.Request) *Route {
 	if g == nil {
 		return nil
 	}
-	host := hostmatch.StripPort(req.Host)
+	host, port := hostmatch.HostPort(req)
 	for _, route := range g.routes {
 		for _, rule := range route.rules {
-			if rule.Matches(host, req.Method, req.URL.Path) {
+			if rule.Matches(host, port, req.Method, req.URL.Path) {
 				return route
 			}
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -63,9 +63,21 @@ type Proxy struct {
 	// allowlisted hostname onto a different port. Overridable in tests.
 	sniUpstreamPort string
 	ready           func() bool
+
+	downstreamReadHeaderTimeout time.Duration
+	downstreamReadTimeout       time.Duration
+	downstreamIdleTimeout       time.Duration
+	tunnelHandshakeTimeout      time.Duration
 }
 
 const notReadyMessage = "proxy is not ready: awaiting control-plane config"
+
+const (
+	defaultDownstreamReadHeaderTimeout = 10 * time.Second
+	defaultDownstreamReadTimeout       = 30 * time.Second
+	defaultDownstreamIdleTimeout       = 30 * time.Second
+	defaultTunnelHandshakeTimeout      = 10 * time.Second
+)
 
 // Options configures Proxy construction.
 type Options struct {
@@ -97,6 +109,12 @@ type Options struct {
 	// requests can never pass through un-transformed (leaking placeholder
 	// credentials upstream) during startup.
 	Ready func() bool
+	// Downstream timeouts bound unauthenticated client connections. Zero or
+	// negative values use finite defaults and cannot disable the boundary.
+	DownstreamReadHeaderTimeout time.Duration
+	DownstreamReadTimeout       time.Duration
+	DownstreamIdleTimeout       time.Duration
+	TunnelHandshakeTimeout      time.Duration
 }
 
 // New creates a new Proxy. In TLSModeMITM, certCache must be non-nil. In
@@ -104,6 +122,18 @@ type Options struct {
 func New(opts Options) *Proxy {
 	if opts.TLSMode == "" {
 		opts.TLSMode = config.TLSModeMITM
+	}
+	if opts.DownstreamReadHeaderTimeout <= 0 {
+		opts.DownstreamReadHeaderTimeout = defaultDownstreamReadHeaderTimeout
+	}
+	if opts.DownstreamReadTimeout <= 0 {
+		opts.DownstreamReadTimeout = defaultDownstreamReadTimeout
+	}
+	if opts.DownstreamIdleTimeout <= 0 {
+		opts.DownstreamIdleTimeout = defaultDownstreamIdleTimeout
+	}
+	if opts.TunnelHandshakeTimeout <= 0 {
+		opts.TunnelHandshakeTimeout = defaultTunnelHandshakeTimeout
 	}
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	guard := opts.Guard
@@ -127,16 +157,27 @@ func New(opts Options) *Proxy {
 		logger:               opts.Logger,
 		shutdownCtx:          shutdownCtx,
 		shutdownCancel:       shutdownCancel,
+
+		downstreamReadHeaderTimeout: opts.DownstreamReadHeaderTimeout,
+		downstreamReadTimeout:       opts.DownstreamReadTimeout,
+		downstreamIdleTimeout:       opts.DownstreamIdleTimeout,
+		tunnelHandshakeTimeout:      opts.TunnelHandshakeTimeout,
 	}
 
 	p.httpServer = &http.Server{
-		Addr:    opts.HTTPAddr,
-		Handler: http.HandlerFunc(p.handleDirectHTTP),
+		Addr:              opts.HTTPAddr,
+		Handler:           http.HandlerFunc(p.handleDirectHTTP),
+		ReadHeaderTimeout: opts.DownstreamReadHeaderTimeout,
+		ReadTimeout:       opts.DownstreamReadTimeout,
+		IdleTimeout:       opts.DownstreamIdleTimeout,
 	}
 
 	p.httpsServer = &http.Server{
-		Addr:    opts.HTTPSAddr,
-		Handler: http.HandlerFunc(p.handleDirectHTTP),
+		Addr:              opts.HTTPSAddr,
+		Handler:           http.HandlerFunc(p.handleDirectHTTP),
+		ReadHeaderTimeout: opts.DownstreamReadHeaderTimeout,
+		ReadTimeout:       opts.DownstreamReadTimeout,
+		IdleTimeout:       opts.DownstreamIdleTimeout,
 		TLSConfig: &tls.Config{
 			GetCertificate: p.getCertificate,
 		},
@@ -780,7 +821,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 			&tls.Config{MinVersion: tls.VersionTLS12},
 		)
 	} else {
-		upstreamConn, err = dialer.DialContext(r.Context(), "tcp", upstreamHost)
+		upstreamConn, err = p.guard.DialContext(r.Context(), dialer, "tcp", upstreamHost)
 	}
 	if err != nil {
 		p.logger.Error("websocket upstream dial failed",
@@ -937,7 +978,6 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 		Resolver:  resolver,
-		Control:   guard.DialControl,
 	}
 	if responseHeaderTimeout <= 0 {
 		responseHeaderTimeout = config.DefaultUpstreamResponseHeaderTimeout
@@ -946,8 +986,10 @@ func buildTransport(resolver *net.Resolver, guard *dnsguard.Guard, responseHeade
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
-		Proxy:       proxyFunc,
-		DialContext: dialer.DialContext,
+		Proxy: proxyFunc,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return guard.DialContext(ctx, dialer, network, address)
+		},
 		// A custom DialContext disables net/http's automatic HTTP/2; opt back in
 		// so gRPC upstreams negotiate h2 over the same (dnsguard-controlled) dialer.
 		ForceAttemptHTTP2:     true,

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,6 +32,8 @@ import (
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/mcpgateway"
 	"github.com/ironsh/iron-proxy/internal/transform"
+	_ "github.com/ironsh/iron-proxy/internal/transform/jsonrpc"
+	_ "github.com/ironsh/iron-proxy/internal/transform/requestpolicy"
 )
 
 func testLogger() *slog.Logger {
@@ -140,6 +143,80 @@ func startProxyWithTransforms(t *testing.T, transforms []transform.Transformer) 
 	return p, httpAddr, httpsAddr, pool
 }
 
+func startProxyWithDeadlines(t *testing.T, timeout time.Duration) (*Proxy, string, string) {
+	t.Helper()
+	caCert, caKey := generateTestCA(t)
+	cache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
+	p := New(Options{
+		HTTPAddr:                    "127.0.0.1:0",
+		HTTPSAddr:                   "127.0.0.1:0",
+		CertCache:                   cache,
+		Pipeline:                    transform.NewPipelineHolder(pipeline),
+		Logger:                      testLogger(),
+		DownstreamReadHeaderTimeout: timeout,
+		DownstreamReadTimeout:       timeout,
+		DownstreamIdleTimeout:       timeout,
+		TunnelHandshakeTimeout:      timeout,
+	})
+	httpLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	httpsLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tlsLn := tls.NewListener(httpsLn, p.httpsServer.TLSConfig)
+	go func() { _ = p.httpServer.Serve(httpLn) }()
+	go func() { _ = p.httpsServer.Serve(tlsLn) }()
+	t.Cleanup(func() {
+		_ = p.httpServer.Close()
+		_ = p.httpsServer.Close()
+	})
+	return p, httpLn.Addr().String(), httpsLn.Addr().String()
+}
+
+func requirePeerCloses(t *testing.T, conn net.Conn) {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	buffer := make([]byte, 4096)
+	for {
+		_, err := conn.Read(buffer)
+		if err == nil {
+			continue
+		}
+		var networkError net.Error
+		if errors.As(err, &networkError) {
+			require.False(t, networkError.Timeout(), "peer did not enforce its deadline")
+		}
+		return
+	}
+}
+
+func TestProxyStalledDirectConnectionsExpire(t *testing.T) {
+	const timeout = 150 * time.Millisecond
+	_, httpAddr, httpsAddr := startProxyWithDeadlines(t, timeout)
+
+	tests := []struct {
+		name, address string
+		payload       string
+	}{
+		{"http partial header", httpAddr, "GET http://example.com/ HTTP/1.1\r\nHost: example.com"},
+		{"http partial body", httpAddr, "POST http://example.com/ HTTP/1.1\r\nHost: example.com\r\nContent-Length: 100\r\n\r\nx"},
+		{"tls handshake", httpsAddr, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := net.DialTimeout("tcp", tc.address, time.Second)
+			require.NoError(t, err)
+			defer conn.Close()
+			if tc.payload != "" {
+				_, err = io.WriteString(conn, tc.payload)
+				require.NoError(t, err)
+			}
+			requirePeerCloses(t, conn)
+		})
+	}
+}
+
 func startHTTPProxyWithMCP(t *testing.T, policy *mcp.Policy, gateway *mcpgateway.Gateway) (*Proxy, string) {
 	t.Helper()
 	pipeline := transform.NewPipeline(nil, transform.BodyLimits{}, testLogger())
@@ -220,6 +297,81 @@ func TestHTTPProxy_PostBody(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "echo: request body", string(body))
+}
+
+func TestHTTPProxy_EgressPoliciesRejectBeforeUpstream(t *testing.T) {
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	upstreamURL, err := url.Parse(upstream.URL)
+	require.NoError(t, err)
+	host, port, err := net.SplitHostPort(upstreamURL.Host)
+	require.NoError(t, err)
+
+	allow, err := transform.Lookup("allowlist")
+	require.NoError(t, err)
+	requestPolicy, err := transform.Lookup("request_policy")
+	require.NoError(t, err)
+	jsonRPC, err := transform.Lookup("json_rpc")
+	require.NoError(t, err)
+	allowTransform, err := allow(mustYAMLNode(t, fmt.Sprintf("domains: [%q]", host)), testLogger())
+	require.NoError(t, err)
+	requestTransform, err := requestPolicy(mustYAMLNode(t, fmt.Sprintf(`rules:
+  - host: %q
+    port: %q
+    path: /artifact
+    http_methods: [GET, HEAD]
+    require_empty_body: true
+    query: {mode: empty}
+  - host: %q
+    port: %q
+    path: /rpc
+    http_methods: [POST]
+    query: {mode: empty}
+`, host, port, host, port)), testLogger())
+	require.NoError(t, err)
+	rpcTransform, err := jsonRPC(mustYAMLNode(t, fmt.Sprintf(`rules:
+  - host: %q
+    port: %q
+    path: /rpc
+    http_methods: [POST]
+    allowed_methods: [eth_call]
+`, host, port)), testLogger())
+	require.NoError(t, err)
+
+	_, proxyAddr, _, _ := startProxyWithTransforms(t, []transform.Transformer{allowTransform, requestTransform, rpcTransform})
+	client := &http.Client{Transport: &http.Transport{Proxy: func(*http.Request) (*url.URL, error) {
+		return url.Parse("http://" + proxyAddr)
+	}}}
+	do := func(method, path, body string) int {
+		t.Helper()
+		req, requestErr := http.NewRequest(method, upstream.URL+path, strings.NewReader(body))
+		require.NoError(t, requestErr)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, requestErr := client.Do(req)
+		require.NoError(t, requestErr)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	cases := []struct{ name, method, path, body string }{
+		{"query rejected", http.MethodGet, "/artifact?extra=value", ""},
+		{"body rejected", http.MethodGet, "/artifact", "data"},
+		{"RPC method rejected", http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":1,"method":"notAllowed","params":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, http.StatusForbidden, do(tc.method, tc.path, tc.body))
+		})
+	}
+	require.Zero(t, upstreamHits.Load(), "denied requests must never reach the mock upstream")
+	require.Equal(t, http.StatusOK, do(http.MethodPost, "/rpc", `{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[]}`))
+	require.Equal(t, int64(1), upstreamHits.Load())
 }
 
 func TestMCPGatewayRoutesAllowedCallWithCredential(t *testing.T) {

--- a/internal/proxy/sni_passthrough.go
+++ b/internal/proxy/sni_passthrough.go
@@ -114,7 +114,7 @@ func (p *Proxy) serveSNIPassthrough(clientConn net.Conn) error {
 	if port == "" {
 		port = defaultSNIUpstream
 	}
-	upstream, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(sni, port))
+	upstream, err := p.guard.DialContext(ctx, dialer, "tcp", net.JoinHostPort(sni, port))
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -51,6 +51,11 @@ func (p *Proxy) listenTunnel() error {
 // handleTunnel peeks at the first byte to dispatch to HTTP proxy or SOCKS5.
 // This is the single logging point for tunnel connection errors.
 func (p *Proxy) handleTunnel(conn net.Conn) {
+	if err := conn.SetReadDeadline(time.Now().Add(p.tunnelHandshakeTimeout)); err != nil {
+		p.logger.Debug("tunnel deadline error", slog.String("error", err.Error()))
+		_ = conn.Close()
+		return
+	}
 	br := bufio.NewReader(conn)
 	first, err := br.Peek(1)
 	if err != nil {
@@ -78,7 +83,7 @@ func (p *Proxy) handleTunnel(conn net.Conn) {
 // CONNECT establishes a tunnel; all other methods are forwarded through the
 // normal HTTP proxy path.
 func (p *Proxy) serveTunnelProxyHTTP(conn net.Conn) error {
-	return serveOneHTTPConn(conn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return p.serveOneHTTPConn(conn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodConnect {
 			p.handleTunnelCONNECT(w, r)
 			return
@@ -349,6 +354,9 @@ func (p *Proxy) serveTunnel(clientConn net.Conn, target string, tunnelInfo *tran
 }
 
 func (p *Proxy) serveTunnelWithReader(clientConn net.Conn, br *bufio.Reader, target string, tunnelInfo *transform.TunnelInfo) error {
+	if err := clientConn.SetReadDeadline(time.Now().Add(p.tunnelHandshakeTimeout)); err != nil {
+		return fmt.Errorf("set tunneled protocol deadline: %w", err)
+	}
 	first, err := br.Peek(1)
 	if err != nil {
 		return fmt.Errorf("peek client protocol: %w", err)
@@ -385,11 +393,16 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string, tunnelInfo *t
 	})
 	defer func() { _ = tlsConn.Close() }()
 
-	if err := tlsConn.HandshakeContext(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), p.tunnelHandshakeTimeout)
+	defer cancel()
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return fmt.Errorf("TLS handshake for %s: %w", target, err)
 	}
+	if err := tlsConn.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("clear TLS handshake deadline for %s: %w", target, err)
+	}
 
-	return serveOneHTTPConn(tlsConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return p.serveOneHTTPConn(tlsConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p.handleHTTP(w, r, tunnelInfo)
 	}))
 }
@@ -398,12 +411,12 @@ func (p *Proxy) serveTunnelTLS(clientConn net.Conn, target string, tunnelInfo *t
 func (p *Proxy) serveTunnelHTTP(clientConn net.Conn, target string, tunnelInfo *transform.TunnelInfo) error {
 	defer clientConn.Close()
 
-	return serveOneHTTPConn(clientConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return p.serveOneHTTPConn(clientConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p.handleHTTP(w, r, tunnelInfo)
 	}))
 }
 
-func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
+func (p *Proxy) serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 	ln := newOneConnListener(conn)
 	var hijacked atomic.Bool
 	var handlers sync.WaitGroup
@@ -413,8 +426,9 @@ func serveOneHTTPConn(conn net.Conn, handler http.Handler) error {
 			defer handlers.Done()
 			handler.ServeHTTP(w, r)
 		}),
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       10 * time.Second,
+		ReadHeaderTimeout: p.downstreamReadHeaderTimeout,
+		ReadTimeout:       p.downstreamReadTimeout,
+		IdleTimeout:       p.downstreamIdleTimeout,
 		ConnState: func(_ net.Conn, state http.ConnState) {
 			if state == http.StateHijacked {
 				hijacked.Store(true)

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -23,6 +23,11 @@ import (
 
 func startTunnelProxy(t *testing.T, transforms []transform.Transformer) (*Proxy, string, *x509.CertPool) {
 	t.Helper()
+	return startTunnelProxyWithHandshakeTimeout(t, transforms, 0)
+}
+
+func startTunnelProxyWithHandshakeTimeout(t *testing.T, transforms []transform.Transformer, timeout time.Duration) (*Proxy, string, *x509.CertPool) {
+	t.Helper()
 
 	caCert, caKey := generateTestCA(t)
 	cache, err := certcache.NewFromCA(caCert, caKey, 100, 72*time.Hour)
@@ -31,12 +36,13 @@ func startTunnelProxy(t *testing.T, transforms []transform.Transformer) (*Proxy,
 	pipeline := transform.NewPipeline(transforms, transform.BodyLimits{}, testLogger())
 	holder := transform.NewPipelineHolder(pipeline)
 	p := New(Options{
-		HTTPAddr:   "127.0.0.1:0",
-		HTTPSAddr:  "127.0.0.1:0",
-		TunnelAddr: "127.0.0.1:0",
-		CertCache:  cache,
-		Pipeline:   holder,
-		Logger:     testLogger(),
+		HTTPAddr:               "127.0.0.1:0",
+		HTTPSAddr:              "127.0.0.1:0",
+		TunnelAddr:             "127.0.0.1:0",
+		CertCache:              cache,
+		Pipeline:               holder,
+		Logger:                 testLogger(),
+		TunnelHandshakeTimeout: timeout,
 	})
 
 	// Start tunnel listener
@@ -106,6 +112,38 @@ func TestTunnel_CONNECT_HTTP(t *testing.T) {
 	body, err := io.ReadAll(resp2.Body)
 	require.NoError(t, err)
 	require.Equal(t, "hello from tunnel", string(body))
+}
+
+func TestTunnelStalledHandshakesExpire(t *testing.T) {
+	_, tunnelAddr, _ := startTunnelProxyWithHandshakeTimeout(t, nil, 150*time.Millisecond)
+
+	t.Run("initial byte", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+		requirePeerCloses(t, conn)
+	})
+
+	t.Run("partial socks handshake", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+		_, err = conn.Write([]byte{0x05})
+		require.NoError(t, err)
+		requirePeerCloses(t, conn)
+	})
+
+	t.Run("post connect protocol", func(t *testing.T) {
+		conn, err := net.DialTimeout("tcp", tunnelAddr, time.Second)
+		require.NoError(t, err)
+		defer conn.Close()
+		_, err = fmt.Fprint(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+		require.NoError(t, err)
+		response, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, response.StatusCode)
+		requirePeerCloses(t, conn)
+	})
 }
 
 func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
@@ -733,6 +771,8 @@ func TestTunnel_SOCKS5_WebSocket(t *testing.T) {
 // MITM branch too, which cannot be exercised end-to-end because
 // handleWebSocket verifies upstream certificates against system roots.
 func TestServeOneHTTPConn_HijackWaitsForHandler(t *testing.T) {
+	p := New(Options{})
+	t.Cleanup(p.shutdownCancel)
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
 
@@ -741,7 +781,7 @@ func TestServeOneHTTPConn_HijackWaitsForHandler(t *testing.T) {
 
 	go func() {
 		defer close(serveReturned)
-		err := serveOneHTTPConn(serverConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := p.serveOneHTTPConn(serverConn, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Background HTTP handler: report failures via t.Error.
 			hj, ok := w.(http.Hijacker)
 			if !ok {

--- a/internal/transform/jsonrpc/jsonrpc.go
+++ b/internal/transform/jsonrpc/jsonrpc.go
@@ -1,0 +1,340 @@
+// Package jsonrpc implements a fail-closed JSON-RPC request policy transform.
+package jsonrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"gopkg.in/yaml.v3"
+)
+
+const defaultMaxBodyBytes int64 = 1024 * 1024
+
+type ruleConfig struct {
+	Host           string   `yaml:"host"`
+	Port           string   `yaml:"port"`
+	Path           string   `yaml:"path"`
+	HTTPMethods    []string `yaml:"http_methods"`
+	AllowedMethods []string `yaml:"allowed_methods"`
+}
+
+type config struct {
+	MaxBodyBytes int64        `yaml:"max_body_bytes"`
+	Rules        []ruleConfig `yaml:"rules"`
+}
+
+type rule struct {
+	host           string
+	port           string
+	path           string
+	httpMethods    map[string]struct{}
+	allowedMethods map[string]struct{}
+}
+
+type policy struct {
+	maxBodyBytes int64
+	rules        []rule
+}
+
+func init() { transform.Register("json_rpc", factory) }
+
+func factory(node yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
+	var cfg config
+	if err := transform.DecodeKnownFields(node, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing json_rpc config: %w", err)
+	}
+	if cfg.MaxBodyBytes == 0 {
+		cfg.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if cfg.MaxBodyBytes < 1 {
+		return nil, fmt.Errorf("json_rpc: max_body_bytes must be positive")
+	}
+	if len(cfg.Rules) == 0 {
+		return nil, fmt.Errorf("json_rpc: at least one rule is required")
+	}
+	p := &policy{maxBodyBytes: cfg.MaxBodyBytes}
+	for i, source := range cfg.Rules {
+		compiled, err := compileRule(source)
+		if err != nil {
+			return nil, fmt.Errorf("json_rpc: rules[%d]: %w", i, err)
+		}
+		p.rules = append(p.rules, compiled)
+	}
+	return p, nil
+}
+
+func compileRule(source ruleConfig) (rule, error) {
+	host := strings.ToLower(strings.TrimSuffix(source.Host, "."))
+	if host == "" || strings.ContainsAny(host, "*?/\\@") {
+		return rule{}, fmt.Errorf("host must be an exact hostname")
+	}
+	portNumber, err := strconv.ParseUint(source.Port, 10, 16)
+	if err != nil || portNumber == 0 {
+		return rule{}, fmt.Errorf("port must be an integer from 1 through 65535")
+	}
+	if source.Path == "" || !strings.HasPrefix(source.Path, "/") {
+		return rule{}, fmt.Errorf("path must be an absolute exact path")
+	}
+	if strings.ContainsAny(source.Path, "*?[]\\") {
+		return rule{}, fmt.Errorf("path must not contain glob or query syntax")
+	}
+	if decoded, err := url.PathUnescape(source.Path); err != nil || decoded != source.Path {
+		return rule{}, fmt.Errorf("path must use its canonical unescaped spelling")
+	}
+	if len(source.HTTPMethods) == 0 || len(source.AllowedMethods) == 0 {
+		return rule{}, fmt.Errorf("http_methods and allowed_methods must be non-empty")
+	}
+	result := rule{
+		host:           host,
+		port:           source.Port,
+		path:           source.Path,
+		httpMethods:    make(map[string]struct{}, len(source.HTTPMethods)),
+		allowedMethods: make(map[string]struct{}, len(source.AllowedMethods)),
+	}
+	for _, method := range source.HTTPMethods {
+		method = strings.ToUpper(method)
+		if method == "" || method == "CONNECT" || strings.ContainsAny(method, " \t\r\n") {
+			return rule{}, fmt.Errorf("invalid HTTP method %q", method)
+		}
+		result.httpMethods[method] = struct{}{}
+	}
+	for _, method := range source.AllowedMethods {
+		if method == "" || strings.ContainsAny(method, "*? \t\r\n") {
+			return rule{}, fmt.Errorf("JSON-RPC methods must be exact non-empty names")
+		}
+		result.allowedMethods[method] = struct{}{}
+	}
+	return result, nil
+}
+
+func (p *policy) Name() string { return "json_rpc" }
+
+func (p *policy) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	host, port := hostmatch.HostPort(req)
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	var matched *rule
+	for i := range p.rules {
+		if p.rules[i].host == host && p.rules[i].port == port {
+			matched = &p.rules[i]
+			break
+		}
+	}
+	if matched == nil {
+		return continueResult(), nil
+	}
+
+	// CONNECT is only the transport setup. The inner MITM request is parsed
+	// and evaluated independently against the exact path and protocol policy.
+	if req.Method == http.MethodConnect {
+		tctx.Annotate("decision", "tunnel")
+		return continueResult(), nil
+	}
+	if requestPath(req) != matched.path {
+		return reject(tctx, "path"), nil
+	}
+	if _, ok := matched.httpMethods[req.Method]; !ok {
+		return reject(tctx, "http_method"), nil
+	}
+	if isWebSocket(req) {
+		return reject(tctx, "websocket"), nil
+	}
+	if len(req.TransferEncoding) != 0 || req.Header.Get("Transfer-Encoding") != "" {
+		return reject(tctx, "transfer_encoding"), nil
+	}
+	if req.Header.Get("Content-Encoding") != "" {
+		return reject(tctx, "content_encoding"), nil
+	}
+	mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return reject(tctx, "content_type"), nil
+	}
+	for key, value := range params {
+		if !strings.EqualFold(key, "charset") || !strings.EqualFold(value, "utf-8") {
+			return reject(tctx, "content_type"), nil
+		}
+	}
+	if req.ContentLength <= 0 {
+		return reject(tctx, "content_length"), nil
+	}
+	if req.ContentLength > p.maxBodyBytes {
+		return reject(tctx, "body_oversize"), nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil || int64(len(body)) != req.ContentLength {
+		return reject(tctx, "body_incomplete"), nil
+	}
+	root, err := decodeUniqueJSON(body)
+	if err != nil {
+		return reject(tctx, "malformed_json"), nil
+	}
+	methods, reason := validateEnvelope(root, matched.allowedMethods)
+	if reason != "" {
+		return reject(tctx, reason), nil
+	}
+	tctx.Annotate("decision", "allow")
+	tctx.Annotate("request_count", len(methods))
+	tctx.Annotate("methods", methods)
+	return continueResult(), nil
+}
+
+func (p *policy) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return continueResult(), nil
+}
+
+func continueResult() *transform.TransformResult {
+	return &transform.TransformResult{Action: transform.ActionContinue}
+}
+
+func reject(tctx *transform.TransformContext, reason string) *transform.TransformResult {
+	tctx.Annotate("decision", "reject")
+	tctx.Annotate("reason", reason)
+	return &transform.TransformResult{Action: transform.ActionReject}
+}
+
+func requestPath(req *http.Request) string {
+	if req.URL == nil {
+		return ""
+	}
+	if req.URL.RawPath != "" {
+		return req.URL.EscapedPath()
+	}
+	return req.URL.Path
+}
+
+func isWebSocket(req *http.Request) bool {
+	if !strings.EqualFold(req.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	for _, value := range req.Header.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func decodeUniqueJSON(body []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	value, err := decodeValue(decoder)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("trailing JSON value")
+		}
+		return nil, err
+	}
+	return value, nil
+}
+
+func decodeValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("object key is not a string")
+			}
+			if _, duplicate := object[key]; duplicate {
+				return nil, fmt.Errorf("duplicate object key")
+			}
+			value, err := decodeValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+		}
+		if token, err = decoder.Token(); err != nil || token != json.Delim('}') {
+			return nil, fmt.Errorf("unterminated object")
+		}
+		return object, nil
+	case '[':
+		var array []any
+		for decoder.More() {
+			value, err := decodeValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		if token, err = decoder.Token(); err != nil || token != json.Delim(']') {
+			return nil, fmt.Errorf("unterminated array")
+		}
+		return array, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON delimiter")
+	}
+}
+
+func validateEnvelope(root any, allowed map[string]struct{}) ([]string, string) {
+	requests, ok := root.([]any)
+	if !ok {
+		requests = []any{root}
+	} else if len(requests) == 0 {
+		return nil, "empty_batch"
+	}
+	methods := make([]string, 0, len(requests))
+	for _, item := range requests {
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, "invalid_envelope"
+		}
+		for key := range object {
+			if key != "jsonrpc" && key != "id" && key != "method" && key != "params" {
+				return nil, "invalid_envelope"
+			}
+		}
+		if object["jsonrpc"] != "2.0" {
+			return nil, "invalid_envelope"
+		}
+		switch object["id"].(type) {
+		case string, json.Number:
+		default:
+			return nil, "notification"
+		}
+		method, ok := object["method"].(string)
+		if !ok || method == "" {
+			return nil, "invalid_envelope"
+		}
+		if params, present := object["params"]; present {
+			switch params.(type) {
+			case []any, map[string]any:
+			default:
+				return nil, "invalid_envelope"
+			}
+		}
+		if _, ok := allowed[method]; !ok {
+			return nil, "method"
+		}
+		methods = append(methods, method)
+	}
+	return methods, ""
+}

--- a/internal/transform/jsonrpc/jsonrpc_test.go
+++ b/internal/transform/jsonrpc/jsonrpc_test.go
@@ -1,0 +1,149 @@
+package jsonrpc
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func testPolicy(t *testing.T, max int64) transform.Transformer {
+	t.Helper()
+	if max == 0 {
+		max = 1024
+	}
+	var node yaml.Node
+	require.NoError(t, node.Encode(config{MaxBodyBytes: max, Rules: []ruleConfig{{
+		Host: "rpc.example", Port: "443", Path: "/rpc", HTTPMethods: []string{"POST"},
+		AllowedMethods: []string{"eth_chainId", "eth_call"},
+	}}}))
+	result, err := factory(node, slog.Default())
+	require.NoError(t, err)
+	return result
+}
+
+func request(t *testing.T, method, target, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Host = req.URL.Host
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = transform.NewBufferedBody(req.Body, 1024*1024)
+	return req
+}
+
+func decision(t *testing.T, p transform.Transformer, req *http.Request) (transform.TransformAction, map[string]any) {
+	t.Helper()
+	tctx := &transform.TransformContext{}
+	result, err := p.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	return result.Action, tctx.DrainAnnotations()
+}
+
+func TestJSONRPC_AllowsSingleAndAllAllowedBatch(t *testing.T) {
+	p := testPolicy(t, 0)
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}`,
+		`[{"jsonrpc":"2.0","id":1,"method":"eth_chainId"},{"jsonrpc":"2.0","id":"two","method":"eth_call","params":[{},"latest"]}]`,
+	} {
+		action, annotations := decision(t, p, request(t, "POST", "https://rpc.example/rpc", body))
+		require.Equal(t, transform.ActionContinue, action)
+		require.Equal(t, "allow", annotations["decision"])
+	}
+}
+
+func TestJSONRPC_RejectsMalformedDuplicateNotificationAndDisallowedBatches(t *testing.T) {
+	p := testPolicy(t, 0)
+	cases := []struct{ name, body, reason string }{
+		{"malformed", `{`, "malformed_json"},
+		{"duplicate top", `{"jsonrpc":"2.0","id":1,"method":"eth_chainId","method":"eth_call"}`, "malformed_json"},
+		{"duplicate nested", `{"jsonrpc":"2.0","id":1,"method":"eth_call","params":{"to":"0x1","to":"0x2"}}`, "malformed_json"},
+		{"notification", `{"jsonrpc":"2.0","method":"eth_chainId"}`, "notification"},
+		{"null id", `{"jsonrpc":"2.0","id":null,"method":"eth_chainId"}`, "notification"},
+		{"empty batch", `[]`, "empty_batch"},
+		{"unknown", `{"jsonrpc":"2.0","id":1,"method":"eth_unknown"}`, "method"},
+		{"mixed batch", `[{"jsonrpc":"2.0","id":1,"method":"eth_chainId"},{"jsonrpc":"2.0","id":2,"method":"eth_sendTransaction"}]`, "method"},
+		{"invalid params", `{"jsonrpc":"2.0","id":1,"method":"eth_call","params":"secret"}`, "invalid_envelope"},
+		{"extra field", `{"jsonrpc":"2.0","id":1,"method":"eth_chainId","secret":"x"}`, "invalid_envelope"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, annotations := decision(t, p, request(t, "POST", "https://rpc.example/rpc", tc.body))
+			require.Equal(t, transform.ActionReject, action)
+			require.Equal(t, tc.reason, annotations["reason"])
+		})
+	}
+}
+
+func TestJSONRPC_RejectsTransportAndEndpointBypasses(t *testing.T) {
+	p := testPolicy(t, 1024)
+	valid := `{"jsonrpc":"2.0","id":1,"method":"eth_chainId"}`
+	cases := []struct {
+		name   string
+		mutate func(*http.Request)
+		reason string
+	}{
+		{"wrong path", func(r *http.Request) { r.URL.Path = "/other" }, "path"},
+		{"encoded path", func(r *http.Request) { r.URL.RawPath = "/%72pc" }, "path"},
+		{"wrong method", func(r *http.Request) { r.Method = "GET" }, "http_method"},
+		{"wrong port", func(r *http.Request) { r.Host = "rpc.example:8443" }, ""},
+		{"websocket", func(r *http.Request) {
+			r.Header.Set("Connection", "Upgrade")
+			r.Header.Set("Upgrade", "websocket")
+		}, "websocket"},
+		{"chunked", func(r *http.Request) { r.TransferEncoding = []string{"chunked"}; r.ContentLength = -1 }, "transfer_encoding"},
+		{"compressed", func(r *http.Request) { r.Header.Set("Content-Encoding", "gzip") }, "content_encoding"},
+		{"missing length", func(r *http.Request) { r.ContentLength = -1 }, "content_length"},
+		{"incomplete", func(r *http.Request) { r.ContentLength++ }, "body_incomplete"},
+		{"oversize", func(r *http.Request) { r.ContentLength = 1025 }, "body_oversize"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := request(t, "POST", "https://rpc.example/rpc", valid)
+			tc.mutate(req)
+			action, annotations := decision(t, p, req)
+			if tc.reason == "" {
+				require.Equal(t, transform.ActionContinue, action, "policy applies only to exact endpoint")
+				return
+			}
+			require.Equal(t, transform.ActionReject, action)
+			require.Equal(t, tc.reason, annotations["reason"])
+		})
+	}
+}
+
+func TestJSONRPC_CONNECTIsTransportOnly(t *testing.T) {
+	p := testPolicy(t, 0)
+	req := request(t, "CONNECT", "https://rpc.example:443", "")
+	req.Host = "rpc.example:443"
+	action, annotations := decision(t, p, req)
+	require.Equal(t, transform.ActionContinue, action)
+	require.Equal(t, "tunnel", annotations["decision"])
+}
+
+func TestJSONRPCRejectsUnknownYAMLFieldsAtEveryNestingLevel(t *testing.T) {
+	for name, source := range map[string]string{
+		"config": `unexpected: true
+rules: []`,
+		"rule": `rules:
+  - host: rpc.example
+    port: "443"
+    path: /rpc
+    http_methods: [POST]
+    allowed_methods: [eth_call]
+    unexpected: true`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var document yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(source), &document))
+			_, err := factory(*document.Content[0], slog.Default())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "field unexpected")
+		})
+	}
+}

--- a/internal/transform/requestpolicy/requestpolicy.go
+++ b/internal/transform/requestpolicy/requestpolicy.go
@@ -1,0 +1,302 @@
+// Package requestpolicy implements exact HTTP request-shape policies.
+package requestpolicy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/ironsh/iron-proxy/internal/hostmatch"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"gopkg.in/yaml.v3"
+)
+
+type queryParameterConfig struct {
+	Name            string   `yaml:"name"`
+	Required        bool     `yaml:"required"`
+	ExactValues     []string `yaml:"exact_values,omitempty"`
+	ValuePattern    string   `yaml:"value_pattern,omitempty"`
+	CaseInsensitive bool     `yaml:"case_insensitive,omitempty"`
+}
+
+type queryConfig struct {
+	Mode       string                 `yaml:"mode"`
+	Parameters []queryParameterConfig `yaml:"parameters"`
+}
+
+type ruleConfig struct {
+	Host             string      `yaml:"host"`
+	Port             string      `yaml:"port"`
+	Path             string      `yaml:"path"`
+	HTTPMethods      []string    `yaml:"http_methods"`
+	RequireEmptyBody bool        `yaml:"require_empty_body"`
+	Query            queryConfig `yaml:"query"`
+}
+
+type config struct {
+	Rules []ruleConfig `yaml:"rules"`
+}
+
+type queryParameter struct {
+	required        bool
+	caseInsensitive bool
+	exactValues     []string
+	valuePattern    *regexp.Regexp
+}
+
+type rule struct {
+	host             string
+	port             string
+	path             string
+	httpMethods      map[string]struct{}
+	requireEmptyBody bool
+	queryMode        string
+	queryParameters  map[string]queryParameter
+}
+
+type policy struct{ rules []rule }
+
+func init() { transform.Register("request_policy", factory) }
+
+func factory(node yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
+	var cfg config
+	if err := transform.DecodeKnownFields(node, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing request_policy config: %w", err)
+	}
+	if len(cfg.Rules) == 0 {
+		return nil, fmt.Errorf("request_policy: at least one rule is required")
+	}
+	p := &policy{}
+	for i, source := range cfg.Rules {
+		compiled, err := compileRule(source)
+		if err != nil {
+			return nil, fmt.Errorf("request_policy: rules[%d]: %w", i, err)
+		}
+		p.rules = append(p.rules, compiled)
+	}
+	return p, nil
+}
+
+func compileRule(source ruleConfig) (rule, error) {
+	host := strings.ToLower(strings.TrimSuffix(source.Host, "."))
+	if host == "" || strings.ContainsAny(host, "*?/\\@") {
+		return rule{}, fmt.Errorf("host must be an exact hostname")
+	}
+	portNumber, err := strconv.ParseUint(source.Port, 10, 16)
+	if err != nil || portNumber == 0 {
+		return rule{}, fmt.Errorf("port must be an integer from 1 through 65535")
+	}
+	if source.Path == "" || !strings.HasPrefix(source.Path, "/") {
+		return rule{}, fmt.Errorf("path must be an absolute exact path")
+	}
+	if strings.ContainsAny(source.Path, "*?[]\\") {
+		return rule{}, fmt.Errorf("path must not contain glob or query syntax")
+	}
+	if decoded, err := url.PathUnescape(source.Path); err != nil || decoded != source.Path {
+		return rule{}, fmt.Errorf("path must use its canonical unescaped spelling")
+	}
+	if len(source.HTTPMethods) == 0 {
+		return rule{}, fmt.Errorf("http_methods must be non-empty")
+	}
+	result := rule{
+		host:             host,
+		port:             source.Port,
+		path:             source.Path,
+		httpMethods:      make(map[string]struct{}, len(source.HTTPMethods)),
+		requireEmptyBody: source.RequireEmptyBody,
+		queryMode:        source.Query.Mode,
+		queryParameters:  make(map[string]queryParameter, len(source.Query.Parameters)),
+	}
+	for _, method := range source.HTTPMethods {
+		method = strings.ToUpper(method)
+		if method == "" || method == http.MethodConnect || strings.ContainsAny(method, " \t\r\n") {
+			return rule{}, fmt.Errorf("invalid HTTP method %q", method)
+		}
+		result.httpMethods[method] = struct{}{}
+	}
+	if result.queryMode != "empty" && result.queryMode != "exact" {
+		return rule{}, fmt.Errorf("query.mode must be empty or exact")
+	}
+	if result.queryMode == "empty" && len(source.Query.Parameters) != 0 {
+		return rule{}, fmt.Errorf("empty query mode must not define parameters")
+	}
+	if result.queryMode == "exact" && len(source.Query.Parameters) == 0 {
+		return rule{}, fmt.Errorf("exact query mode requires parameters")
+	}
+	for i, parameter := range source.Query.Parameters {
+		if parameter.Name == "" || strings.ContainsAny(parameter.Name, "&=; \t\r\n") {
+			return rule{}, fmt.Errorf("query.parameters[%d] has invalid name", i)
+		}
+		if _, exists := result.queryParameters[parameter.Name]; exists {
+			return rule{}, fmt.Errorf("query parameter %q is duplicated", parameter.Name)
+		}
+		if (len(parameter.ExactValues) == 0) == (parameter.ValuePattern == "") {
+			return rule{}, fmt.Errorf("query parameter %q requires exactly one of exact_values or value_pattern", parameter.Name)
+		}
+		compiled := queryParameter{
+			required: parameter.Required, caseInsensitive: parameter.CaseInsensitive, exactValues: parameter.ExactValues,
+		}
+		if parameter.ValuePattern != "" {
+			if parameter.CaseInsensitive {
+				return rule{}, fmt.Errorf("query parameter %q cannot combine value_pattern with case_insensitive", parameter.Name)
+			}
+			pattern, err := regexp.Compile(parameter.ValuePattern)
+			if err != nil {
+				return rule{}, fmt.Errorf("query parameter %q has invalid value_pattern: %w", parameter.Name, err)
+			}
+			pattern.Longest()
+			compiled.valuePattern = pattern
+		} else {
+			if compiled.caseInsensitive {
+				for i := range compiled.exactValues {
+					compiled.exactValues[i] = strings.ToLower(compiled.exactValues[i])
+				}
+			}
+			slices.Sort(compiled.exactValues)
+		}
+		result.queryParameters[parameter.Name] = compiled
+	}
+	return result, nil
+}
+
+func (p *policy) Name() string { return "request_policy" }
+
+func (p *policy) TransformRequest(_ context.Context, tctx *transform.TransformContext, req *http.Request) (*transform.TransformResult, error) {
+	host, port := hostmatch.HostPort(req)
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	hostPortMatched := false
+	pathMatched := false
+	for i := range p.rules {
+		rule := &p.rules[i]
+		if rule.host != host || rule.port != port {
+			continue
+		}
+		hostPortMatched = true
+		if req.Method == http.MethodConnect {
+			tctx.Annotate("decision", "tunnel")
+			return continueResult(), nil
+		}
+		if requestPath(req) != rule.path {
+			continue
+		}
+		pathMatched = true
+		if _, ok := rule.httpMethods[req.Method]; !ok {
+			continue
+		}
+		if rule.requireEmptyBody {
+			if reason := validateEmptyBody(req); reason != "" {
+				return reject(tctx, reason), nil
+			}
+		}
+		if reason := validateQuery(req.URL, rule); reason != "" {
+			return reject(tctx, reason), nil
+		}
+		tctx.Annotate("decision", "allow")
+		return continueResult(), nil
+	}
+	if !hostPortMatched {
+		return continueResult(), nil
+	}
+	if !pathMatched {
+		return reject(tctx, "path"), nil
+	}
+	return reject(tctx, "http_method"), nil
+}
+
+func (p *policy) TransformResponse(_ context.Context, _ *transform.TransformContext, _ *http.Request, _ *http.Response) (*transform.TransformResult, error) {
+	return continueResult(), nil
+}
+
+func validateEmptyBody(req *http.Request) string {
+	if len(req.TransferEncoding) != 0 || req.Header.Get("Transfer-Encoding") != "" {
+		return "transfer_encoding"
+	}
+	if req.Header.Get("Content-Encoding") != "" {
+		return "content_encoding"
+	}
+	if req.ContentLength != 0 {
+		return "content_length"
+	}
+	if req.Body == nil || req.Body == http.NoBody {
+		return ""
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil || len(body) != 0 {
+		return "body"
+	}
+	return ""
+}
+
+func validateQuery(requestURL *url.URL, rule *rule) string {
+	if requestURL == nil {
+		return "query"
+	}
+	if rule.queryMode == "empty" {
+		if requestURL.RawQuery != "" {
+			return "query"
+		}
+		return ""
+	}
+	values, err := url.ParseQuery(requestURL.RawQuery)
+	if err != nil {
+		return "query"
+	}
+	for name, actual := range values {
+		parameter, ok := rule.queryParameters[name]
+		if !ok {
+			return "query"
+		}
+		if parameter.valuePattern != nil {
+			if len(actual) != 1 {
+				return "query"
+			}
+			match := parameter.valuePattern.FindStringIndex(actual[0])
+			if match == nil || match[0] != 0 || match[1] != len(actual[0]) {
+				return "query"
+			}
+			continue
+		}
+		if parameter.caseInsensitive {
+			for i := range actual {
+				actual[i] = strings.ToLower(actual[i])
+			}
+		}
+		slices.Sort(actual)
+		if !slices.Equal(actual, parameter.exactValues) {
+			return "query"
+		}
+	}
+	for name, parameter := range rule.queryParameters {
+		if parameter.required && len(values[name]) == 0 {
+			return "query"
+		}
+	}
+	return ""
+}
+
+func requestPath(req *http.Request) string {
+	if req.URL == nil {
+		return ""
+	}
+	if req.URL.RawPath != "" {
+		return req.URL.EscapedPath()
+	}
+	return req.URL.Path
+}
+
+func continueResult() *transform.TransformResult {
+	return &transform.TransformResult{Action: transform.ActionContinue}
+}
+
+func reject(tctx *transform.TransformContext, reason string) *transform.TransformResult {
+	tctx.Annotate("decision", "reject")
+	tctx.Annotate("reason", reason)
+	return &transform.TransformResult{Action: transform.ActionReject}
+}

--- a/internal/transform/requestpolicy/requestpolicy_test.go
+++ b/internal/transform/requestpolicy/requestpolicy_test.go
@@ -1,0 +1,168 @@
+package requestpolicy
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func policyFromYAML(t *testing.T, source string) (transform.Transformer, error) {
+	t.Helper()
+	var document yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(source), &document))
+	return factory(*document.Content[0], slog.Default())
+}
+
+func run(t *testing.T, p transform.Transformer, req *http.Request) (transform.TransformAction, map[string]any) {
+	t.Helper()
+	req.Body = transform.NewBufferedBody(req.Body, 1024*1024)
+	tctx := &transform.TransformContext{}
+	result, err := p.TransformRequest(context.Background(), tctx, req)
+	require.NoError(t, err)
+	return result.Action, tctx.DrainAnnotations()
+}
+
+func TestRequestPolicy_RequestShape(t *testing.T) {
+	p, err := policyFromYAML(t, `rules:
+  - host: api.example
+    port: "443"
+    path: /lookup
+    http_methods: [GET, HEAD]
+    require_empty_body: true
+    query:
+      mode: exact
+      parameters:
+        - {name: q, required: true, value_pattern: "alpha|alphabet"}
+        - {name: token, required: true, exact_values: [stub]}
+        - {name: format, exact_values: [JSON], case_insensitive: true}
+  - host: api.example
+    port: "443"
+    path: /artifact
+    http_methods: [GET]
+    require_empty_body: true
+    query: {mode: empty}
+`)
+	require.NoError(t, err)
+	const target = "https://api.example/lookup?q=alphabet&token=stub&format=json"
+	cases := []struct {
+		name, method, target, body, reason string
+		mutate                             func(*http.Request)
+	}{
+		{"allowed GET", "GET", target, "", "", nil},
+		{"allowed HEAD", "HEAD", target, "", "", nil},
+		{"CONNECT transport", "CONNECT", "api.example:443", "", "", nil},
+		{"other host", "GET", "https://other.example/", "", "", nil},
+		{"other port", "GET", "https://api.example:8443/", "", "", nil},
+		{"optional parameter omitted", "GET", "https://api.example/lookup?token=stub&q=alpha", "", "", nil},
+		{"decoded value", "GET", "https://api.example/lookup?token=stub&q=alpha%62et", "", "", nil},
+		{"empty query", "GET", "https://api.example/artifact", "", "", nil},
+		{"unknown parameter", "GET", target + "&extra=x", "", "query", nil},
+		{"duplicate pattern value", "GET", target + "&q=alpha", "", "query", nil},
+		{"missing required parameter", "GET", "https://api.example/lookup?q=alpha", "", "query", nil},
+		{"case sensitive value", "GET", "https://api.example/lookup?q=alpha&token=STUB", "", "query", nil},
+		{"pattern prefix", "GET", "https://api.example/lookup?q=prefixalphabet&token=stub", "", "query", nil},
+		{"pattern suffix", "GET", "https://api.example/lookup?q=alphabetsuffix&token=stub", "", "query", nil},
+		{"artifact query", "GET", "https://api.example/artifact?extra=x", "", "query", nil},
+		{"wrong path", "GET", "https://api.example/other", "", "path", nil},
+		{"wrong method", "POST", target, "", "http_method", nil},
+		{"request body", "GET", target, "data", "content_length", nil},
+		{"chunked body", "GET", target, "data", "transfer_encoding", func(r *http.Request) { r.ContentLength = -1; r.TransferEncoding = []string{"chunked"} }},
+		{"hidden body", "GET", target, "data", "body", func(r *http.Request) { r.ContentLength = 0 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.target, strings.NewReader(tc.body))
+			if tc.mutate != nil {
+				tc.mutate(req)
+			}
+			action, annotations := run(t, p, req)
+			if tc.reason == "" {
+				require.Equal(t, transform.ActionContinue, action)
+				if tc.method == http.MethodConnect {
+					require.Equal(t, "tunnel", annotations["decision"])
+				}
+			} else {
+				require.Equal(t, transform.ActionReject, action)
+				require.Equal(t, tc.reason, annotations["reason"])
+			}
+		})
+	}
+}
+
+func TestRequestPolicy_ExactQueryValues(t *testing.T) {
+	p, err := policyFromYAML(t, `rules:
+  - host: api.example
+    port: "443"
+    path: /
+    http_methods: [GET]
+    query:
+      mode: exact
+      parameters:
+        - {name: project, required: true, exact_values: [first, second, second]}
+        - {name: label, required: true, exact_values: [Hello World], case_insensitive: true}
+`)
+	require.NoError(t, err)
+	cases := []struct {
+		name, query string
+		allow       bool
+	}{
+		{"reordered and decoded", "label=HELLO%20WORLD&project=second&project=first&project=second", true},
+		{"missing value", "project=first&project=second&label=hello+world", false},
+		{"extra value", "project=first&project=second&project=second&project=second&label=hello+world", false},
+		{"changed value", "project=first&project=second&project=changed&label=hello+world", false},
+		{"different decoded value", "project=first&project=second&project=second&label=hello%2520world", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, _ := run(t, p, httptest.NewRequest("GET", "https://api.example/?"+tc.query, nil))
+			require.Equal(t, tc.allow, action == transform.ActionContinue)
+		})
+	}
+}
+
+func TestRequestPolicy_InvalidConfig(t *testing.T) {
+	const source = `rules:
+  - host: api.example
+    port: "443"
+    path: /
+    http_methods: [GET]
+    query:
+      mode: exact
+      parameters:
+        - {name: key, required: true, exact_values: [value]}
+`
+	cases := []struct{ name, old, replacement string }{
+		{"wildcard host", "api.example", `"*.example"`},
+		{"invalid port", `"443"`, `"0"`},
+		{"encoded path", "path: /", "path: /%61"},
+		{"CONNECT method", "[GET]", "[CONNECT]"},
+		{"empty parameter list", "parameters:\n        - {name: key, required: true, exact_values: [value]}", "parameters: []"},
+		{"missing matcher", ", exact_values: [value]", ""},
+		{"empty exact values", "[value]", "[]"},
+		{"empty pattern", "exact_values: [value]", `value_pattern: ""`},
+		{"both matchers", "exact_values: [value]", "exact_values: [value], value_pattern: value"},
+		{"null matcher", "exact_values: [value]", "value_pattern: null"},
+		{"invalid regex", "exact_values: [value]", `value_pattern: "["`},
+		{"nonscalar pattern", "exact_values: [value]", "value_pattern: [value]"},
+		{"pattern with case option", "exact_values: [value]", "value_pattern: value, case_insensitive: true"},
+		{"nonboolean case option", "exact_values: [value]", `exact_values: [value], case_insensitive: "true"`},
+		{"unknown config field", "rules:", "rulez:"},
+		{"unknown rule field", "http_methods:", "http_method:"},
+		{"unknown query field", "mode:", "modes:"},
+		{"unknown parameter field", "required:", "require:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := policyFromYAML(t, strings.Replace(source, tc.old, tc.replacement, 1))
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/transform/strictdecode.go
+++ b/internal/transform/strictdecode.go
@@ -1,0 +1,21 @@
+package transform
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DecodeKnownFields decodes one transform config and rejects unknown YAML
+// fields at every nested struct level. A misspelled security-policy field must
+// never silently become its zero value.
+func DecodeKnownFields(node yaml.Node, destination any) error {
+	payload, err := yaml.Marshal(&node)
+	if err != nil {
+		return fmt.Errorf("encoding transform config for strict decode: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(payload))
+	decoder.KnownFields(true)
+	return decoder.Decode(destination)
+}


### PR DESCRIPTION
Adds exact HTTP method/path/query policies and JSON-RPC method allowlists for single and batch requests. Includes destination-port matching, hostname-scoped private-IP exceptions, client read/handshake timeouts, and a source-build Dockerfile.
