### PR TITLE
feat(grpc): add a per-RPC timeout to the grpc transform

### DIFF
--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -34,7 +35,10 @@ type grpcConfig struct {
 	SendRequestBody  bool                   `yaml:"send_request_body"`
 	SendResponseBody bool                   `yaml:"send_response_body"`
 	Rules            []hostmatch.RuleConfig `yaml:"rules"`
+	Timeout          time.Duration          `yaml:"timeout"` // per-RPC deadline (default 15s)
 }
+
+const defaultTimeout = 15 * time.Second
 
 type tlsConfig struct {
 	Enabled bool   `yaml:"enabled"` // enable TLS (default false, meaning plaintext)
@@ -51,6 +55,7 @@ type GRPCTransform struct {
 	rules            []hostmatch.Rule
 	conn             *grpc.ClientConn
 	client           transformv1.TransformServiceClient
+	timeout          time.Duration
 }
 
 func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
@@ -117,6 +122,11 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 		return nil, fmt.Errorf("grpc transform %q: %w", cfg.Name, err)
 	}
 
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
 	return &GRPCTransform{
 		name:             cfg.Name,
 		sendRequestBody:  cfg.SendRequestBody,
@@ -124,6 +134,7 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 		rules:            rules,
 		conn:             conn,
 		client:           transformv1.NewTransformServiceClient(conn),
+		timeout:          timeout,
 	}, nil
 }
 
@@ -139,7 +150,9 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
 
-	resp, err := g.client.TransformRequest(ctx, &transformv1.TransformRequestRequest{
+	callCtx, cancel := context.WithTimeout(ctx, g.timeout)
+	defer cancel()
+	resp, err := g.client.TransformRequest(callCtx, &transformv1.TransformRequestRequest{
 		Context: transformContextToProto(tctx),
 		Request: pbReq,
 	})
@@ -180,7 +193,9 @@ func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.T
 		return nil, fmt.Errorf("grpc transform %q: marshaling response: %w", g.name, err)
 	}
 
-	grpcResp, err := g.client.TransformResponse(ctx, &transformv1.TransformResponseRequest{
+	callCtx, cancel := context.WithTimeout(ctx, g.timeout)
+	defer cancel()
+	grpcResp, err := g.client.TransformResponse(callCtx, &transformv1.TransformResponseRequest{
 		Context:  transformContextToProto(tctx),
 		Request:  pbReq,
 		Response: pbResp,

--- a/internal/transform/grpc/grpc_test.go
+++ b/internal/transform/grpc/grpc_test.go
@@ -9,9 +9,12 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
 	transformv1 "github.com/ironsh/iron-proxy/gen/transform/v1"
@@ -23,19 +26,24 @@ import (
 type fakeServer struct {
 	transformv1.UnimplementedTransformServiceServer
 
+	reqDelay     time.Duration // if >0, TransformRequest blocks this long or until ctx is done
 	reqAction    transformv1.TransformAction
 	reqResponse  *transformv1.HttpResponse
 	reqModified  *transformv1.HttpRequest
 	reqAnnot     map[string]string
 	lastReqProto *transformv1.TransformRequestRequest
 
+	respDelay     time.Duration // if >0, TransformResponse blocks this long or until ctx is done
 	respAction    transformv1.TransformAction
 	respModified  *transformv1.HttpResponse
 	respAnnot     map[string]string
 	lastRespProto *transformv1.TransformResponseRequest
 }
 
-func (f *fakeServer) TransformRequest(_ context.Context, in *transformv1.TransformRequestRequest) (*transformv1.TransformRequestResponse, error) {
+func (f *fakeServer) TransformRequest(ctx context.Context, in *transformv1.TransformRequestRequest) (*transformv1.TransformRequestResponse, error) {
+	if err := delay(ctx, f.reqDelay); err != nil {
+		return nil, err
+	}
 	f.lastReqProto = in
 	return &transformv1.TransformRequestResponse{
 		Action:          f.reqAction,
@@ -45,13 +53,30 @@ func (f *fakeServer) TransformRequest(_ context.Context, in *transformv1.Transfo
 	}, nil
 }
 
-func (f *fakeServer) TransformResponse(_ context.Context, in *transformv1.TransformResponseRequest) (*transformv1.TransformResponseResponse, error) {
+func (f *fakeServer) TransformResponse(ctx context.Context, in *transformv1.TransformResponseRequest) (*transformv1.TransformResponseResponse, error) {
+	if err := delay(ctx, f.respDelay); err != nil {
+		return nil, err
+	}
 	f.lastRespProto = in
 	return &transformv1.TransformResponseResponse{
 		Action:           f.respAction,
 		ModifiedResponse: f.respModified,
 		Annotations:      f.respAnnot,
 	}, nil
+}
+
+// delay blocks for d or until ctx is done, so a client that gave up does not
+// leave the fake server sleeping past the end of the test.
+func delay(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func startFakeServer(t *testing.T, srv *fakeServer) string {
@@ -82,6 +107,65 @@ func newTestTransform(t *testing.T, name, target string, sendReq, sendResp bool)
 
 func testContext() *transform.TransformContext {
 	return &transform.TransformContext{}
+}
+
+// A server slower than the configured timeout must fail the call with
+// DeadlineExceeded. The pipeline does not forward a request whose transform
+// failed, so a slow or unreachable server fails closed instead of holding the
+// proxied request open.
+func TestTimeout_DeadlineExceeded(t *testing.T) {
+	srv := &fakeServer{
+		reqDelay:   time.Second,
+		respDelay:  time.Second,
+		reqAction:  transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+		respAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+	}
+	addr := startFakeServer(t, srv)
+
+	gt, err := newGRPCTransform(grpcConfig{Name: "slow", Target: addr, Timeout: 50 * time.Millisecond})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gt.Close() })
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/foo", nil)
+	require.NoError(t, err)
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"TransformRequest", func() error {
+			_, err := gt.TransformRequest(context.Background(), testContext(), req)
+			return err
+		}},
+		{"TransformResponse", func() error {
+			_, err := gt.TransformResponse(context.Background(), testContext(), req, resp)
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			require.Error(t, err)
+			require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+		})
+	}
+}
+
+func TestTimeout_DefaultWhenOmitted(t *testing.T) {
+	srv := &fakeServer{reqAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE}
+	gt := newTestTransform(t, "default-timeout", startFakeServer(t, srv), false, false)
+	require.Equal(t, defaultTimeout, gt.timeout)
+}
+
+func TestFactory_ParsesTimeout(t *testing.T) {
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("name: t\ntarget: localhost:9500\ntimeout: 2s\n"), &node))
+	tr, err := factory(node, nil)
+	require.NoError(t, err)
+	gt := tr.(*GRPCTransform)
+	t.Cleanup(func() { _ = gt.Close() })
+	require.Equal(t, 2*time.Second, gt.timeout)
 }
 
 func TestName(t *testing.T) {

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -596,6 +596,9 @@ transforms:
       target: "localhost:9500"
       send_request_body: true
       send_response_body: true
+      # Deadline for each call to the server (default 15s). A call that exceeds
+      # it fails, and the proxy refuses the request rather than forwarding it.
+      timeout: "15s"
       # Only forward matching requests to this server (omit for all requests).
       rules:
         - host: "api.openai.com"


### PR DESCRIPTION
## What

Adds a `timeout` option to the `grpc` transform and applies it to every `TransformRequest` / `TransformResponse` RPC via `context.WithTimeout`.

```yaml
transforms:
  - name: grpc
    config:
      name: "policy-engine"
      target: "localhost:9500"
      timeout: "15s"   # default when omitted
```

## Why

Today the transform calls the external `TransformService` with the caller's context and no deadline of its own. If that server is slow or unreachable, the proxied request hangs until the client gives up — the proxy has no say in how long that takes. For a policy/authorization server on the request path, a bounded failure is far better than an unbounded stall: on deadline the RPC fails with `DeadlineExceeded`, the pipeline does not forward a request whose transform failed, and the request fails closed quickly instead of holding a connection open.

## Behavior notes

- `timeout` is a Go duration (`"15s"`, `"500ms"`), same shape as the `judge` transform's `timeout`. Zero/omitted applies the default.
- Default is **15s**. This is the one observable change for existing configs: an RPC that previously could block indefinitely now fails after 15s. Happy to lower it (judge uses 8s) if you'd prefer.
- The deadline is derived from the caller's context, so an already-cancelled request still short-circuits as before.
- Docs: added to `iron-proxy.example.yaml` next to the other grpc keys. The README has no grpc transform section yet (#233 touches the transforms table), so I did not add one here.

## Testing

- `TestTimeout_DeadlineExceeded` — table over both RPCs; a fake server that blocks (ctx-aware) longer than a 50ms timeout must yield `codes.DeadlineExceeded`.
- `TestTimeout_DefaultWhenOmitted` — default applied when unset.
- `TestFactory_ParsesTimeout` — YAML `timeout: 2s` decodes through the factory.
- `go test -race ./internal/transform/grpc/`, `go vet`, `golangci-lint run` clean.

We have been running this in production behind an external gRPC authorization service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
