### PR TITLE
fix(proxy): bind the MITM'd inner request to the CONNECT authority

### DIFF
--- a/internal/proxy/connect_authority_test.go
+++ b/internal/proxy/connect_authority_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSameAuthority(t *testing.T) {
+	cases := []struct {
+		name          string
+		inner, target string
+		scheme        string
+		want          bool
+	}{
+		{"exact host:port", "example.com:443", "example.com:443", "https", true},
+		{"implicit https port", "example.com", "example.com:443", "https", true},
+		{"implicit http port", "example.com", "example.com:80", "http", true},
+		{"case insensitive", "Example.COM", "example.com:443", "https", true},
+		{"nonstandard port match", "example.com:8443", "example.com:8443", "https", true},
+		{"different host", "blocked.example.com", "allowed.example.com:443", "https", false},
+		{"same host different port", "example.com:8443", "example.com:443", "https", false},
+		{"implicit vs nonstandard", "example.com", "example.com:8443", "https", false},
+		{"ipv6 implicit port", "[2001:db8::1]", "[2001:db8::1]:443", "https", true},
+		{"ipv6 both ports", "[2001:db8::1]:443", "[2001:db8::1]:443", "https", true},
+		{"ipv6 loopback", "[::1]", "[::1]:443", "https", true},
+		{"ipv6 different host", "[2001:db8::2]", "[2001:db8::1]:443", "https", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, sameAuthority(tc.inner, tc.target, tc.scheme))
+		})
+	}
+}
+
+// A tunnel authorized for one host must not carry a request addressed to
+// another, even when that request's SNI and Host agree with each other. The
+// matching case (CONNECT to host:443, inner Host without a port) is covered by
+// TestTunnel_CONNECT_HTTPS_MITM.
+func TestTunnel_CONNECT_RejectsHostMismatch(t *testing.T) {
+	p, tunnelAddr, caPool := startTunnelProxy(t, nil)
+
+	// The request must be refused before any upstream dial.
+	p.transport = &http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("unexpected upstream dial")
+		},
+	}
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT allowed.example.com:443 HTTP/1.1\r\nHost: allowed.example.com:443\r\n\r\n")
+	require.NoError(t, err)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	tlsConn := tls.Client(conn, &tls.Config{RootCAs: caPool, ServerName: "other.example.com"})
+	defer func() { _ = tlsConn.Close() }()
+	require.NoError(t, tlsConn.Handshake())
+
+	req, err := http.NewRequest(http.MethodGet, "https://other.example.com/", nil)
+	require.NoError(t, err)
+	require.NoError(t, req.Write(tlsConn))
+
+	inner, err := http.ReadResponse(bufio.NewReader(tlsConn), req)
+	require.NoError(t, err)
+	defer inner.Body.Close()
+	require.Equal(t, http.StatusBadRequest, inner.StatusCode)
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -340,6 +340,20 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		}
 	}
 
+	// Bind the inner request to the CONNECT authority. The tunnel was
+	// authorized for tunnelInfo.Target but the proxy dials r.Host, so a client
+	// could otherwise CONNECT to an allowed host and then address a different
+	// one behind the same front end (RFC 9110 §7.4). Together with the SNI
+	// check above this yields CONNECT target == SNI == Host.
+	if tunnelInfo != nil && tunnelInfo.Target != "" && !sameAuthority(r.Host, tunnelInfo.Target, scheme) {
+		p.logger.Warn("Host does not match CONNECT target",
+			slog.String("connect_target", tunnelInfo.Target),
+			slog.String("host", r.Host),
+		)
+		http.Error(w, "Host does not match CONNECT target", http.StatusBadRequest)
+		return
+	}
+
 	// Clone tunnelInfo so a transform that mutates the annotations map can't
 	// leak state into sibling requests that share the same tunnel.
 	tctx := &transform.TransformContext{
@@ -984,6 +998,29 @@ func containsDotSegments(p string) bool {
 		}
 	}
 	return false
+}
+
+// sameAuthority reports whether an inner request's Host names the same origin
+// as the CONNECT target: host compared case-insensitively, port by value, with
+// the scheme's default port filled in when absent (RFC 9110 §4.2.3).
+func sameAuthority(innerHost, connectTarget, scheme string) bool {
+	def := "443"
+	if scheme == "http" {
+		def = "80"
+	}
+	ih, ip := hostPortOrDefault(innerHost, def)
+	ch, cp := hostPortOrDefault(connectTarget, def)
+	return strings.EqualFold(ih, ch) && ip == cp
+}
+
+// hostPortOrDefault splits host:port, using def when no port is present. A
+// bracketed IPv6 literal without a port is unwrapped so it compares equal to
+// the host net.SplitHostPort returns for the with-port form.
+func hostPortOrDefault(hostport, def string) (host, port string) {
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		return h, p
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(hostport, "["), "]"), def
 }
 
 func copyHeaders(dst, src http.Header) {


### PR DESCRIPTION
## What

In MITM mode, refuse an inner request whose `Host` does not name the same origin as the tunnel's CONNECT target. Comparison is by host (case-insensitive) and effective port, so `Host: example.com` matches `CONNECT example.com:443`, and `[2001:db8::1]` matches `[2001:db8::1]:443`.

## Why

The CONNECT stage authorizes a destination, but `handleHTTP` only checks SNI == Host and then dials `r.Host`. So a client can:

1. `CONNECT allowed.example.com:443` — passes the allowlist / external policy at the CONNECT stage;
2. handshake with SNI `blocked.example.com`, send `Host: blocked.example.com`.

SNI and Host agree with each other, so the existing check passes and the proxy mints a leaf for, and dials, `blocked.example.com` — a host the CONNECT stage never saw. When allowed and blocked hosts share a front end that routes on `Host` (CDN, virtual hosting) this is a clean bypass of any CONNECT-stage policy; RFC 9110 §7.4 names this case. Together with the SNI check, the new check gives `CONNECT target == SNI == Host`, so the proxy only ever MITMs and dials the host the CONNECT stage authorized.

## Behavior notes

- Only tunnelled requests are affected (`tunnelInfo != nil`); direct HTTP proxying is unchanged.
- Repeated requests to the same authority over one tunnel keep working (HTTP/1.1 keep-alive, HTTP/2 multiplexing). Reusing a tunnel for a *different* origin (HTTP/2 connection coalescing, RFC 9113 §9.1.1) is refused; supporting that would need per-request authorization of the new authority, which is out of scope here.
- A client that CONNECTs to an IP literal and then sends a hostname in `Host` is refused — that is the virtual-host case above. SOCKS5 clients should resolve remotely (`socks5h://`, `--socks5-hostname`), which the README already shows.
- Rejection is 400 with a one-line body, matching the adjacent SNI/Host mismatch path. Happy to switch to 421 Misdirected Request if you'd prefer that semantics.

## Testing

- `TestSameAuthority` — table over default/explicit/non-default ports, case, and IPv6 literals.
- `TestTunnel_CONNECT_RejectsHostMismatch` — end-to-end through the tunnel listener: CONNECT to `allowed.example.com:443`, TLS with SNI/Host `other.example.com` → 400, with a transport that fails the test if any upstream dial is attempted. The matching case (CONNECT `host:443`, inner `Host` without port) is already exercised by `TestTunnel_CONNECT_HTTPS_MITM`.
- `go test -race ./internal/proxy/`, `go vet`, `golangci-lint run` clean.
