### PR TITLE
fix(grpc): re-present the CONNECT credential to the server on inner-request RPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,11 @@ All protocols go through the same transform pipeline as regular HTTP/HTTPS
 requests. Absolute-form HTTP requests are handled by the normal HTTP proxy
 path. For CONNECT and SOCKS5, the proxy evaluates a synthetic CONNECT request
 against your allowlist and secrets transforms, so tunnel connections are
-subject to the same default-deny policy.
+subject to the same default-deny policy. The CONNECT request's headers,
+including `Proxy-Authorization`, are visible to transforms at that stage, and
+`grpc` transforms re-present the CONNECT credential to their server on every
+inner request of the tunnel, so an external authorization service can check a
+live credential per request rather than rely on the decision made at CONNECT.
 
 After the CONNECT or SOCKS5 handshake, the proxy peeks at the first byte to
 detect the inner protocol:

--- a/internal/proxy/connect_credential_test.go
+++ b/internal/proxy/connect_credential_test.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+func TestTunnelCredentialPropagatesToInnerTransforms(t *testing.T) {
+	seen := make(chan *transform.TunnelInfo, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	_, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{&tunnelInfoTransform{seen: seen}})
+	target := upstream.Listener.Addr().String()
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: Basic dXNlcjpwYXNz\r\n\r\n", target, target)
+	require.NoError(t, err)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, err = fmt.Fprintf(conn, "GET /test HTTP/1.1\r\nHost: %s\r\n\r\n", target)
+	require.NoError(t, err)
+	resp2, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	_ = resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	select {
+	case info := <-seen:
+		require.Equal(t, "Basic dXNlcjpwYXNz", info.Credential)
+	case <-time.After(2 * time.Second):
+		t.Fatal("inner transform did not receive tunnel info")
+	}
+}

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -337,6 +337,7 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string, connectHeaders h
 	return true, nil, &transform.TunnelInfo{
 		Target:            target,
 		RequestTransforms: result.RequestTransforms,
+		Credential:        connectHeaders.Get("Proxy-Authorization"),
 	}
 }
 
@@ -451,6 +452,7 @@ func cloneTunnelInfo(info *transform.TunnelInfo) *transform.TunnelInfo {
 	return &transform.TunnelInfo{
 		Target:            info.Target,
 		RequestTransforms: traces,
+		Credential:        info.Credential,
 	}
 }
 

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -138,6 +138,7 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
+	applyTunnelCredential(pbReq, tctx)
 
 	resp, err := g.client.TransformRequest(ctx, &transformv1.TransformRequestRequest{
 		Context: transformContextToProto(tctx),
@@ -175,6 +176,7 @@ func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.T
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
+	applyTunnelCredential(pbReq, tctx)
 	pbResp, err := httpResponseToProto(resp, g.sendResponseBody)
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling response: %w", g.name, err)
@@ -214,6 +216,21 @@ func (g *GRPCTransform) Close() error {
 }
 
 // --- proto conversion helpers ---
+
+// applyTunnelCredential re-presents the tunnel's CONNECT credential to the
+// server on inner requests, so each request is checked against a live
+// credential rather than the decision made once at CONNECT. It overwrites any
+// Proxy-Authorization the inner request carried, since the tunnel's is the one
+// the server validated. Only the proto is modified; req.Header is untouched.
+func applyTunnelCredential(pbReq *transformv1.HttpRequest, tctx *transform.TransformContext) {
+	if tctx == nil || tctx.Tunnel == nil || tctx.Tunnel.Credential == "" {
+		return
+	}
+	if pbReq.Headers == nil {
+		pbReq.Headers = make(map[string]*transformv1.HeaderValues, 1)
+	}
+	pbReq.Headers["Proxy-Authorization"] = &transformv1.HeaderValues{Values: []string{tctx.Tunnel.Credential}}
+}
 
 func transformContextToProto(tctx *transform.TransformContext) *transformv1.TransformContext {
 	pb := &transformv1.TransformContext{

--- a/internal/transform/grpc/tunnel_credential_test.go
+++ b/internal/transform/grpc/tunnel_credential_test.go
@@ -1,0 +1,79 @@
+package grpc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	transformv1 "github.com/ironsh/iron-proxy/gen/transform/v1"
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// Both RPCs must carry the tunnel's CONNECT credential to the server, and it
+// must not leak into the http.Request that is forwarded upstream.
+func TestTunnelCredential_RePresentedOnEachRPC(t *testing.T) {
+	srv := &fakeServer{
+		reqAction:  transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+		respAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+	}
+	gt := newTestTransform(t, "authz", startFakeServer(t, srv), false, false)
+
+	tctx := &transform.TransformContext{
+		Tunnel: &transform.TunnelInfo{Target: "example.com:443", Credential: "Basic dXNlcjpwYXNz"},
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	require.NoError(t, err)
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: http.NoBody}
+
+	cases := []struct {
+		name string
+		call func() error
+		sent func() *transformv1.HttpRequest
+	}{
+		{"TransformRequest", func() error {
+			_, err := gt.TransformRequest(context.Background(), tctx, req)
+			return err
+		}, func() *transformv1.HttpRequest { return srv.lastReqProto.GetRequest() }},
+		{"TransformResponse", func() error {
+			_, err := gt.TransformResponse(context.Background(), tctx, req, resp)
+			return err
+		}, func() *transformv1.HttpRequest { return srv.lastRespProto.GetRequest() }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tc.call())
+			require.Equal(t, []string{"Basic dXNlcjpwYXNz"}, tc.sent().GetHeaders()["Proxy-Authorization"].GetValues())
+			require.Empty(t, req.Header.Get("Proxy-Authorization"))
+		})
+	}
+}
+
+func TestApplyTunnelCredential(t *testing.T) {
+	cases := []struct {
+		name string
+		tctx *transform.TransformContext
+		pb   *transformv1.HttpRequest
+		want []string
+	}{
+		{"nil context", nil, &transformv1.HttpRequest{}, nil},
+		{"no tunnel", &transform.TransformContext{}, &transformv1.HttpRequest{}, nil},
+		{"empty credential", &transform.TransformContext{Tunnel: &transform.TunnelInfo{Target: "example.com:443"}},
+			&transformv1.HttpRequest{}, nil},
+		{"sets header", &transform.TransformContext{Tunnel: &transform.TunnelInfo{Credential: "Bearer tunnel"}},
+			&transformv1.HttpRequest{}, []string{"Bearer tunnel"}},
+		// The tunnel's credential is the one the server validated at CONNECT;
+		// a client-supplied inner header must not replace it.
+		{"overrides inner header", &transform.TransformContext{Tunnel: &transform.TunnelInfo{Credential: "Bearer tunnel"}},
+			&transformv1.HttpRequest{Headers: map[string]*transformv1.HeaderValues{
+				"Proxy-Authorization": {Values: []string{"Bearer someone-else"}},
+			}}, []string{"Bearer tunnel"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			applyTunnelCredential(tc.pb, tc.tctx)
+			require.Equal(t, tc.want, tc.pb.GetHeaders()["Proxy-Authorization"].GetValues())
+		})
+	}
+}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -104,6 +104,11 @@ type TunnelInfo struct {
 	// audit consume this to attribute tunnel-level annotations to the
 	// transform that produced them.
 	RequestTransforms []TransformTrace
+
+	// Credential is the Proxy-Authorization value presented on the CONNECT,
+	// kept so per-request policy can re-check it. Never serialized: TunnelInfo
+	// reaches audit output.
+	Credential string `json:"-"`
 }
 
 // Annotate attaches audit metadata to the current transform's trace.

--- a/internal/transform/tunnel_test.go
+++ b/internal/transform/tunnel_test.go
@@ -1,0 +1,16 @@
+package transform
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTunnelInfo_CredentialNotSerialized(t *testing.T) {
+	blob, err := json.Marshal(&TunnelInfo{Target: "example.com:443", Credential: "Basic c2VjcmV0"})
+	require.NoError(t, err)
+	require.Contains(t, string(blob), "example.com:443")
+	require.NotContains(t, string(blob), "c2VjcmV0")
+	require.NotContains(t, string(blob), "Credential")
+}


### PR DESCRIPTION
## What

Keep the `Proxy-Authorization` value from the CONNECT request in `TunnelInfo`, and have the `grpc` transform put it on the request proto of every `TransformRequest` / `TransformResponse` RPC made for requests inside that tunnel.

## Why

An authorization decision made at CONNECT currently stands for the whole life of the tunnel. Inner requests carry no proxy credential, so an external `TransformService` has nothing live to check on them — it can only trust whatever identity it established at CONNECT (e.g. via annotations). The consequence is that **revoking a credential does not stop traffic**: an established tunnel keeps egressing under the revoked identity until whatever expiry the server recorded, and revocation is not expiry.

We measured this against a live deployment: after revoking the credential, 21 consecutive inner requests over 100 seconds were still authorized, while a *new* CONNECT with the same credential was correctly refused. With this change each inner request is authorized against a live credential.

## Behavior notes

- The tunnel's credential **overwrites** any `Proxy-Authorization` the inner request itself carried. That is deliberate: the tunnel's credential is the one the server validated at CONNECT, so a client-supplied inner header must not get to choose which identity its requests are attributed to.
- Only the proto sent to the server is modified. `req.Header` is untouched, so the credential is never forwarded upstream to the origin (tested).
- `TunnelInfo.Credential` is tagged `json:"-"`; `TunnelInfo` reaches audit output and this value is a live secret (tested).
- Servers that don't read the header are unaffected — they receive one extra header on requests they already receive.
- Known limit, unchanged by this PR: after a WebSocket upgrade the proxy byte-shuttles, so there are no further RPCs and a connection upgraded before a revoke keeps flowing.
- Relationship to #184: that PR adds *built-in* proxy authentication and consumes `Proxy-Authorization` at the proxy boundary. This one is about *external* `TransformService` servers doing the authorization; the two compose (the retained credential is exactly what such a server needs to re-check).

## Testing

- `TestTunnelCredential_RePresentedOnEachRPC` (grpc) — through a fake server, both RPCs carry the credential and `req.Header` stays clean.
- `TestApplyTunnelCredential` (grpc) — table: nil ctx / no tunnel / empty credential are no-ops; header set; client-supplied inner header is overridden.
- `TestTunnelCredentialPropagatesToInnerTransforms` (proxy) — end-to-end through the tunnel listener: CONNECT with `Proxy-Authorization`, then an inner request; the inner transform sees the credential on its `TunnelInfo` (covers both capture in `tunnelTransformCheck` and `cloneTunnelInfo`).
- `TestTunnelInfo_CredentialNotSerialized` (transform) — the `json:"-"` tag.
- `go test -race` on `internal/proxy`, `internal/transform`, `internal/transform/grpc`; `go vet`; `golangci-lint run` clean.
