### PR TITLE
feat(proxy): emit RFC 9209 Proxy-Status on proxy-generated responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,37 @@ configured authorize and complete endpoints; ordinary proxied traffic remains
 subject to the full upstream deny list. Public, loopback, link-local, and cloud
 metadata ranges cannot be added through this setting.
 
+### Proxy-Status
+
+Set `proxy.proxy_status_name` to have the proxy add an
+[RFC 9209](https://www.rfc-editor.org/rfc/rfc9209) `Proxy-Status` header to
+responses it generates itself — transform rejections (HTTP and CONNECT) and
+upstream failures — so a client can tell a policy refusal or an unreachable
+destination apart from the origin returning the same status code. Successfully
+proxied responses are never touched.
+
+```yaml
+proxy:
+  proxy_status_name: "egress" # header is off when unset
+  proxy_status_verbose: false # default
+```
+
+By default the header carries only the proxy's name and a coarse error class:
+`http_request_denied` for a 4xx rejection, `proxy_internal_error` for a 5xx one,
+and `destination_unavailable` for any upstream failure:
+
+```
+Proxy-Status: egress; error=http_request_denied
+```
+
+Upstream failures are deliberately uniform: for a filtering proxy, telling a
+denied CIDR apart from an unresolvable name or a refused port lets a client map
+the network it was fenced out of (RFC 9209 §4). The precise cause is always on
+the audit line. `proxy_status_verbose: true` puts it in the header too
+(`destination_ip_prohibited`, `dns_error`, `connection_refused`,
+`tls_certificate_error`, …) along with `details` and `next-hop`; enable it only
+where clients are as trusted as the operator.
+
 ### Allowlist
 
 Default-deny. Requests must match at least one domain glob or CIDR to proceed.

--- a/cmd/iron-proxy/main.go
+++ b/cmd/iron-proxy/main.go
@@ -233,6 +233,8 @@ func main() {
 		HTTPAddr:                      cfg.Proxy.HTTPListen,
 		HTTPSAddr:                     cfg.Proxy.HTTPSListen,
 		TunnelAddr:                    cfg.Proxy.TunnelListen,
+		ProxyStatusName:               cfg.Proxy.ProxyStatusName,
+		ProxyStatusVerbose:            cfg.Proxy.ProxyStatusVerbose,
 		TLSMode:                       cfg.TLS.Mode,
 		CertCache:                     certCache,
 		Pipeline:                      holder,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,15 @@ type Proxy struct {
 	// at connect time against the resolved address. When unset, a secure
 	// default (IMDS + loopback) is applied; set to an empty list to disable.
 	UpstreamDenyCIDRs CIDRList `yaml:"upstream_deny_cidrs"`
+	// ProxyStatusName identifies this proxy in the RFC 9209 Proxy-Status header
+	// on responses it generates itself (transform rejections, upstream
+	// failures). Empty (the default) disables the header.
+	ProxyStatusName string `yaml:"proxy_status_name"`
+	// ProxyStatusVerbose reports the precise error type, details and next-hop
+	// instead of a uniform destination_unavailable. Off by default: for a
+	// filtering proxy the error type tells a client which ranges are denied,
+	// which names resolve and which ports answer.
+	ProxyStatusVerbose bool `yaml:"proxy_status_verbose"`
 	// UpstreamProxy routes iron-proxy's own outbound connections through an
 	// upstream SOCKS5/HTTP CONNECT proxy. The standard HTTP_PROXY/HTTPS_PROXY/
 	// NO_PROXY environment variables override these fields when set.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/ironsh/iron-proxy/internal/certcache"
@@ -25,6 +26,7 @@ import (
 	"github.com/ironsh/iron-proxy/internal/dnsguard"
 	"github.com/ironsh/iron-proxy/internal/mcp"
 	"github.com/ironsh/iron-proxy/internal/mcpgateway"
+	"github.com/ironsh/iron-proxy/internal/proxystatus"
 	"github.com/ironsh/iron-proxy/internal/responseretry"
 	"github.com/ironsh/iron-proxy/internal/transform"
 	"golang.org/x/net/http2"
@@ -41,6 +43,8 @@ type Proxy struct {
 	tlsMode              string
 	tlsListener          net.Listener
 	tunnelAddr           string
+	proxyStatusName      string
+	proxyStatusVerbose   bool
 	tunnelListener       net.Listener
 	tunnelDone           chan struct{}
 	certCache            *certcache.Cache
@@ -72,13 +76,18 @@ type Options struct {
 	HTTPAddr   string
 	HTTPSAddr  string
 	TunnelAddr string
-	TLSMode    string
-	CertCache  *certcache.Cache // required when TLSMode == config.TLSModeMITM
-	Pipeline   *transform.PipelineHolder
-	Resolver   *net.Resolver
-	Guard      *dnsguard.Guard   // nil is treated as an empty (no-op) guard
-	MCPPolicy  *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
-	MCPGateway *mcpgateway.Holder
+	// ProxyStatusName identifies this proxy in RFC 9209 Proxy-Status headers on
+	// proxy-generated responses; empty disables them. ProxyStatusVerbose adds
+	// the precise error type, details and next-hop (see config.Proxy).
+	ProxyStatusName    string
+	ProxyStatusVerbose bool
+	TLSMode            string
+	CertCache          *certcache.Cache // required when TLSMode == config.TLSModeMITM
+	Pipeline           *transform.PipelineHolder
+	Resolver           *net.Resolver
+	Guard              *dnsguard.Guard   // nil is treated as an empty (no-op) guard
+	MCPPolicy          *mcp.PolicyHolder // optional MCP-aware policy interceptor; nil disables MCP handling
+	MCPGateway         *mcpgateway.Holder
 	// ResponseRetryHandler may add headers and replay the exact transformed
 	// request once after selected upstream response statuses.
 	ResponseRetryHandler *responseretry.Handler
@@ -115,6 +124,8 @@ func New(opts Options) *Proxy {
 		httpsAddr:            opts.HTTPSAddr,
 		tlsMode:              opts.TLSMode,
 		tunnelAddr:           opts.TunnelAddr,
+		proxyStatusName:      opts.ProxyStatusName,
+		proxyStatusVerbose:   opts.ProxyStatusVerbose,
 		tunnelDone:           make(chan struct{}),
 		certCache:            opts.CertCache,
 		pipeline:             opts.Pipeline,
@@ -387,12 +398,14 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		result.Action = transform.ActionContinue // error, not reject
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
+		p.annotateUpstreamError(w.Header(), r.Host, err)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
 	if rejectResp != nil {
 		result.Action = transform.ShortCircuitAction(result.RequestTransforms)
 		result.StatusCode = rejectResp.StatusCode
+		p.annotateReject(rejectResp, r.Host)
 		p.writeResponse(w, rejectResp)
 		return
 	}
@@ -422,6 +435,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 			if rejectResp != nil {
 				result.Action = transform.ActionReject
 				result.StatusCode = rejectResp.StatusCode
+				p.annotateReject(rejectResp, r.Host)
 				p.writeResponse(w, rejectResp)
 				return
 			}
@@ -488,6 +502,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
+		p.annotateUpstreamError(w.Header(), r.Host, err)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
@@ -531,6 +546,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
+		p.annotateUpstreamError(w.Header(), r.Host, err)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
@@ -579,6 +595,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 				result.Action = transform.ActionContinue
 				result.StatusCode = http.StatusBadGateway
 				result.Err = err
+				p.annotateUpstreamError(w.Header(), r.Host, err)
 				http.Error(w, "bad gateway", http.StatusBadGateway)
 				return
 			}
@@ -607,6 +624,7 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
 		result.Err = err
+		p.annotateUpstreamError(w.Header(), r.Host, err)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
@@ -787,6 +805,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 			slog.String("host", host),
 			slog.String("error", err.Error()),
 		)
+		p.annotateUpstreamError(w.Header(), host, err)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
@@ -803,6 +822,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request, scheme, 
 	if writeErr := r.Write(upstreamConn); writeErr != nil {
 		p.logger.Error("websocket upstream write failed", slog.String("error", writeErr.Error()))
 		upstreamConn.Close()
+		p.annotateUpstreamError(w.Header(), host, writeErr)
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		return
 	}
@@ -893,6 +913,87 @@ func (p *Proxy) streamSSE(w http.ResponseWriter, resp *http.Response) {
 			break
 		}
 	}
+}
+
+// annotateReject adds a Proxy-Status to a response a transform generated in
+// place of forwarding. 4xx is a verdict on the request (http_request_denied);
+// 5xx means something the proxy depends on failed (proxy_internal_error), so
+// the client should retry rather than treat the request as denied.
+func (p *Proxy) annotateReject(resp *http.Response, host string) {
+	if p.proxyStatusName == "" || resp == nil {
+		return
+	}
+	if resp.Header == nil {
+		resp.Header = http.Header{}
+	}
+	errType := proxystatus.ErrHTTPRequestDenied
+	if resp.StatusCode >= 500 {
+		errType = proxystatus.ErrProxyInternalError
+	}
+	item := proxystatus.Item{Proxy: p.proxyStatusName, Error: errType}
+	if p.proxyStatusVerbose {
+		item.NextHop = host
+	}
+	proxystatus.Append(resp.Header, item)
+}
+
+// annotateUpstreamError adds a Proxy-Status for an upstream failure to headers
+// that have not been written yet. Non-verbose output is a uniform
+// destination_unavailable so a denied CIDR, an unresolvable name and a refused
+// port are indistinguishable to the client; the cause is on the audit line.
+func (p *Proxy) annotateUpstreamError(h http.Header, host string, err error) {
+	if p.proxyStatusName == "" || h == nil {
+		return
+	}
+	item := proxystatus.Item{
+		Proxy: p.proxyStatusName,
+		Error: proxystatus.ErrDestinationUnavailable,
+	}
+	if p.proxyStatusVerbose {
+		errType, details := classifyUpstreamError(err)
+		item.Error = errType
+		item.Details = details
+		item.NextHop = host
+	}
+	proxystatus.Append(h, item)
+}
+
+// classifyUpstreamError maps a dial/transport error to an RFC 9209 error type
+// for verbose Proxy-Status output. Only the deny-CIDR case carries details: the
+// operator configured that refusal and the address came from the request.
+func classifyUpstreamError(err error) (errType, details string) {
+	if err == nil {
+		return proxystatus.ErrProxyInternalError, ""
+	}
+	if dnsguard.IsDenyError(err) {
+		return proxystatus.ErrDestinationIPProhibited, err.Error()
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		if dnsErr.IsTimeout {
+			return proxystatus.ErrDNSTimeout, ""
+		}
+		return proxystatus.ErrDNSError, ""
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return proxystatus.ErrConnectionTimeout, ""
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return proxystatus.ErrConnectionRefused, ""
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return proxystatus.ErrConnectionTerminated, ""
+	}
+
+	var tlsErr *tls.CertificateVerificationError
+	if errors.As(err, &tlsErr) {
+		return proxystatus.ErrTLSCertificateError, ""
+	}
+
+	return proxystatus.ErrDestinationUnavailable, ""
 }
 
 func (p *Proxy) writeResponse(w http.ResponseWriter, resp *http.Response) {

--- a/internal/proxy/proxystatus_test.go
+++ b/internal/proxy/proxystatus_test.go
@@ -1,0 +1,194 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/dnsguard"
+	"github.com/ironsh/iron-proxy/internal/proxystatus"
+	"github.com/ironsh/iron-proxy/internal/transform"
+	"github.com/ironsh/iron-proxy/internal/transform/allowlist"
+)
+
+// buildProxyStatusProxy stands up an HTTP proxy with the given allowlist, deny
+// CIDRs and Proxy-Status identity, and returns its address.
+func buildProxyStatusProxy(t *testing.T, allowed []string, denyCIDRs []string, statusName string) string {
+	return buildProxyStatusProxyV(t, allowed, denyCIDRs, statusName, false)
+}
+
+func buildProxyStatusProxyV(t *testing.T, allowed []string, denyCIDRs []string, statusName string, verbose bool) string {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	al, err := allowlist.New(allowed, nil)
+	require.NoError(t, err)
+	pipeline := transform.NewPipeline([]transform.Transformer{al}, transform.BodyLimits{}, logger)
+
+	guard, err := dnsguard.New(denyCIDRs)
+	require.NoError(t, err)
+
+	p := New(Options{
+		HTTPAddr:           "127.0.0.1:0",
+		Pipeline:           transform.NewPipelineHolder(pipeline),
+		Guard:              guard,
+		Logger:             logger,
+		ProxyStatusName:    statusName,
+		ProxyStatusVerbose: verbose,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = p.httpServer.Serve(ln) }()
+	t.Cleanup(func() { _ = p.httpServer.Close() })
+
+	return ln.Addr().String()
+}
+
+func proxyClient(addr string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: addr}),
+		},
+		Timeout: 5 * time.Second,
+	}
+}
+
+// By default a deny-CIDR block must be INDISTINGUISHABLE from any other
+// unreachable destination. A client that can only reach the network through
+// this proxy would otherwise use the error type as a probe oracle — learning
+// which internal ranges are filtered, one CONNECT at a time. RFC 9209 S4.
+func TestProxyStatus_DenyCIDRIsNotDisclosedByDefault(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr := buildProxyStatusProxy(t, []string{"*"}, []string{"127.0.0.0/8"}, "iron-test")
+
+	resp, err := proxyClient(proxyAddr).Get(upstream.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	got := resp.Header.Get(proxystatus.HeaderName)
+	require.Contains(t, got, "iron-test")
+	require.Contains(t, got, "error="+proxystatus.ErrDestinationUnavailable)
+
+	require.NotContains(t, got, proxystatus.ErrDestinationIPProhibited,
+		"naming the policy tells the client this range is filtered")
+	require.NotContains(t, got, "details=",
+		"details echoed the blocked address, which is the address itself leaking back")
+	for _, leak := range []string{"127.0.0", "deny", "CIDR", "cidr", "next-hop"} {
+		require.NotContains(t, got, leak)
+	}
+	// The whole default payload: identity + coarse class, nothing else.
+	require.Equal(t, "iron-test; error=destination_unavailable", got)
+}
+
+// Operators running a proxy for trusted clients can still get the precise
+// cause — the disclosure is a choice, not a limitation.
+func TestProxyStatus_VerboseRevealsProhibitedForTrustedClients(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr := buildProxyStatusProxyV(t, []string{"*"}, []string{"127.0.0.0/8"}, "iron-test", true)
+
+	resp, err := proxyClient(proxyAddr).Get(upstream.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Contains(t, resp.Header.Get(proxystatus.HeaderName),
+		"error="+proxystatus.ErrDestinationIPProhibited)
+}
+
+// An allowlist rejection is the proxy refusing on the request's merits, which
+// is http_request_denied — distinct from the origin returning 403 itself.
+func TestProxyStatus_AllowlistRejectIsReportedAsDenied(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Allow only a host the request will not use, so the allowlist rejects.
+	proxyAddr := buildProxyStatusProxy(t, []string{"allowed.example.com"}, nil, "iron-test")
+
+	resp, err := proxyClient(proxyAddr).Get(upstream.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.GreaterOrEqual(t, resp.StatusCode, 400)
+	require.Less(t, resp.StatusCode, 500)
+
+	got := resp.Header.Get(proxystatus.HeaderName)
+	require.Contains(t, got, "iron-test")
+	require.Contains(t, got, "error="+proxystatus.ErrHTTPRequestDenied)
+}
+
+// The feature is opt-in: with no configured identity there is no meaningful
+// RFC 9209 member to emit, so the header must be absent entirely rather than
+// present-but-anonymous.
+func TestProxyStatus_DisabledWithoutName(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr := buildProxyStatusProxy(t, []string{"*"}, []string{"127.0.0.0/8"}, "")
+
+	resp, err := proxyClient(proxyAddr).Get(upstream.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(proxystatus.HeaderName))
+}
+
+// A successfully proxied response is the origin's, not the proxy's. Stamping
+// an error onto it would misattribute the origin's own status.
+func TestProxyStatus_AbsentOnSuccessfulProxying(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	proxyAddr := buildProxyStatusProxy(t, []string{"*"}, nil, "iron-test")
+
+	resp, err := proxyClient(proxyAddr).Get(upstream.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get(proxystatus.HeaderName))
+}
+
+// A CONNECT refused by a transform is a proxy-generated response too.
+func TestProxyStatus_CONNECTRejectIsAnnotated(t *testing.T) {
+	al, err := allowlist.New([]string{"allowed.example.com"}, nil)
+	require.NoError(t, err)
+	p, tunnelAddr, _ := startTunnelProxy(t, []transform.Transformer{al})
+	p.proxyStatusName = "iron-test"
+
+	conn, err := net.DialTimeout("tcp", tunnelAddr, 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = fmt.Fprintf(conn, "CONNECT blocked.example.com:443 HTTP/1.1\r\nHost: blocked.example.com:443\r\n\r\n")
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Equal(t, "iron-test; error="+proxystatus.ErrHTTPRequestDenied, resp.Header.Get(proxystatus.HeaderName))
+}

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -107,6 +107,7 @@ func (p *Proxy) handleTunnelCONNECT(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
+		p.annotateReject(rejectResp, host)
 		p.writeResponse(w, rejectResp)
 		return
 	}

--- a/internal/proxystatus/proxystatus.go
+++ b/internal/proxystatus/proxystatus.go
@@ -1,0 +1,135 @@
+// Package proxystatus serializes the Proxy-Status response header defined by
+// RFC 9209, which lets an intermediary say that it generated a response and
+// why. The field is an RFC 8941 Structured Fields list; each member names one
+// proxy and carries parameters describing what it did:
+//
+//	Proxy-Status: egress; error=destination_ip_prohibited; details="10.0.0.1 denied"
+package proxystatus
+
+import (
+	"net/http"
+	"strings"
+)
+
+// HeaderName is the field name (RFC 9209, Section 2).
+const HeaderName = "Proxy-Status"
+
+// Error types from the IANA "HTTP Proxy-Status Error Types" registry
+// (RFC 9209, Section 2.3) that a forward proxy emits.
+const (
+	ErrDNSTimeout              = "dns_timeout"
+	ErrDNSError                = "dns_error"
+	ErrDestinationUnavailable  = "destination_unavailable"
+	ErrDestinationIPProhibited = "destination_ip_prohibited"
+	ErrConnectionRefused       = "connection_refused"
+	ErrConnectionTerminated    = "connection_terminated"
+	ErrConnectionTimeout       = "connection_timeout"
+	ErrTLSCertificateError     = "tls_certificate_error"
+	ErrHTTPRequestDenied       = "http_request_denied"
+	ErrProxyInternalError      = "proxy_internal_error"
+)
+
+// Item is one member of the Proxy-Status list. Only Proxy is required;
+// zero-valued parameters are omitted.
+type Item struct {
+	Proxy   string // the intermediary's name
+	Error   string // an error type, normally one of the Err* constants
+	Details string // free-form context; RFC 9209 warns this can leak internals
+	NextHop string // the upstream this item concerns
+}
+
+// String serializes the item as a single list member. Proxy and Error are
+// emitted as sf-tokens when the grammar allows and as sf-strings otherwise, so
+// any operator-chosen value is safe; Details is always an sf-string.
+func (it Item) String() string {
+	var b strings.Builder
+	b.WriteString(encodeBareItem(it.Proxy))
+	if it.Error != "" {
+		b.WriteString("; error=")
+		b.WriteString(encodeBareItem(it.Error))
+	}
+	if it.NextHop != "" {
+		b.WriteString("; next-hop=")
+		b.WriteString(encodeBareItem(it.NextHop))
+	}
+	if it.Details != "" {
+		b.WriteString("; details=")
+		b.WriteString(encodeString(it.Details))
+	}
+	return b.String()
+}
+
+// Append adds item to h's Proxy-Status field, after any member an upstream
+// proxy already contributed. A blank item.Proxy is a no-op: RFC 9209 gives no
+// meaning to an unidentified member.
+func Append(h http.Header, item Item) {
+	if h == nil || strings.TrimSpace(item.Proxy) == "" {
+		return
+	}
+	encoded := item.String()
+	if existing := h.Get(HeaderName); existing != "" {
+		h.Set(HeaderName, existing+", "+encoded)
+		return
+	}
+	h.Set(HeaderName, encoded)
+}
+
+func encodeBareItem(s string) string {
+	if isToken(s) {
+		return s
+	}
+	return encodeString(s)
+}
+
+// isToken reports whether s is an sf-token (RFC 8941, Section 3.3.4): an
+// initial ALPHA or "*", then tchar / ":" / "/".
+func isToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	if c := s[0]; !isAlpha(c) && c != '*' {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !isTokenChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isTokenChar(c byte) bool {
+	if isAlpha(c) || (c >= '0' && c <= '9') {
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~', ':', '/':
+		return true
+	}
+	return false
+}
+
+// encodeString renders s as an sf-string (RFC 8941, Section 3.3.3). The
+// grammar admits only printable ASCII, so other bytes are dropped rather than
+// emitted raw into a header.
+func encodeString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\\' || c == '"':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		case c >= 0x20 && c <= 0x7E:
+			b.WriteByte(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/proxystatus/proxystatus_test.go
+++ b/internal/proxystatus/proxystatus_test.go
@@ -1,0 +1,58 @@
+package proxystatus
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemString(t *testing.T) {
+	cases := []struct {
+		name string
+		item Item
+		want string
+	}{
+		{"proxy only", Item{Proxy: "iron"}, "iron"},
+		{"error as token", Item{Proxy: "iron", Error: ErrHTTPRequestDenied}, "iron; error=http_request_denied"},
+		{"details quoted", Item{Proxy: "iron", Error: ErrDestinationIPProhibited, Details: "169.254.169.254 denied"},
+			`iron; error=destination_ip_prohibited; details="169.254.169.254 denied"`},
+		{"next-hop", Item{Proxy: "iron", NextHop: "example.com:443"}, "iron; next-hop=example.com:443"},
+		{"dotted name stays a token", Item{Proxy: "egress.internal.example.com"}, "egress.internal.example.com"},
+		{"leading digit is quoted", Item{Proxy: "4proxy"}, `"4proxy"`},
+		{"space is quoted", Item{Proxy: "my proxy"}, `"my proxy"`},
+		{"details escapes quotes and backslashes", Item{Proxy: "iron", Details: `he said "hi" \ bye`},
+			`iron; details="he said \"hi\" \\ bye"`},
+		// A raw CR/LF in details would split the header and allow injection.
+		{"details drops non-printable bytes", Item{Proxy: "iron", Details: "before\r\nX-Injected: yes\tafter\x00"},
+			`iron; details="beforeX-Injected: yesafter"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.item.String())
+		})
+	}
+}
+
+func TestAppend(t *testing.T) {
+	t.Run("sets header", func(t *testing.T) {
+		h := http.Header{}
+		Append(h, Item{Proxy: "iron", Error: ErrHTTPRequestDenied})
+		require.Equal(t, "iron; error=http_request_denied", h.Get(HeaderName))
+	})
+	t.Run("preserves an upstream proxy's member", func(t *testing.T) {
+		h := http.Header{HeaderName: {"upstream; error=connection_refused"}}
+		Append(h, Item{Proxy: "iron", Error: ErrHTTPRequestDenied})
+		require.Equal(t, "upstream; error=connection_refused, iron; error=http_request_denied", h.Get(HeaderName))
+	})
+	t.Run("blank proxy name is a no-op", func(t *testing.T) {
+		for _, name := range []string{"", "   "} {
+			h := http.Header{}
+			Append(h, Item{Proxy: name, Error: ErrHTTPRequestDenied})
+			require.Empty(t, h.Get(HeaderName))
+		}
+	})
+	t.Run("nil header does not panic", func(t *testing.T) {
+		Append(nil, Item{Proxy: "iron"})
+	})
+}

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -38,6 +38,15 @@ proxy:
   # to begin replying (e.g. LLM context-compaction endpoints).
   # upstream_response_header_timeout: "5m"
   #
+  # Identify this proxy in an RFC 9209 Proxy-Status header on responses it
+  # generates itself (transform rejections, upstream failures) so clients can
+  # tell them from origin responses. Off when unset. proxy_status_verbose
+  # reveals the precise upstream error type (denied CIDR vs DNS failure vs
+  # refused port), which is a disclosure for a filtering proxy, so it defaults
+  # to false.
+  # proxy_status_name: "egress"
+  # proxy_status_verbose: false
+  #
   # CIDRs the proxy refuses to dial upstream. Enforced at TCP connect time
   # against the resolved address — defeats DNS rebinding and TOCTOU between
   # allowlist evaluation and the eventual connect. CIDR notation is required


### PR DESCRIPTION
## What

Opt-in [RFC 9209](https://www.rfc-editor.org/rfc/rfc9209) `Proxy-Status` header on responses the proxy generates itself, so a client can tell "the proxy refused/couldn't reach this" from "the origin said this".

```yaml
proxy:
  proxy_status_name: "egress"   # header is off when unset
  proxy_status_verbose: false   # default
```

```
HTTP/1.1 403 Forbidden
Proxy-Status: egress; error=http_request_denied
```

## Why

Today a 502 from the deny-CIDR guard is byte-identical to a 502 from an origin that is down, and a 403 produced by a transform looks exactly like the origin refusing. The information that tells them apart is only in the audit log, which the client — typically a sandboxed agent — can't read. #230 describes the resulting misdiagnosis (an agent reading a policy denial as a dead credential). This gives the client a machine-readable answer in the standard place for it, without changing status codes or bodies.

## Design

- **Opt-in.** `proxy_status_name` empty (default) → no behaviour change at all. RFC 9209 gives no meaning to an unidentified member, so there is nothing to emit without a name.
- **Only proxy-generated responses.** Wired at: transform rejections (HTTP and CONNECT), MCP policy rejections, transform pipeline errors, and upstream dial/transport failures (including the WebSocket and response-retry replay paths). Successfully proxied responses are never stamped — that would misattribute the origin's status. MCP gateway/route errors and request-body buffering errors are left alone: they're neither policy verdicts nor upstream failures.
- **Coarse by default, on purpose.** Rejections report `http_request_denied` (4xx) or `proxy_internal_error` (5xx — a dependency the proxy needs failed, so "retry" rather than "you're denied"). *Every* upstream failure reports the same `destination_unavailable` with no details. For a filtering proxy the specific type is itself a disclosure: a client that can only reach the network through the proxy could use `destination_ip_prohibited` vs `dns_error` vs `connection_refused` to map the ranges it was fenced out of (RFC 9209 §4 calls this out). The precise cause is always on the audit line.
- **`proxy_status_verbose: true`** restores the specific type (`destination_ip_prohibited`, `dns_timeout`, `connection_refused`, `tls_certificate_error`, …), `details`, and `next-hop`, for deployments whose clients are as trusted as the operator.
- **Serializer** (`internal/proxystatus`): names/errors are emitted as sf-tokens when the RFC 8941 grammar allows and quoted strings otherwise, so any operator-chosen name is safe; `details` is always quoted with `"`/`\` escaped and non-printable bytes dropped (a raw CR/LF would otherwise split the header). `Append` preserves a member an upstream proxy already added.
- Docs in README (new *Proxy-Status* section) and `iron-proxy.example.yaml`.

## Testing

- `internal/proxystatus`: serializer grammar (token vs string, escaping, header-injection bytes), append/preserve/no-op cases.
- `internal/proxy`: through a real proxy — a deny-CIDR block is indistinguishable from any other unreachable destination by default and the exact default payload is `name; error=destination_unavailable`; verbose reveals `destination_ip_prohibited`; an allowlist rejection reports `http_request_denied` on both the HTTP path and a CONNECT; the header is absent when unconfigured and on successfully proxied responses.
- `go test -race` on `cmd`, `internal/proxy`, `internal/proxystatus`, `internal/config`; `go vet`; `golangci-lint run` clean.

Related: #230. A follow-up could put a short reason in the body as that issue asks; this PR keeps bodies unchanged.
