### PR TITLE
fix(proxy): answer a CONNECT whose transform errored with 503 + Retry-After, not 403

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -297,6 +297,24 @@ func notReadyResponse() *http.Response {
 	}
 }
 
+const transformErrorMessage = "proxy policy check unavailable"
+
+// transformErrorResponse answers a CONNECT whose transform pipeline failed, as
+// opposed to rejected: the proxy could not decide, so the client should retry
+// shortly rather than treat the destination as forbidden. The body names
+// neither the transform nor the error; those stay on the audit line.
+func transformErrorResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 " + http.StatusText(http.StatusServiceUnavailable),
+		Header: http.Header{
+			"Content-Type": []string{"text/plain; charset=utf-8"},
+			"Retry-After":  []string{"1"},
+		},
+		Body: io.NopCloser(strings.NewReader(transformErrorMessage + "\n")),
+	}
+}
+
 func (p *Proxy) handleDirectHTTP(w http.ResponseWriter, r *http.Request) {
 	p.handleHTTP(w, r, nil)
 }

--- a/internal/proxy/transform_error_status_test.go
+++ b/internal/proxy/transform_error_status_test.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ironsh/iron-proxy/internal/transform"
+)
+
+// failingTransform stands in for a policy transform whose backend is down: it
+// errors instead of returning a verdict.
+type failingTransform struct{}
+
+func (failingTransform) Name() string { return "failing-authz" }
+
+func (failingTransform) TransformRequest(context.Context, *transform.TransformContext, *http.Request) (*transform.TransformResult, error) {
+	return nil, errors.New("authz backend timeout")
+}
+
+func (failingTransform) TransformResponse(context.Context, *transform.TransformContext, *http.Request, *http.Response) (*transform.TransformResult, error) {
+	return &transform.TransformResult{Action: transform.ActionContinue}, nil
+}
+
+// A CONNECT whose transform errors is not a verdict on the request, so it must
+// be 503 + Retry-After rather than 403, the audit line must agree with what the
+// client was sent, and the body must not name the transform or its error.
+func TestTunnel_CONNECT_TransformErrorIs503(t *testing.T) {
+	pipeline := transform.NewPipeline([]transform.Transformer{failingTransform{}}, transform.BodyLimits{}, testLogger())
+	audited := make(chan *transform.PipelineResult, 1)
+	pipeline.SetAuditFunc(func(r *transform.PipelineResult) { audited <- r })
+	p := New(Options{
+		HTTPAddr:   "127.0.0.1:0",
+		TunnelAddr: "127.0.0.1:0",
+		Pipeline:   transform.NewPipelineHolder(pipeline),
+		Logger:     testLogger(),
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go p.handleTunnel(conn)
+		}
+	}()
+
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), 5*time.Second)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = fmt.Fprintf(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, "1", resp.Header.Get("Retry-After"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotContains(t, string(body), "authz backend timeout")
+	require.NotContains(t, string(body), "failing-authz")
+
+	select {
+	case r := <-audited:
+		require.Equal(t, http.StatusServiceUnavailable, r.StatusCode)
+		require.Error(t, r.Err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no audit entry for the CONNECT")
+	}
+}

--- a/internal/proxy/tunnel.go
+++ b/internal/proxy/tunnel.go
@@ -314,13 +314,13 @@ func (p *Proxy) tunnelTransformCheck(remoteAddr, target string, connectHeaders h
 	rejectResp, err := pl.ProcessRequest(req.Context(), tctx, req, &result.RequestTransforms)
 	if err != nil {
 		result.Action = transform.ActionContinue
-		result.StatusCode = http.StatusBadGateway
+		result.StatusCode = http.StatusServiceUnavailable
 		result.Err = err
 		p.logger.Warn("tunnel transform error",
 			slog.String("target", target),
 			slog.String("error", err.Error()),
 		)
-		return false, nil, nil
+		return false, transformErrorResponse(), nil
 	}
 	if rejectResp != nil {
 		result.Action = transform.ShortCircuitAction(result.RequestTransforms)


### PR DESCRIPTION
## What

When the transform pipeline *errors* on a CONNECT (as opposed to *rejecting* it), answer `503 Service Unavailable` with `Retry-After: 1` instead of `403 Forbidden`, and record 503 on the audit line.

## Why

`tunnelTransformCheck` returns `(false, nil, nil)` on a pipeline error and `handleTunnelCONNECT` turns that nil response into a 403. That conflates two opposite conditions:

- A transform that **rejects** has made a verdict about the request — it will fail identically on retry, so 4xx is right.
- A transform that **errors** (an external policy service that timed out or is briefly unreachable) has made no verdict at all. The request may be perfectly valid.

A client that reads 403 as "you are not allowed here" stops retrying, so a brief blip in a policy backend becomes a hard failure — and a client that *does* retry immediately amplifies load onto the service that is already struggling. 503 + Retry-After is the honest encoding: the proxy is temporarily unable to decide.

The path also disagreed with itself: `tunnelTransformCheck` recorded **502** on the audit line while the client got **403**, so the audit entry, the client and the warn log reported three different statuses for one event. Both now say 503.

## Behavior notes

- CONNECT path only. The plain-HTTP path already answers 502 on a transform error, which doesn't carry 403's stop-retrying meaning, so it's left alone to keep this to the actual defect. (If you'd rather have 502 here too for symmetry I can switch — 503 was chosen because it's the status already used for the not-ready case and it's the one `Retry-After` is defined for.)
- The body is a generic one-liner. The failing transform's name and the backend error text stay in the audit line and warn log — a requesting workload shouldn't learn which internal dependency is down.
- With #250, this 503 additionally carries `Proxy-Status: <name>; error=proxy_internal_error`, so a client can tell "your credential is bad" (4xx) from "retry shortly" (5xx) without parsing prose.

## Testing

- `TestTunnel_CONNECT_TransformErrorIs503` — a transform that errors; asserts 503, `Retry-After: 1`, the body leaks neither the transform name nor the error text, and the audit entry records 503 with the error.
- `go test -race ./internal/proxy/`, `go vet`, `golangci-lint run` clean.
