### PR TITLE
feat(grpc): allowed_headers — restrict which headers are sent to the TransformService server

### DIFF
--- a/internal/transform/grpc/allowed_headers_test.go
+++ b/internal/transform/grpc/allowed_headers_test.go
@@ -1,0 +1,96 @@
+package grpc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	transformv1 "github.com/ironsh/iron-proxy/gen/transform/v1"
+)
+
+func headerNames(h map[string]*transformv1.HeaderValues) []string {
+	names := make([]string, 0, len(h))
+	for k := range h {
+		names = append(names, k)
+	}
+	return names
+}
+
+func TestAllowedHeaders_FiltersWhatReachesServer(t *testing.T) {
+	srv := &fakeServer{
+		reqAction:  transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+		respAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE,
+	}
+	gt, err := newGRPCTransform(grpcConfig{
+		Name:           "policy",
+		Target:         startFakeServer(t, srv),
+		AllowedHeaders: []string{"user-agent", "/^X-Trace-.*$/"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gt.Close() })
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.example.com/v1/messages", nil)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "client/1.0")
+	req.Header.Set("X-Trace-Id", "abc")
+	req.Header.Set("Authorization", "Bearer upstream-secret")
+	req.Header.Set("Cookie", "session=1")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}, "Set-Cookie": {"s=2"}, "X-Trace-Id": {"abc"}},
+		Body:       http.NoBody,
+	}
+
+	_, err = gt.TransformRequest(context.Background(), testContext(), req)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"User-Agent", "X-Trace-Id"}, headerNames(srv.lastReqProto.GetRequest().GetHeaders()))
+
+	_, err = gt.TransformResponse(context.Background(), testContext(), req, resp)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"User-Agent", "X-Trace-Id"}, headerNames(srv.lastRespProto.GetRequest().GetHeaders()))
+	require.ElementsMatch(t, []string{"X-Trace-Id"}, headerNames(srv.lastRespProto.GetResponse().GetHeaders()))
+
+	// Only the proto is filtered; the request that goes upstream keeps its headers.
+	require.Equal(t, "Bearer upstream-secret", req.Header.Get("Authorization"))
+	require.Equal(t, "session=1", req.Header.Get("Cookie"))
+}
+
+func TestAllowedHeaders_EmptyForwardsAll(t *testing.T) {
+	srv := &fakeServer{reqAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE}
+	gt := newTestTransform(t, "all", startFakeServer(t, srv), false, false)
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer x")
+	req.Header.Set("Cookie", "a=b")
+
+	_, err = gt.TransformRequest(context.Background(), testContext(), req)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Authorization", "Cookie"}, headerNames(srv.lastReqProto.GetRequest().GetHeaders()))
+}
+
+func TestAllowedHeaders_InvalidRegex(t *testing.T) {
+	srv := &fakeServer{reqAction: transformv1.TransformAction_TRANSFORM_ACTION_CONTINUE}
+	_, err := newGRPCTransform(grpcConfig{
+		Name:           "bad",
+		Target:         startFakeServer(t, srv),
+		AllowedHeaders: []string{"/[/"},
+	})
+	require.ErrorContains(t, err, "invalid allowed_headers regex")
+}
+
+func TestFactory_ParsesAllowedHeaders(t *testing.T) {
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("name: t\ntarget: localhost:9500\nallowed_headers: [Content-Type, /^X-Trace-.*$/]\n"), &node))
+	tr, err := factory(node, nil)
+	require.NoError(t, err)
+	gt := tr.(*GRPCTransform)
+	t.Cleanup(func() { _ = gt.Close() })
+	require.Len(t, gt.allowedHeaders, 2)
+	require.True(t, headerAllowed(gt.allowedHeaders, "content-type"))
+	require.True(t, headerAllowed(gt.allowedHeaders, "x-trace-id"))
+	require.False(t, headerAllowed(gt.allowedHeaders, "authorization"))
+}

--- a/internal/transform/grpc/grpc.go
+++ b/internal/transform/grpc/grpc.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -34,6 +36,7 @@ type grpcConfig struct {
 	SendRequestBody  bool                   `yaml:"send_request_body"`
 	SendResponseBody bool                   `yaml:"send_response_body"`
 	Rules            []hostmatch.RuleConfig `yaml:"rules"`
+	AllowedHeaders   []string               `yaml:"allowed_headers"` // headers sent to the server; empty = all
 }
 
 type tlsConfig struct {
@@ -49,8 +52,40 @@ type GRPCTransform struct {
 	sendRequestBody  bool
 	sendResponseBody bool
 	rules            []hostmatch.Rule
+	allowedHeaders   []headerMatcher // nil = forward every header
 	conn             *grpc.ClientConn
 	client           transformv1.TransformServiceClient
+}
+
+// headerMatcher matches one allowed_headers entry: a literal canonical header
+// name, or a /.../ pattern compiled as a case-insensitive regexp (the same
+// syntax as the header_allowlist transform).
+type headerMatcher struct {
+	name string
+	re   *regexp.Regexp
+}
+
+func (m headerMatcher) matches(canonical string) bool {
+	if m.re != nil {
+		return m.re.MatchString(canonical)
+	}
+	return m.name == canonical
+}
+
+func parseHeaderMatchers(name string, patterns []string) ([]headerMatcher, error) {
+	matchers := make([]headerMatcher, 0, len(patterns))
+	for _, p := range patterns {
+		if len(p) >= 2 && strings.HasPrefix(p, "/") && strings.HasSuffix(p, "/") {
+			re, err := regexp.Compile("(?i)" + p[1:len(p)-1])
+			if err != nil {
+				return nil, fmt.Errorf("grpc transform %q: invalid allowed_headers regex %q: %w", name, p, err)
+			}
+			matchers = append(matchers, headerMatcher{re: re})
+			continue
+		}
+		matchers = append(matchers, headerMatcher{name: http.CanonicalHeaderKey(p)})
+	}
+	return matchers, nil
 }
 
 func factory(cfg yaml.Node, _ *slog.Logger) (transform.Transformer, error) {
@@ -117,11 +152,18 @@ func newGRPCTransform(cfg grpcConfig) (*GRPCTransform, error) {
 		return nil, fmt.Errorf("grpc transform %q: %w", cfg.Name, err)
 	}
 
+	allowed, err := parseHeaderMatchers(cfg.Name, cfg.AllowedHeaders)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
 	return &GRPCTransform{
 		name:             cfg.Name,
 		sendRequestBody:  cfg.SendRequestBody,
 		sendResponseBody: cfg.SendResponseBody,
 		rules:            rules,
+		allowedHeaders:   allowed,
 		conn:             conn,
 		client:           transformv1.NewTransformServiceClient(conn),
 	}, nil
@@ -134,7 +176,7 @@ func (g *GRPCTransform) TransformRequest(ctx context.Context, tctx *transform.Tr
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 
-	pbReq, err := httpRequestToProto(req, g.sendRequestBody)
+	pbReq, err := httpRequestToProto(req, g.sendRequestBody, g.allowedHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
@@ -171,11 +213,11 @@ func (g *GRPCTransform) TransformResponse(ctx context.Context, tctx *transform.T
 		return &transform.TransformResult{Action: transform.ActionContinue}, nil
 	}
 
-	pbReq, err := httpRequestToProto(req, g.sendRequestBody)
+	pbReq, err := httpRequestToProto(req, g.sendRequestBody, g.allowedHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling request: %w", g.name, err)
 	}
-	pbResp, err := httpResponseToProto(resp, g.sendResponseBody)
+	pbResp, err := httpResponseToProto(resp, g.sendResponseBody, g.allowedHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("grpc transform %q: marshaling response: %w", g.name, err)
 	}
@@ -266,13 +308,13 @@ func annotationsToStruct(annotations map[string]any) *structpb.Struct {
 	return &structpb.Struct{Fields: fields}
 }
 
-func httpRequestToProto(req *http.Request, sendBody bool) (*transformv1.HttpRequest, error) {
+func httpRequestToProto(req *http.Request, sendBody bool, allowed []headerMatcher) (*transformv1.HttpRequest, error) {
 	pb := &transformv1.HttpRequest{
 		Method:     req.Method,
 		Url:        req.URL.String(),
 		Host:       req.Host,
 		RemoteAddr: req.RemoteAddr,
-		Headers:    headersToProto(req.Header),
+		Headers:    headersToProto(req.Header, allowed),
 	}
 
 	if sendBody && req.Body != nil {
@@ -286,10 +328,10 @@ func httpRequestToProto(req *http.Request, sendBody bool) (*transformv1.HttpRequ
 	return pb, nil
 }
 
-func httpResponseToProto(resp *http.Response, sendBody bool) (*transformv1.HttpResponse, error) {
+func httpResponseToProto(resp *http.Response, sendBody bool, allowed []headerMatcher) (*transformv1.HttpResponse, error) {
 	pb := &transformv1.HttpResponse{
 		StatusCode: int32(resp.StatusCode),
-		Headers:    headersToProto(resp.Header),
+		Headers:    headersToProto(resp.Header, allowed),
 	}
 
 	if sendBody && resp.Body != nil {
@@ -358,15 +400,30 @@ func applyModifiedResponse(pb *transformv1.HttpResponse, resp *http.Response) {
 	}
 }
 
-func headersToProto(h http.Header) map[string]*transformv1.HeaderValues {
-	if len(h) == 0 {
-		return nil
-	}
+// headersToProto converts h, keeping only headers matched by allowed when it
+// is non-empty. Filtering applies to the proto alone; h itself is untouched.
+func headersToProto(h http.Header, allowed []headerMatcher) map[string]*transformv1.HeaderValues {
 	out := make(map[string]*transformv1.HeaderValues, len(h))
 	for k, vs := range h {
+		if len(allowed) > 0 && !headerAllowed(allowed, k) {
+			continue
+		}
 		out[k] = &transformv1.HeaderValues{Values: vs}
 	}
+	if len(out) == 0 {
+		return nil
+	}
 	return out
+}
+
+func headerAllowed(allowed []headerMatcher, name string) bool {
+	canonical := http.CanonicalHeaderKey(name)
+	for _, m := range allowed {
+		if m.matches(canonical) {
+			return true
+		}
+	}
+	return false
 }
 
 func protoToHeaders(h map[string]*transformv1.HeaderValues) http.Header {

--- a/iron-proxy.example.yaml
+++ b/iron-proxy.example.yaml
@@ -596,6 +596,9 @@ transforms:
       target: "localhost:9500"
       send_request_body: true
       send_response_body: true
+      # Restrict which request (and response) headers are sent to the server.
+      # Default: all. Same syntax as header_allowlist: literal names or /regex/.
+      # allowed_headers: ["Content-Type", "User-Agent", "/^X-Request-.*$/"]
       # Only forward matching requests to this server (omit for all requests).
       rules:
         - host: "api.openai.com"


### PR DESCRIPTION
## What

Adds `allowed_headers` to the `grpc` transform: when set, only matching headers are included in the request/response protos sent to the `TransformService` server. Empty (default) forwards everything, as today.

```yaml
transforms:
  - name: grpc
    config:
      name: "policy-engine"
      target: "localhost:9500"
      allowed_headers: ["Content-Type", "User-Agent", "/^X-Request-.*$/"]
```

## Why

`send_request_body: false` keeps bodies local, but for an external policy service the sensitive material is usually in the headers: the upstream `Authorization` bearer, cookies, third-party API keys. A policy decision rarely needs any of them, yet today all of them cross to a second service (often over plaintext h2c) and land in its request logs. This is the same knob Envoy's `ext_authz` exposes as `authorization_request.allowed_headers`, and the same posture as the existing `header_allowlist` transform: an allowlist, because a denylist silently leaks whatever nobody thought of.

## Behavior notes

- Syntax mirrors `header_allowlist`: literal names matched case-insensitively against the canonical form, or `/.../` compiled as a case-insensitive regexp. An invalid regex fails at startup.
- Applies to the request headers on both RPCs and to the upstream response headers on `TransformResponse` (so `Set-Cookie` etc. don't cross either).
- Only the proto is filtered. The `http.Request` that goes upstream is not touched — `header_allowlist` remains the tool for stripping headers from the upstream request.
- Docs: `iron-proxy.example.yaml` (the README has no grpc transform section yet, same as #247).

## Testing

- `TestAllowedHeaders_FiltersWhatReachesServer` — through a fake server: only allowed request headers reach it on both RPCs, response headers are filtered too, and the upstream `http.Request` keeps its `Authorization`/`Cookie`.
- `TestAllowedHeaders_EmptyForwardsAll` — default unchanged.
- `TestAllowedHeaders_InvalidRegex` — startup error.
- `TestFactory_ParsesAllowedHeaders` — YAML decoding and case-insensitive matching.
- `go test -race ./internal/transform/grpc/`, `go vet`, `golangci-lint run` clean.
