### PR TITLE
fix(proxy): do not forward request body on body-less GET and HEAD requests

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -483,7 +483,16 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	reqBody := transform.RequireBufferedBody(r.Body)
 	// Check Len() before StreamingReader(), which clears the original reader.
 	reqBodyLen := reqBody.Len()
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, io.NopCloser(reqBody.StreamingReader()))
+
+	isBodyless := (r.Method == http.MethodGet || r.Method == http.MethodHead) &&
+		reqBodyLen <= 0 && r.ContentLength <= 0 && len(r.TransferEncoding) == 0
+
+	var bodyReader io.Reader
+	if !isBodyless {
+		bodyReader = io.NopCloser(reqBody.StreamingReader())
+	}
+
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, bodyReader)
 	if err != nil {
 		result.Action = transform.ActionContinue
 		result.StatusCode = http.StatusBadGateway
@@ -493,10 +502,13 @@ func (p *Proxy) handleHTTP(w http.ResponseWriter, r *http.Request, tunnelInfo *t
 	}
 	copyHeaders(upstreamReq.Header, r.Header)
 	sanitizeUpstreamHeaders(upstreamReq.Header)
-	// If a transform buffered the request body, set ContentLength so the
-	// upstream receives a Content-Length header instead of chunked encoding.
-	// Otherwise, preserve the original Content-Length from the client.
-	if reqBodyLen >= 0 {
+	if isBodyless {
+		upstreamReq.Body = http.NoBody
+		upstreamReq.ContentLength = 0
+	} else if reqBodyLen >= 0 {
+		// If a transform buffered the request body, set ContentLength so the
+		// upstream receives a Content-Length header instead of chunked encoding.
+		// Otherwise, preserve the original Content-Length from the client.
 		upstreamReq.ContentLength = int64(reqBodyLen)
 	} else {
 		upstreamReq.ContentLength = r.ContentLength
@@ -643,6 +655,9 @@ type multiReadCloser struct {
 }
 
 func prepareReplayBody(body io.ReadCloser, contentLength, limit int64) (io.ReadCloser, []byte, bool, error) {
+	if body == nil || body == http.NoBody {
+		return body, nil, true, nil
+	}
 	if limit <= 0 || contentLength > limit {
 		return body, nil, false, nil
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -677,6 +677,44 @@ func TestHTTPProxy_RequestContentLengthPreserved(t *testing.T) {
 	require.Equal(t, requestBody, gotBody)
 }
 
+func TestHTTPProxy_GetHeadBodyless(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			var gotBody []byte
+			var hasContentLengthHeader bool
+			var hasTransferEncoding bool
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, hasContentLengthHeader = r.Header["Content-Length"]
+				hasTransferEncoding = len(r.TransferEncoding) > 0
+				if r.Body != nil {
+					gotBody, _ = io.ReadAll(r.Body)
+				}
+				w.WriteHeader(http.StatusOK)
+				if r.Method != http.MethodHead {
+					_, _ = fmt.Fprint(w, "response body")
+				}
+			}))
+			defer upstream.Close()
+
+			_, httpAddr, _, _ := startProxy(t)
+
+			req, err := http.NewRequest(method, fmt.Sprintf("http://%s/test", httpAddr), nil)
+			require.NoError(t, err)
+			req.Host = upstream.Listener.Addr().String()
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Empty(t, gotBody)
+			require.False(t, hasContentLengthHeader, "body-less %s request should not send Content-Length header upstream", method)
+			require.False(t, hasTransferEncoding, "body-less %s request should not send Transfer-Encoding header upstream", method)
+		})
+	}
+}
+
 func TestHTTPProxy_ContentLengthPreserved(t *testing.T) {
 	const responseBody = "fixed-size body"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/tunnel_test.go
+++ b/internal/proxy/tunnel_test.go
@@ -111,6 +111,8 @@ func TestTunnel_CONNECT_HTTP(t *testing.T) {
 func TestTunnel_CONNECT_HTTPS_MITM(t *testing.T) {
 	// Start an upstream HTTPS server
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Content-Length"), "GET request over HTTPS MITM tunnel should not have Content-Length")
+		require.Empty(t, r.TransferEncoding, "GET request over HTTPS MITM tunnel should not have Transfer-Encoding")
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "hello from tls tunnel")
 	}))


### PR DESCRIPTION
## Summary

Do not forward an empty request body reader or `Content-Length: 0` / chunked encoding headers on body-less `GET` and `HEAD` requests.

## Problem & Motivation

In `internal/proxy/proxy.go`, `upstreamReq` was always created by wrapping the request body in an opaque reader:
```go
http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, io.NopCloser(reqBody.StreamingReader()))
```
and then setting `upstreamReq.ContentLength` from `reqBodyLen` (which is 0 when unbuffered/empty) or `r.ContentLength`.

Because `io.NopCloser` wraps the reader in a generic struct rather than `nil` or `http.NoBody`, Go's `net/http` client transport treats the request as carrying a streaming body and emits either `Content-Length: 0` or chunked transfer encoding upstream. Strict upstream servers (such as `ipecho.io`) reject `GET` / `HEAD` requests carrying a body with:
```text
HTTP 500: Request with a GET or HEAD method cannot have a body.
```

## Solution

1. In `internal/proxy/proxy.go` (`handleHTTP`):
   - Check whether the incoming request is body-less:
     ```go
     isBodyless := (r.Method == http.MethodGet || r.Method == http.MethodHead) &&
         reqBodyLen <= 0 && r.ContentLength <= 0 && len(r.TransferEncoding) == 0
     ```
   - When `isBodyless` is true, pass `nil` as the body reader to `http.NewRequestWithContext` and assign `upstreamReq.Body = http.NoBody` with `upstreamReq.ContentLength = 0`.
   - This ensures Go's `net/http` client transport recognizes the request as bodyless and omits `Content-Length` and `Transfer-Encoding` headers (matching Go standard library `httputil.ReverseProxy` behavior).
2. In `prepareReplayBody`:
   - Return early when `body == nil || body == http.NoBody`, avoiding wrapping `http.NoBody` in an opaque `io.NopCloser(bytes.NewReader(replayBody))`.
3. Added regression tests:
   - `TestHTTPProxy_GetHeadBodyless`: verifies that both `GET` and `HEAD` requests through the proxy send neither `Content-Length` nor `Transfer-Encoding` headers to upstream and succeed with HTTP 200.
   - `TestTunnel_CONNECT_HTTPS_MITM`: verifies that `GET` requests over HTTPS MITM tunnel do not receive `Content-Length` or `Transfer-Encoding` headers upstream.

Fixes #246
